### PR TITLE
Autre batch de traduction

### DIFF
--- a/postgresql/logicaldecoding.xml
+++ b/postgresql/logicaldecoding.xml
@@ -1,59 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- doc/src/sgml/logicaldecoding.sgml -->
  <chapter id="logicaldecoding">
-  <title>Logical Decoding</title>
+  <title>Décodage logique (Logical Decoding)</title>
   <indexterm zone="logicaldecoding">
    <primary>Logical Decoding</primary>
   </indexterm>
   <para>
-   PostgreSQL provides infrastructure to stream the modifications performed
-   via SQL to external consumers.  This functionality can be used to for a
-   variety of purposes, including replication solutions and auditing.
+   PostgreSQL fournit une infrastructure pour envoyer par flux les modifications
+   effectuées en SQL à des consommateurs externes. Cette fonctionnalité peut
+   être utilisée dans plusieurs buts, y compris pour des solutions de
+   réplication ou d'audit.
   </para>
 
   <para>
-   Changes are sent out in streams identified by logical replication slots.
-   Each stream outputs each change exactly once.
+   Les changemennts sont envoyés dans des flux identifiés par des slots de
+   réplication logiques. Chacun de ces slots envoie chaque changement
+   une seule et unique fois.
   </para>
 
   <para>
-   The format in which those changes are streamed is determined by the output
-   plugin used.  An example plugin is provided, and additional plugins can be
-   written to extend the choice of available formats without modifying any
-   core code.
-   Every output plugin has access to each individual new row produced
-   by <command>INSERT</command> and the new row version created
-   by <command>UPDATE</command>.  Availability of old row versions for
-   <command>UPDATE</command> and <command>DELETE</command> depends on
-   the configured
+   Le format dans lequels ces changements sont envoyés est déterminné par
+   le plugin de sortie utilisé.  Un plugin d'exemple est fourni, et des
+   plugins additionnels peuvent être écrits pour étendre le choix de format
+   de sortie disponible sans modifier une seule ligne de code du moteur.
+   Chaque plugin de sortie a accès a chaque nouvelle ligne individuelle
+   produite par <command>INSERT</command> ainsi que les nouvelles versions
+   de lignes créées  par <command>UPDATE</command>.  La disponibilité des
+   anciennes version de ligne dépend du
    <link linkend="sql-createtable-replica-identity"><literal>REPLICA
-   IDENTITY</literal></link>.
+   IDENTITY</literal></link> configuré.
   </para>
 
   <para>
-   Changes can be consumed either using the streaming replication protocol
-   (see <xref linkend="protocol-replication"/> and
-   <xref linkend="logicaldecoding-walsender"/>), or by calling functions
-   via SQL (see <xref linkend="logicaldecoding-sql"/>). It is also possible
-   to write additional methods of consuming the output of a replication slot
-   without modifying core code
-   (see <xref linkend="logicaldecoding-writer"/>).
+   Les changements peuvent être consommés soit en utilisant le proctole
+   de réplication par flux (voir <xref linkend="protocol-replication"/>
+   et <xref linkend="logicaldecoding-walsender"/>),ou par l'appel de
+   fonctions en SQL (voir <xref linkend="logicaldecoding-sql"/>).  Il est
+   également possible d'écrire de nouvelles méthodes de consommation de
+   sortie d'un slot de réplication sans modifier une seule ligne de
+   code du moteur
+   (voir <xref linkend="logicaldecoding-writer"/>).
   </para>
 
   <sect1 id="logicaldecoding-example">
-   <title>Logical Decoding Example</title>
+   <title>Exemple de décodage logique</title>
    <para>
-    The following example demonstrates the SQL interface.
+    L'exemple suivant explique l'interface SQL.
    </para>
    <para>
-    Before you can use logical decoding, you must set
-    <xref linkend="guc-wal-level"/> to <literal>logical</literal> and
-    <xref linkend="guc-max-replication-slots"/> to at least 1.
-    Then, you should connect to the target database (in the example
-    below, <literal>postgres</literal>) as a superuser.
+    Avant de pouvoir utiliser le décodage logique, il est nécessaire
+    de positionner <xref linkend="guc-wal-level"/> à <literal>logical</literal>
+    et <xref linkend="guc-max-replication-slots"/> à au moins 1.
+    Il sera alors possible de se connecter à la base de donénes cible (dans
+    l'exemple suivant, <literal>postgres</literal>) en tant que super utilisateur.
    </para>
 <programlisting>
-postgres=# -- Create a slot named 'regression_slot' using the output plugin 'test_decoding'
+postgres=# -- Créé un slot nommé 'regression_slot' utilisant le plugin de sortie 'test_decoding'
 postgres=# SELECT * FROM pg_create_logical_replication_slot('regression_slot', 'test_decoding');
     slot_name    | xlog_position
 -----------------+---------------
@@ -66,7 +68,7 @@ postgres=# SELECT * FROM pg_replication_slots;
  regression_slot | test_decoding | logical   |  12052 | postgres | f      |        |          684 | 0/16A4408
 (1 row)
 
-postgres=# -- There are no changes to see yet
+postgres=# -- Il n'y a pas encore de changement à voir
 postgres=# SELECT * FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
  location | xid | data
 ----------+-----+------
@@ -75,7 +77,7 @@ postgres=# SELECT * FROM pg_logical_slot_get_changes('regression_slot', NULL, NU
 postgres=# CREATE TABLE data(id serial primary key, data text);
 CREATE TABLE
 
-postgres=# -- DDL isn't replicated, so all you'll see is the transaction
+postgres=# -- le DDL n'est pas répliqué, donc seule la transaction est visible
 postgres=# SELECT * FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
  location  | xid |    data
 -----------+-----+------------
@@ -83,8 +85,8 @@ postgres=# SELECT * FROM pg_logical_slot_get_changes('regression_slot', NULL, NU
  0/16E0380 | 688 | COMMIT 688
 (2 rows)
 
-postgres=# -- Once changes are read, they're consumed and not emitted
-postgres=# -- in a subsequent call:
+postgres=# -- Une fois les changements lus, ils sont consommés et ne seront pas renvoyés
+postgres=# -- dans un appel ultérieur&nbsp;:
 postgres=# SELECT * FROM pg_logical_slot_get_changes('regression_slot', NULL, NULL);
  location | xid | data
 ----------+-----+------
@@ -106,7 +108,7 @@ postgres=# SELECT * FROM pg_logical_slot_get_changes('regression_slot', NULL, NU
 
 postgres=# INSERT INTO data(data) VALUES('3');
 
-postgres=# -- You can also peek ahead in the change stream without consuming changes
+postgres=# -- Il est également possible de prévisualiser le flux de changement sans le consommer
 postgres=# SELECT * FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL);
  location  | xid |                     data
 -----------+-----+-----------------------------------------------
@@ -115,7 +117,7 @@ postgres=# SELECT * FROM pg_logical_slot_peek_changes('regression_slot', NULL, N
  0/16E0B90 | 690 | COMMIT 690
 (3 rows)
 
-postgres=# -- You can also peek ahead in the change stream without consuming changes
+postgres=# -- Il est également possible de prévisualiser le flux de changement sans le consommer
 postgres=# SELECT * FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL);
  location  | xid |                     data
 -----------+-----+-----------------------------------------------
@@ -124,7 +126,7 @@ postgres=# SELECT * FROM pg_logical_slot_peek_changes('regression_slot', NULL, N
  0/16E0B90 | 690 | COMMIT 690
 (3 rows)
 
-postgres=# -- options can be passed to output plugin, to influence the formatting
+postgres=# -- des options peuvent être fournies au plugin de sortir pour influer sur le formatage
 postgres=# SELECT * FROM pg_logical_slot_peek_changes('regression_slot', NULL, NULL, 'include-timestamp', 'on');
  location  | xid |                     data
 -----------+-----+-----------------------------------------------
@@ -133,8 +135,8 @@ postgres=# SELECT * FROM pg_logical_slot_peek_changes('regression_slot', NULL, N
  0/16E0B90 | 690 | COMMIT 690 (at 2014-02-27 16:41:51.863092+01)
 (3 rows)
 
-postgres=# -- Remember to destroy a slot you no longer need to stop it consuming
-postgres=# -- server resources:
+postgres=# -- Il ne faut pas oublier de détruire un slot une fois qu'on n'en a plus besoin
+postgres=# -- afin qu'il ne consomme plus de ressources sur le serveur&nbsp;:
 postgres=# SELECT pg_drop_replication_slot('regression_slot');
  pg_drop_replication_slot
 -----------------------
@@ -142,12 +144,13 @@ postgres=# SELECT pg_drop_replication_slot('regression_slot');
 (1 row)
 </programlisting>
    <para>
-    The following example shows usage of the walsender interface using
-    the <link linkend="app-pgrecvlogical"><command>pg_recvlogical</command></link>
-    shell command. It requires the replication configurations to be allowed
-    (see <xref linkend="streaming-replication-authentication"/>)
-    and <varname>max_wal_senders</varname> to be set sufficiently high for
-    another connection.
+    L'exemple suivant montre l'utilisation de l'interface walsender en utilisant
+    la commande shell
+    <link linkend="app-pgrecvlogical"><command>pg_recvlogical</command></link>.
+    Cela nécessite d'avoir configuré les autorisations de réplication
+    (voir <xref linkend="streaming-replication-authentication"/>) et que
+    <varname>max_wal_senders</varname> soit positionné suffisamment haut pour
+    permettre une nouvelle connexion.
    </para>
 <programlisting>
 # pg_recvlogical -d postgres --slot test --create
@@ -163,161 +166,175 @@ CTRL-C
 </programlisting>
   </sect1>
   <sect1 id="logicaldecoding-explanation">
-   <title>Logical Decoding Concepts</title>
+   <title>Concepts de décodage logique</title>
    <sect2>
-    <title>Logical Decoding</title>
+    <title>Décodage logique</title>
     <indexterm>
      <primary>Logical Decoding</primary>
     </indexterm>
     <para>
-     Logical decoding is the process of extracting all persistent changes
-     to a database's tables into a coherent, easy to understand format which
-     can be interpreted without detailed knowledge of the database's internal
-     state.
+     Le décodage logique correspond au processus d'extractions de tous les
+     changements persistants sur une table d'une base de données dans un
+     format cohérent et simple à comprendre, qui peut être interprêté sans
+     une connaissance détaillée de l'état interne de la base de données.
     </para>
     <para>
-     In <productname>PostgreSQL</productname>, logical decoding is implemented
-     by decoding the contents of the <link linkend="wal">write-ahead
-     log</link>, which describe changes on a storage level, into an
-     application-specific form such as a stream of tuples or SQL statements.
+     Dans <productname>PostgreSQL</productname>, le décodage logique est
+     implémenté en décodant le contenu des <link linkend="wal">journaux de
+     transaction (WAL)</link>, qui décrivent les changement au niveau
+     stockage, dans un format spécifique tel que le flux de lignes ou des
+     ordres SQL.
     </para>
    </sect2>
 
    <sect2>
-    <title>Replication Slots</title>
+    <title>Slots de réplication</title>
     <indexterm>
      <primary>replication slot</primary>
      <secondary>logical replication</secondary>
     </indexterm>
     <para>
-     In the context of logical replication, a slot represents a stream of
-     changes which can be replayed to a client in the order they were made on
-     the origin server. Each slot streams a sequence of changes from a single
-     database, sending each change exactly once (except when peeking forward
-     in the stream).
+     Dans le contexte de la réplication logique, un slot représent un flux
+     de changements qui peut être rejoué par un client, dans l'ordre dans
+     ils ont été effectués sur le serveur d'origine.  Chaque slot envoie dans
+     ce flux une séquence de changements d'une unique base en envoyant chaque
+     changement une seule et unique fois (sauf utilisation de la
+     prévisualisation dans le flux).
     </para>
     <note>
-     <para><productname>PostgreSQL</productname> also has streaming replication slots
-     (see <xref linkend="streaming-replication"/>), but they are used somewhat
-     differently there.
+     <para><productname>PostgreSQL</productname> possède également des slots
+     de réplication (voir <xref linkend="streaming-replication"/>), mais
+     ceux-ci sont utilisés de manière un peu différente ici.
      </para>
     </note>
     <para>
-     Replication slots have an identifier which is unique across all databases
-     in a <productname>PostgreSQL</productname> cluster. Slots persist
-     independently of the connection using them and are crash-safe.
+     Les slots de réplication ont un identifiant qui est unique à travers
+     toutes les bases d'une instance <productname>PostgreSQL</productname>.
+     Les slots persistent indépendamment de la connexion les utilisant et sont
+     résistants à un arrêt brutal.
     </para>
     <para>
-     Multiple independent slots may exist for a single database. Each slot has
-     its own state, allowing different consumers to receive changes from
-     different points in the database change stream. For most applications, a
-     separate slot will be required for each consumer.
+     De nombreux slots indépendants peuvent exister pour une même base.
+     Chacun possède sont propre état, autorisant différents consommateurs
+     à recevoir des changements depuis différents points dans le flux de
+     changement de la base.  Pour la plupart des utilisations, un slot séparé
+     sera requis pour chaque consommateur.
     </para>
     <para>
-     A logical replication slot knows nothing about the state of the
-     receiver(s).  It's even possible to have multiple different receivers using
-     the same slot at different times; they'll just get the changes following
-     on from when the last receiver stopped consuming them. Only one receiver
-     may consume changes from a slot at any given time.
+     Un slot de réplication logique ne sait rien sur l'état du ou des
+     destinataire(s).  Il est même possible d'avoir plusieurs destinataires
+     différents utilisant un même slot à des moments différents; ils ne
+     recevront que les changements à partir de là où le dernier destinataire
+     a arrêté de les consommer.  Un seul destinataire peut consommer les
+     changements d'un slot à un instant donné.
     </para>
     <note>
      <para>
-      Replication slots persist across crashes and know nothing about the state
-      of their consumer(s). They will prevent removal of required resources
-      even when there is no connection using them. This consumes storage
-      because neither required WAL nor required rows from the system catalogs
-      can be removed by VACUUM as long as they are required by a replication
-      slot, so if a slot is no longer required it should be dropped.
+      Les slots de réplications persistent après un arrêt brutal et ne
+      connaissent rien de l'état de leur(s) consommateur(s).  Ils empêcheront
+      la suppression automatique des ressources nécessaires même si aucune
+      connexion ne les utilise.  Cela consomme de l'espace car aucun des
+      journaux de transaction et aucune des lignes des catalogues système requis
+      ne  peuvent être supprimés par VACUUM tant qu'ils sont requis par un slot
+      de réplication.  Par conséquent, si un slot n'est plus nécessaire il
+      devrait être supprimé.
      </para>
     </note>
    </sect2>
    <sect2>
-    <title>Output Plugins</title>
+    <title>Plugins de sortie</title>
     <para>
-     Output plugins transform the data from the write-ahead log's internal
-     representation into the format the consumer of a replication slot desires.
+     Les plugins de sortie transforment les données depuis la représentation
+     interne dans les journaux de transaction (WAL) vers le format dont le
+     consommateur d'un slot de réplication a besoin.
     </para>
    </sect2>
    <sect2>
-    <title>Exported Snapshots</title>
+    <title>Instantanés exportés</title>
     <para>
-     When a new replication slot is created using the walsender interface a
-     snapshot is exported
-     (see <xref linkend="functions-snapshot-synchronization"/>) which will show
-     exactly the state of the database after which all changes will be
-     included in the change stream. This can be used to create a new replica by
-     using <link linkend="sql-set-transaction"><literal>SET TRANSACTION
-     SNAPSHOT</literal></link> to read the state of the database at the moment
-     the slot was created. This transaction can then be used to dump the
-     database's state at that point in time which afterwards can be updated
-     using the slot's contents without losing any changes.
+     Quand un nouveau slot de réplication est créé avec l'interface
+     walsender, un instantané est exporté (voir
+     <xref linkend="functions-snapshot-synchronization"/>), qui montrera
+     exactement l'état de la base de données après lequel tous les
+     changements seront inclus dans le flux de changement.  Cela peut être
+     utilisé pour créer un nouveau réplicat en utilisant
+     <link linkend="sql-set-transaction"><literal>SET TRANSACTION SNAPSHOT
+     </literal></link> pour lire l'état de la base au moment où le slot a
+     été créé.  Cette transaction peut alors être utilisée pour exporter
+     l'état de la base à ce point dans le temps, lequel peut ensuite être
+     mis à jour en utilisant le contenu des slots sans perdre le moindre
+     changement.
     </para>
    </sect2>
   </sect1>
   <sect1 id="logicaldecoding-walsender">
-   <title>Streaming Replication Protocol Interface</title>
+   <title>Interface du protocole de réplication par flux</title>
    <para>
-    The <literal>CREATE_REPLICATION_SLOT slot_name LOGICAL
-    options</literal>, <literal>DROP_REPLICATION_SLOT slot_name</literal>
-    and <literal>START_REPLICATION SLOT slot_name LOGICAL options</literal>
-    commands can be used to create, drop and stream changes from a replication
-    slot respectively. These commands are only available over a replication
-    connection; they cannot be used via SQL.
-    See <xref linkend="protocol-replication"/>.
+    Les commandes <literal>CREATE_REPLICATION_SLOT nom_slot LOGICAL
+    options</literal>, <literal>DROP_REPLICATION_SLOT nom_slot</literal>
+    et <literal>START_REPLICATION SLOT nom_slot LOGICAL options</literal>
+    peuvent être utilisées pour créer, supprimer et envoyer par flux les
+    changements respectivement depuis un slot de réplications.  Ces commandes
+    sont uniquement disponibles au travers d'une connexion de réplication, et
+    ne peuvent être utilisée via des commandes SQL.
+    Voir <xref linkend="protocol-replication"/>.
    </para>
    <para>
-    The <command>pg_recvlogical</command> command
-    (see <xref linkend="app-pgrecvlogical"/>) can be used to control logical
-    decoding over a walsender connection.
+    La commande  <command>pg_recvlogical</command>
+    (voir <xref linkend="app-pgrecvlogical"/>) peut être utilisée pour
+    contrôler le décodage logique au travers d'une connexion walsender.
    </para>
   </sect1>
   <sect1 id="logicaldecoding-sql">
-   <title>Logical Decoding <acronym>SQL</acronym> Interface</title>
+   <title>Interface <acronym>SQL</acronym> de décodage logique</title>
    <para>
-     See <xref linkend="functions-replication"/> for detailed documentation on
-     the SQL-level API for interacting with logical decoding.
+     Voir <xref linkend="functions-replication"/> pour une documentation
+     détaillée sur l'API de niveau SQL afin d'intéragir avec le décodage
+     logique.
    </para>
    <para>
-    Synchronous replication (see <xref linkend="synchronous-replication"/>) is
-    only supported on replication slots used over the walsender interface. The
-    function interface and additional, non-core interfaces do not support
-    synchronous replication.
+    La réplication synchrone (voir<xref linkend="synchronous-replication"/>)
+    est uniquement supportée sur des slots de réplication utilisés au travers
+    de l'interface walsender.  L'interface de fonction et autres interfaces
+    additionnelles ne faisant pas partie du moteur ne gèrent pas la
+    réplication synchrone.
    </para>
   </sect1>
   <sect1 id="logicaldecoding-catalogs">
-   <title>System catalogs related to logical decoding</title>
+   <title>Catalogues systèmes liés au décodage logique</title>
    <para>
-    The <link linkend="catalog-pg-replication-slots"><structname>pg_replication_slots</structname></link>
-    view and the
+    Les vues <link linkend="catalog-pg-replication-slots"><structname>
+    pg_replication_slots</structname></link> et
     <link linkend="monitoring-stats-views-table"><structname>pg_stat_replication</structname></link>
-    view provide information about the current state of replication slots and
-    walsender connections respectively. These views apply to both physical and
-    logical replication.
+    fournissent respectivement des informations sur l'état courant des slots de
+    réplication et des connexions walsender.  Ces vues s'appliquent à la fois
+    à la réplication physique et logique.
    </para>
   </sect1>
   <sect1 id="logicaldecoding-output-plugin">
-   <title>Logical Decoding Output Plugins</title>
+   <title>Plugins de sortie de décodage logique</title>
    <para>
-    An example output plugin can be found in the
+    Un exemple de plugin de sortie peut être trouvé dans le sous répertoire
     <link linkend="test-decoding">
      <filename>contrib/test_decoding</filename>
     </link>
-    subdirectory of the PostgreSQL source tree.
+    de l'arboresence du code source de PostgreSQL.
    </para>
    <sect2 id="logicaldecoding-output-init">
-    <title>Initialization Function</title>
+    <title>Fonction d'initialisation</title>
     <indexterm zone="logicaldecoding">
      <primary>_PG_output_plugin_init</primary>
     </indexterm>
     <para>
-     An output plugin is loaded by dynamically loading a shared library with
-     the output plugin's name as the library base name. The normal library
-     search path is used to locate the library. To provide the required output
-     plugin callbacks and to indicate that the library is actually an output
-     plugin it needs to provide a function named
-     <function>_PG_output_plugin_init</function>. This function is passed a
-     struct that needs to be filled with the callback function pointers for
-     individual actions.
+     Un plugin de sortie est chargé en chargeant dynamiquement une
+     bibliothèque partagée avec comme nom de base le nom du plugin de sortie.
+     Le chemin de recherche de bibliothèque habituel est utilisé pour
+     localiser cette bibliothèque.  Pour fournir les callbacks de plugins de
+     sortie requis et pour indiquer que la bibliothèque est effectivement un
+     plugin de sortie, elle doit fournir une fonction nommée <function>
+     _PG_output_plugin_init</function>.  Une structure est passée à cette
+     fonction qui doit la remplir avec les pointeurs des fonctions de callback
+     pour chaque action individuelle.
 <programlisting>
 typedef struct OutputPluginCallbacks
 {
@@ -330,63 +347,66 @@ typedef struct OutputPluginCallbacks
 
 typedef void (*LogicalOutputPluginInit)(struct OutputPluginCallbacks *cb);
 </programlisting>
-     The <function>begin_cb</function>, <function>change_cb</function>
-     and <function>commit_cb</function> callbacks are required,
-     while <function>startup_cb</function>
-     and <function>shutdown_cb</function> are optional.
+     Les callbacks <function>begin_cb</function>, <function>change_cb</function>
+     et <function>commit_cb</function> sont obligatoires,
+     alors que <function>startup_cb</function>
+     et <function>shutdown_cb</function> sont facultatifs.
     </para>
    </sect2>
 
    <sect2 id="logicaldecoding-capabilities">
-    <title>Capabilities</title>
+    <title>Capacités</title>
     <para>
-     To decode, format and output changes, output plugins can use most of the
-     backend's normal infrastructure, including calling output functions. Read
-     only access to relations is permitted as long as only relations are
-     accessed that either have been created by <command>initdb</command> in
-     the <literal>pg_catalog</literal> schema, or have been marked as user
-     provided catalog tables using
+     Pour décoder, formatter et sortir les changements, les plugins de sortie
+     peuvent utiliser une grande partie de l'infrastructure habituelle des
+     processus clients, y compris l'appels aux fonctions de sortie.  Les accès
+     en lecture seule aux relations est permis du moment que les relations
+     accédées ont soit été créées par <command>initdb</command> dans le schéma
+     <literal>pg_catalog</literal>, ou ont été marqués comme tables du
+     catalogue pour l'utilisateur en utilisant
 <programlisting>
-ALTER TABLE user_catalog_table SET (user_catalog_table = true);
-CREATE TABLE another_catalog_table(data text) WITH (user_catalog_table = true);
+ALTER TABLE table_catalogue_utilisateur SET (user_catalog_table = true);
+CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);
 </programlisting>
-     Any actions leading to xid assignment are prohibited. That, among others,
-     includes writing to tables, performing DDL changes and
-     calling <literal>txid_current()</literal>.
+     Toute action amenant à un assignement de d'identifiant de transaction est
+     interdit.  Cela inclue, entre autre, l'écriture dans des tables,
+     effectuer des changement DDL et appeler <literal>txid_current()</literal>.
     </para>
    </sect2>
 
    <sect2 id="logicaldecoding-output-plugin-callbacks">
-    <title>Output Plugin Callbacks</title>
+    <title>Callbacks de plugin de sortie</title>
     <para>
-     An output plugin gets notified about changes that are happening via
-     various callbacks it needs to provide.
+     Un plugin de sortie est notifié des changements arrivant au traviers de
+     différents callbacks qu'il doit fournir.
     </para>
     <para>
-     Concurrent transactions are decoded in commit order, and only changes
-     belonging to a specific transaction are decoded between
-     the <literal>begin</literal> and <literal>commit</literal>
-     callbacks. Transactions that were rolled back explicitly or implicitly
-     never get
-     decoded. Successful <link linkend="sql-savepoint">SAVEPOINTs</link> are
-     folded into the transaction containing them in the order they were
-     executed within that transaction.
+     Les transactions concurrentes sont décodées dans l'ordre dans lequel
+     elles sont validées, et seuls les changements appartenent à une
+     transaction spécifique sont décodés entre les callbacks
+     <literal>begin</literal> et <literal>commit</literal>.  Les transactions
+     quit onnt été explicitement ou implicitement annulées ne sont jamais
+     décodées.  Les <link linkend="sql-savepoint">SAVEPOINTs</link> validés
+     sont inclus dans la transaction les contenant, dans l'ordre dans lequel
+     ils ont été effectués dans la transaction.
     </para>
     <note>
      <para>
-      Only transactions that have already safely been flushed to disk will be
-      decoded. That can lead to a COMMIT not immediately being decoded in a
-      directly following <literal>pg_logical_slot_get_changes()</literal>
-      when <varname>synchronous_commit</varname> is set
-      to <literal>off</literal>.
+      Seules les transactions qui ont été synchronisées sur disque de manière
+      sûre seront décodées.  Cela peut amener à ce qu'un COMMIT ne soit pas
+      immédiatement décodé lors d'un appel à
+      <literal>pg_logical_slot_get_changes()</literal> juste après celui-ci
+      quand <varname>synchronous_commit</varname> est positionné à
+      <literal>off</literal>.
      </para>
     </note>
     <sect3 id="logicaldecoding-output-plugin-startup">
-     <title>Startup Callback</title>
+     <title>Callback de démarrage</title>
      <para>
-      The optional <function>startup_cb</function> callback is called whenever
-      a replication slot is created or asked to stream changes, independent
-      of the number of changes that are ready to be put out.
+      Le callback facultatif <function>startup_cb</function> est appelé chaque
+      fois qu'un slot de réplication est créé ou qu'on lui de fournir les flux
+      de changement,indépendamment du nombre de changements qui sont prêt à
+      être fournis.
 <programlisting>
 typedef void (*LogicalDecodeStartupCB) (
     struct LogicalDecodingContext *ctx,
@@ -394,34 +414,35 @@ typedef void (*LogicalDecodeStartupCB) (
     bool is_init
 );
 </programlisting>
-      The <literal>is_init</literal> parameter will be true when the
-      replication slot is being created and false
-      otherwise. <parameter>options</parameter> points to a struct of options
-      that output plugins can set:
+      Le paramètre  <literal>is_init</literal> sera positioné à true quand le
+      slot de réplication est créé, et à false sinon.
+      <parameter>options</parameter> pointe vers une structure d'options
+      que le plugin de sortie peut mositionner&nbsp;:
 <programlisting>
 typedef struct OutputPluginOptions
 {
     OutputPluginOutputType output_type;
 } OutputPluginOptions;
 </programlisting>
-      <literal>output_type</literal> has to either be set to
+      <literal>output_type</literal> doit être positionné soit à
       <literal>OUTPUT_PLUGIN_TEXTUAL_OUTPUT</literal>
-      or <literal>OUTPUT_PLUGIN_BINARY_OUTPUT</literal>.
+      ou à <literal>OUTPUT_PLUGIN_BINARY_OUTPUT</literal>.
      </para>
      <para>
-      The startup callback should validate the options present in
-      <literal>ctx-&gt;output_plugin_options</literal>. If the output plugin
-      needs to have a state, it can
-      use <literal>ctx-&gt;output_plugin_private</literal> to store it.
+      Le callback de démarrage devrait valider les options présentes dans
+      <literal>ctx-&gt;output_plugin_options</literal>.  Si le plugin de
+      sortie a besoin d'avoir un état, il peut utiliser
+      <literal>ctx-&gt;output_plugin_private</literal> pour le stocker.
      </para>
     </sect3>
     <sect3 id="logicaldecoding-output-plugin-shutdown">
-     <title>Shutdown Callback</title>
+     <title>Callback d'arrêt</title>
      <para>
-      The optional <function>shutdown_cb</function> callback is called
-      whenever a formerly active replication slot is not used anymore and can
-      be used to deallocate resources private to the output plugin. The slot
-      isn't necessarily being dropped, streaming is just being stopped.
+      Me callback facultatif <function>shutdown_cb</function> est appelé
+      chaque fois qu'un slot de réplication anciennement actif n'est plus
+      utilisé et peut être utilisé pour désallouer privées du plugin de
+      sortie.  Le slot n'est pas nécessairement supprimé, le flux est juste
+      arrêté.
 <programlisting>
 typedef void (*LogicalDecodeShutdownCB) (
     struct LogicalDecodingContext *ctx
@@ -430,30 +451,28 @@ typedef void (*LogicalDecodeShutdownCB) (
      </para>
    </sect3>
     <sect3 id="logicaldecoding-output-plugin-begin">
-     <title>Transaction Begin Callback</title>
+     <title>Callback de début de transaction</title>
      <para>
-      The required <function>begin_cb</function> callback is called whenever a
-      start of a committed transaction has been decoded. Aborted transactions
-      and their contents never get decoded.
+      Le callback obligatoire <function>begin_cb</function> est appelé chaque
+      fois que le début d'une transaction validée n'a pas été décodé.  Les
+      transactions annulées et leur contenu ne sont pas décodés.
 <programlisting>
 typedef void (*LogicalDecodeBeginCB) (
     struct LogicalDecodingContext *,
     ReorderBufferTXN *txn
 );
 </programlisting>
-      The <parameter>txn</parameter> parameter contains meta information about
-      the transaction, like the time stamp at which it has been committed and
-      its XID.
+      Le paramètre <parameter>txn</parameter> contient des métadonnées sur la
+      transaction, come l'heure à laquelle elle a été validée et son XID.
      </para>
    </sect3>
     <sect3 id="logicaldecoding-output-plugin-commit">
-     <title>Transaction End Callback</title>
+     <title>Callback de fin de transaction</title>
      <para>
-      The required <function>commit_cb</function> callback is called whenever
-      a transaction commit has been
-      decoded. The <function>change_cb</function> callbacks for all modified
-      rows will have been called before this, if there have been any modified
-      rows.
+      Le callback obligatoire <function>commit_cb</function> est appelé chaque
+      fois qu'une transaction validée a été décodée.  Le callback
+      <function>change_cb</function> aura été appelé avant cela pour chacune
+      des lignes modifiées, s'il y en a eu.
 <programlisting>
 typedef void (*LogicalDecodeCommitCB) (
     struct LogicalDecodingContext *,
@@ -463,15 +482,15 @@ typedef void (*LogicalDecodeCommitCB) (
      </para>
     </sect3>
     <sect3 id="logicaldecoding-output-plugin-change">
-     <title>Callback called for each individual change in a
-     transaction</title>
+     <title>Callback appelé pour chaque changement individuel
+      dans une transaction</title>
      <para>
-      The required <function>change_cb</function> callback is called for every
-      individual row modification inside a transaction, may it be
-      an <command>INSERT</command>, <command>UPDATE</command>
-      or <command>DELETE</command>. Even if the original command modified
-      several rows at once the callback will be called individually for each
-      row.
+      Le callback obligatoire <function>change_cb</function> est appelé pour
+      chacune des modifications de ligne au sein d'une transaction, qu'il
+      s'agisse d'un <command>INSERT</command>, <command>UPDATE</command>
+      ou <command>DELETE</command>.  Même si la commande d'origine a modifié
+      plusieurs ligne en une seule instruction, le callback sera appelé
+      pour chaque ligne individuellement.
 <programlisting>
 typedef void (*LogicalDecodeChangeCB) (
     struct LogicalDecodingContext *ctx,
@@ -480,41 +499,40 @@ typedef void (*LogicalDecodeChangeCB) (
     ReorderBufferChange *change
 );
 </programlisting>
-      The <parameter>ctx</parameter> and <parameter>txn</parameter> parameters
-      have the same contents as for the <function>begin_cb</function>
-      and <function>commit_cb</function> callbacks, but additionally the
-      relation descriptor <parameter>relation</parameter> points to the
-      relation the row belongs to and a struct
-      <parameter>change</parameter> describing the row modification are passed
-      in.
+      Les paramètres <parameter>ctx</parameter> et <parameter>txn</parameter>
+      ont le même contenu que pour les callbacks <function>begin_cb</function>
+      et <function>commit_cb</function>, mais en plus le descripteur de relation
+      <parameter>relation</parameter> pointe vers la relation à laquelle
+      apaprtient la ligne et une structure <parameter>change</parameter>
+      décrivant les modifications de lignes y est passée.
      </para>
      <note>
       <para>
-       Only changes in user defined tables that are not unlogged
-       (see <xref linkend="sql-createtable-unlogged"/>) and not temporary
-       (see <xref linkend="sql-createtable-temporary"/>) can be extracted using
-       logical decoding.
+       Seules les changement dans les tables définies par les utilisateurs qui
+       sont et journalisées (voir <xref linkend="sql-createtable-unlogged"/>)
+       et ne sont pas temporaires
+       (voir <xref linkend="sql-createtable-temporary"/>) peuvent être extraite
+       avec le décodage logique.
       </para>
      </note>
     </sect3>
    </sect2>
    <sect2 id="logicaldecoding-output-plugin-output">
-    <title>Functions for producing output from an output plugin</title>
+    <title>Fonction pour produire une sortie dans un plugin de sortie</title>
     <para>
-     To actually produce output, output plugins can write data to
-     the <literal>StringInfo</literal> output buffer
-     in <literal>ctx-&gt;out</literal> when inside
-     the <function>begin_cb</function>, <function>commit_cb</function>
-     or <function>change_cb</function> callbacks. Before writing to the output
-     buffer <function>OutputPluginPrepareWrite(ctx, last_write)</function> has
-     to be called, and after finishing writing to the
-     buffer <function>OutputPluginWrite(ctx, last_write)</function> has to be
-     called to perform the write. The <parameter>last_write</parameter>
-     indicates whether a particular write was the callback's last write.
+     Pour effectivement pouvoir produire une sortie, les plugins de sortie
+     peuvent écrire des données dans le tampon de sortie <literal>StringInfo
+     </literal> dans <literal>ctx-&gt;out</literal> dans les callbacks
+     <function>begin_cb</function>, <function>commit_cb</function>
+     ou <function>change_cb</function>.  Avant d'écrire dans le tampon de
+     sortie, <function>OutputPluginWrite(ctx, last_write)</function> doit avoir
+     été appelé pour effectuer l'écriture.  <parameter>last_write</parameter>
+     indique si une écriture particuli_re était la dernière écriture du
+     callback.
     </para>
     <para>
-     The following example shows how to output data to the consumer of an
-     output plugin:
+     L'exemple suivant montre comment sortir des données pour le consommateur
+     d'un plugin de sortie&nbsp;:
 <programlisting>
 OutputPluginPrepareWrite(ctx, true);
 appendStringInfo(ctx->out, "BEGIN %u", txn->xid);
@@ -524,36 +542,39 @@ OutputPluginWrite(ctx, true);
    </sect2>
   </sect1>
   <sect1 id="logicaldecoding-writer">
-   <title>Logical Decoding Output Writers</title>
+   <title>Écrivains de sortie de décodage logique</title>
    <para>
-    It is possible to add more output methods for logical decoding.
-    For details, see
+    Il est possible d'ajouter d'autres méthodes de sortie pour le décodage
+    logique. Pour plus de détail, voir
     <filename>src/backend/replication/logical/logicalfuncs.c</filename>.
-    Essentially, three functions need to be provided: one to read WAL, one to
-    prepare writing output, and one to write the output
-    (see <xref linkend="logicaldecoding-output-plugin-output"/>).
+    Principalement, trois fonctions doivent être fournies&nbsp;: une pour lire
+    les journaux de transaction, une pour préparer l'écriture de sortie et une
+    pour préparer la sortie
+    (voir <xref linkend="logicaldecoding-output-plugin-output"/>).
    </para>
   </sect1>
   <sect1 id="logicaldecoding-synchronous">
-   <title>Synchronous replication support for Logical Decoding</title>
+   <title>Support de la réplicationp synchrone pour le décoage logique</title>
    <para>
-    Logical decoding may be used to to build
-    <link linkend="synchronous-replication">synchronous
-    replication</link> solutions with the same user interface as synchronous
-    replication for <link linkend="streaming-replication">streaming
-    replication</link>.  To do this, the walsender interface
-    (see <xref linkend="logicaldecoding-walsender"/>) must be used to stream out
-    data. Clients have to send <literal>Standby status update (F)</literal>
-    (see <xref linkend="protocol-replication"/>) messages, just like streaming
-    replication clients do.
+    Le décodage logique peut être utiliser pour construire des solution de
+    <link linkend="synchronous-replication">réplication synchrone</link> avec
+    la même interface utilisateur que la réplication synchrone de la
+    <link linkend="streaming-replication">réplication par flux</link>.  Pour
+    cela, l'interface walsender
+    (voir <xref linkend="logicaldecoding-walsender"/>) doit être utilisée pour
+    renvoyer par flux les données.  Les clients doivent envoyer des messages
+    <literal>Standby status update (F)</literal>
+    (voir <xref linkend="protocol-replication"/>), tout comme le font les
+    clients de réplication par flux.
    </para>
    <note>
     <para>
-     A synchronous replica receiving changes via logical decoding will work in
-     the scope of a single database. Since, in contrast to
-     that, <parameter>synchronous_standby_names</parameter> currently is
-     server wide, this means this technique will not work properly if more
-     than one database is actively used.
+     Un réplicat synchrone recevant des changement grâce au décodage logique
+     fonctionnera dans le cadre d'une seule base de données.  Puisque,
+     à l'opposé de cela, <parameter>synchronous_standby_names</parameter> est
+     actuellement commun à toute l'instance, cela signifie que cette technique
+     ne marchera pas convenablement si plus d'une base de l'instance est
+     utilisée activement.
      </para>
    </note>
   </sect1>

--- a/postgresql/pgprewarm.xml
+++ b/postgresql/pgprewarm.xml
@@ -9,13 +9,14 @@
  </indexterm>
 
  <para>
-  The <filename>pg_prewarm</filename> module provides a convenient way
-  to load relation data into either the operating system buffer cache
-  or the <productname>PostgreSQL</productname> buffer cache.
+  Le module <filename>pg_prewarm</filename> fournit un moyen pratique
+  de charger des données de relations dans le cache de données du système
+  d'exploitation ou dans le cache de données de
+  <productname>PostgreSQL</productname>.
  </para>
 
  <sect2>
-  <title>Functions</title>
+  <title>Fonctions</title>
 
 <synopsis>
 pg_prewarm(regclass, mode text default 'buffer', fork text default 'main',
@@ -24,42 +25,48 @@ pg_prewarm(regclass, mode text default 'buffer', fork text default 'main',
 </synopsis>
 
   <para>
-   The first argument is the relation to be prewarmed.  The second argument
-   is the prewarming method to be used, as further discussed below; the third
-   is the relation fork to be prewarmed, usually <literal>main</literal>.
-   The fourth argument is the first block number to prewarm
-   (<literal>NULL</literal> is accepted as a synonym for zero).  The fifth
-   argument is the last block number to prewarm (<literal>NULL</literal>
-   means prewarm through the last block in the relation).  The return value
-   is the number of blocks prewarmed.
+   Le premier argument correspond à la ration qui doit être préchargée. Le
+   second argument correspond à la méthode de préchargement à utiliser,
+   comme cela sera vu plus bas. Le troisième argument correspond au fork
+   à précharger (généralement <literal>main</literal>).  Le quatrième
+   argument correspond au numéro du premier bloc à précharger
+   (<literal>NULL</literal> est accepté comme synonyme de zero). Le cinquième
+   argument correspond au dernier numéro de bloc à précharger
+   (<literal>NULL</literal> signifie précharger jusqu'au dernier bloc trouvé
+   dans la relation). La valeur retournée correspond au nombre de blocs
+   préchargés.
   </para>
 
   <para>
-   There are three available prewarming methods.  <literal>prefetch</literal>
-   issues asynchronous prefetch requests to the operating system, if this is
-   supported, or throws an error otherwise.  <literal>read</literal> reads
-   the requested range of blocks; unlike <literal>prefetch</literal>, this is
-   synchronous and supported on all platforms and builds, but may be slower.
-   <literal>buffer</literal> reads the requested range of blocks into the
-   database buffer cache.
+   Il y a trois méthodes de préchargement diesponibles.
+   <literal>prefetch</literal> envoie une requête de prélecture asynchrone au
+   système d'exploitation si celui-ci le supporte ou sinon renvoie une erreur.
+   <literal>read</literal> lit l'intervalle de blocs demandé. Contrairement à
+   <literal>prefetch</literal>, toutes les plateformes et options de compilation
+   le supportent, mais peut être plus lent.  <literal>buffer</literal> lit
+   l'intervalle de blocs demandé pour le charger dans le cache de données de la
+   base.
   </para>
 
   <para>
-   Note that with any of these methods, attempting to prewarm more blocks than
-   can be cached &mdash; by the OS when using <literal>prefetch</literal> or
-   <literal>read</literal>, or by <productname>PostgreSQL</productname> when
-   using <literal>buffer</literal> &mdash; will likely result in lower-numbered
-   blocks being evicted as higher numbered blocks are read in.  Prewarmed data
-   also enjoys no special protection from cache evictions, so it is possible
-   for other system activity may evict the newly prewarmed blocks shortly after
-   they are read; conversely, prewarming may also evict other data from cache.
-   For these reasons, prewarming is typically most useful at startup, when
-   caches are largely empty.
+   Il est à noter qu'avec n'importe laquelle de ces méthodes, tenter de
+   précharger plus de blocs que'il est possible de mettre en cache &mdash; par
+   le système d'exploitation en utilisant <literal>prefetch</literal> ou
+   <literal>read</literal>, ou par <productname>PostgreSQL</productname> en
+   utilisant <literal>buffer</literal> &mdash; aura probablement pour effet
+   d'expulser du cache les blocs de numéro inférieur au fur et à mesure que
+   les blocs de numéro supérieurs seront lus.  De plus, le préchargement de
+   données apprécie qu'aucune protection contre l'expulsion de données du
+   cache ne soit présente, il est donc possible que d'autres activités du
+   système d'exploitation puissent évincer du cache les données fraîchement
+   préchargées peu de temps après leur préchargement. Pour toutes ces
+   raisons, le préchargement est typiquement plus utile au démarrage, quand
+   les caches sont majoritairement vides.
   </para>
  </sect2>
 
  <sect2>
-  <title>Author</title>
+  <title>Auteur</title>
 
   <para>
    Robert Haas <email>rhaas@postgresql.org</email>

--- a/postgresql/ref/pg_recvlogical.xml
+++ b/postgresql/ref/pg_recvlogical.xml
@@ -17,8 +17,9 @@ PostgreSQL documentation
 
  <refnamediv>
   <refname>pg_recvlogical</refname>
-  <refpurpose>Control logical decoding (see <xref linkend="logicaldecoding"/>)
-   streams over a walsender connection.</refpurpose>
+  <refpurpose>Contrôle le flux de décodage logique
+   (voir <xref linkend="logicaldecoding"/>) au travers d'une connexion
+   walsender.</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -31,14 +32,14 @@ PostgreSQL documentation
  <refsect1 id="r1-app-pgrecvlogical-1">
   <title>Description</title>
   <para>
-   <command>pg_recvlogical</command> controls logical decoding replication
-   slots and streams data from such replication slots.
+   <command>pg_recvlogical</command> contrôle le décodage logique des slots de
+   réplication et envoie les données par flux depuis ces slots de réplication.
   </para>
   <para>
-   It creates a replication-mode connection, so it is subject to the same
-   constraints as <link
+   Il crée une connexion en mode réplication, et est donc sujet aux même
+   contraintes que <link
    linkend="app-pgreceivexlog"><application>pg_receivexlog</application></link>,
-   plus those for logical replication (see <xref
+   en plus de celles de la réplication logique (voir <xref
    linkend="logicaldecoding"/>).
   </para>
 
@@ -48,8 +49,8 @@ PostgreSQL documentation
   <title>Options</title>
 
    <para>
-    <application>pg_recvlogical</application> runs in one of three modes, which
-    control its primary action:
+    <application>pg_recvlogical</application> fonctionne dans un des trois
+    modes disponibles, qui contrôle son action principale&nbsp;:
 
     <variablelist>
 
@@ -57,10 +58,10 @@ PostgreSQL documentation
       <term><option>--create</option></term>
       <listitem>
        <para>
-        Create a new logical replication slot with the name specified in
-        <option>--slot</option>, using the output plugin
-        <option>--plugin</option>, then exit. The slot is created for the
-        database given in <option>--dbname</option>.
+        Crée un nouveau slot de réplication avec le nom spécifié avec
+        <option>--slot</option>, utilisant le plugin de sortie
+        <option>--plugin</option>, puis quitte.  Le slot est créé pour la base
+        de donnée spécifié par <option>--dbname</option>.
        </para>
       </listitem>
      </varlistentry>
@@ -69,15 +70,17 @@ PostgreSQL documentation
       <term><option>--start</option></term>
       <listitem>
        <para>
-        Begin streaming changes from the logical replication slot with the name
-        specified in <option>--slot</option>, continuing until terminated with a
-        signal. If the server side change stream ends with a server
-        shutdown or disconnect, retry in a loop unless
-        <option>--no-loop</option> is specified. The stream format is
-        determined by the output plugin specified when the slot was created.
+        Démarre l'envoi par flux depuis le slot de réplication logique dont le
+        nom est spécifié par <option>--slot</option>, continuant jusqu'à ce
+        qu'il soit terminé avec un signal.  Si le flux de changement du serveur
+        se finit avec un arrêt ou une déconnexion du serveur, une tentative de
+        reconnexion sera effectuée dans une boucle à moins que l'option
+        <option>--no-loop</option> ne soit spécifiée.  Le format de flux est
+        déterminé par le plugin de sortie spécifié quand le sot est créé.
        </para>
        <para>
-        You must connect to the same database used to create the slot.
+        Il est nécessaire de se connecter à la même base de donnée que celle
+        utilisée pour créer le slot.
        </para>
       </listitem>
      </varlistentry>
@@ -86,8 +89,8 @@ PostgreSQL documentation
       <term><option>--drop</option></term>
       <listitem>
        <para>
-        Drop the replication slot with the name specified
-        in <option>--slot</option>, then exit.
+        Supprime le slot de réplication dont le est spécifié avec
+        <option>--slot</option>, puis quitte.
        </para>
       </listitem>
      </varlistentry>
@@ -96,48 +99,49 @@ PostgreSQL documentation
    </para>
 
    <para>
-    <application>pg_recvlogical</application> supports all the usual
-    <literal>libpq</literal>-based options. These are explained in detail in
-    the documentation for
-    <link linkend="app-psql"><application>psql</application></link> and for
+    <application>pg_recvlogical</application> est compatible avec toutes les
+    options habituelles basée sur la <literal>libpq</literal>.  Celles-ci sont
+    expliquées en détail dans la documentation de
+    <link linkend="app-psql"><application>psql</application></link> et de
     <link linkend="libpq"><literal>libpq</literal></link>.
 
     <variablelist>
 
       <varlistentry>
-       <term><option>-U <replaceable>user</replaceable></option></term>
-       <term><option>--username <replaceable>user</replaceable></option></term>
+       <term><option>-U <replaceable>utilisateur</replaceable></option></term>
+       <term><option>--username <replaceable>utilisateur</replaceable></option></term>
        <listitem>
         <para>
-         Username to connect as. Must have a suitable <literal>pg_hba.conf</literal>
-         entry allowing <literal>replication</literal> connections. Defaults to
-         current operating system user name.
+         Nom d'utilisateur pour la connexion.  Doit avoir une entrée valide dans
+         <literal>pg_hba.conf</literal> autorisant les connexions de
+         <literal>replication</literal>.  Par défaut, le nom de l'utilisateur
+         courant du système d'exploitation est utilisé.
         </para>
        </listitem>
       </varlistentry>
 
       <varlistentry>
-       <term><option>-d <replaceable>database</replaceable></option></term>
-       <term><option>--dbname <replaceable>database</replaceable></option></term>
+       <term><option>-d <replaceable>base</replaceable></option></term>
+       <term><option>--dbname <replaceable>base</replaceable></option></term>
        <listitem>
         <para>
-         The database to connect to in <literal>replication</literal> mode; see
-         mode descriptions for details. May be
-         a <link linkend="libpq-connstring">libpq connstring</link>
-         instead. Defaults to user name.
+         Base de données à laquelle se connecter en mode
+         <literal>réplication</literal>; voir la descriptions des modes pour
+         plus de détails.  Peut sinon être une <link linkend="libpq-connstring">
+         chaîne de connexion (connstring) libpq</link>.  Par défaut le nom de
+         l'utilisateur.
         </para>
        </listitem>
       </varlistentry>
 
       <varlistentry>
-       <term><option>-h <replaceable>hostname-or-ip</replaceable></option></term>
-       <term><option>--host <replaceable>hostname-or-ip</replaceable></option></term>
+       <term><option>-h <replaceable>nom_d_hote-ou-ip</replaceable></option></term>
+       <term><option>--host <replaceable>nom_d_hote-ou-ip</replaceable></option></term>
        <listitem>
         <para>
-         Host or socket to connect
-         to. See <link linkend="app-psql"><application>psql</application></link>
-         and <link linkend="libpq"><literal>libpq</literal></link>
-         documentation.
+         Hôte ou socket auquel se connecter.  Voir la documentation de
+         <link linkend="app-psql"><application>psql</application></link>
+         et <link linkend="libpq"><literal>libpq</literal></link>.
         </para>
        </listitem>
       </varlistentry>
@@ -147,10 +151,10 @@ PostgreSQL documentation
        <term><option>--port <replaceable>port</replaceable></option></term>
        <listitem>
         <para>
-         Port number to connect to. See
+         Numéro de port auquel se connecter.  Voir
          <link linkend="r1-app-psql-3"><application>psql</application></link>
-         for an explanation of default port choices when this is not
-         specified.
+         pour une explication du choix de port par défaut lorsqu'il il n'est
+         pas spécifié.
         </para>
        </listitem>
       </varlistentry>
@@ -160,8 +164,8 @@ PostgreSQL documentation
        <term><option>--no-password</option></term>
        <listitem>
         <para>
-         Prevent prompting for a password. Will exit with an error code if a
-         password is required but not available.
+         Empêche la demande de saisie d'un mot de passe.  Quittera avec un code
+         d'erreur si un mot de passe est nécessaire mais non disponible.
         </para>
        </listitem>
       </varlistentry>
@@ -171,9 +175,9 @@ PostgreSQL documentation
        <term><option>--password</option></term>
        <listitem>
         <para>
-         Provide a password for this connection. Please use the pgservice file
-         (see <xref linkend="libpq-pgservice"/>) or an environment variable
-         instead of this option.
+         Fournit un mot de passe pour cette connexion.  Il est préférable
+         d'utiliser le fichier pgservice (voir <xref linkend="libpq-pgservice"/>
+         ou une variable d'environnement plutôt que d'utiliser cette option.
         </para>
        </listitem>
       </varlistentry>
@@ -183,18 +187,18 @@ PostgreSQL documentation
    </para>
 
    <para>
-    The following command-line options control the location and format of the
-    output and other replication behavior:
+    L'option de ligne de commande suivante contrôle l'emplacement et le format
+    de sortie ainsi que les autres comportements de la réplication&nbsp;:
 
     <variablelist>
 
      <varlistentry>
-      <term><option>-f <replaceable>filename</replaceable></option></term>
-      <term><option>--file=<replaceable>filename</replaceable></option></term>
+      <term><option>-f <replaceable>nom_fichier</replaceable></option></term>
+      <term><option>--file=<replaceable>nom_fichier</replaceable></option></term>
       <listitem>
        <para>
-        Write received and decoded transaction data into this
-        file. Use <literal>-</literal> for stdout.
+        Écrit les données de transactions reçues et décodées dans ce fichier.
+        Utiliser <literal>-</literal> pour la sortie standard.
        </para>
       </listitem>
      </varlistentry>
@@ -205,34 +209,38 @@ PostgreSQL documentation
       <term><option>--no-loop</option></term>
       <listitem>
        <para>
-        When the connection to the server is lost, do not retry in a loop, just exit.
+        Quand la connextion avec le serveur est perdue, ne pas tenter de se
+        reconnecter dans une boucle, simplement quitter.
        </para>
       </listitem>
      </varlistentry>
 
      <varlistentry>
-      <term><option>-o <replaceable>NAME</replaceable>[=<replaceable>VALUE</replaceable>]</option></term>
-      <term><option>--option=<replaceable>NAME</replaceable>[=<replaceable>VALUE</replaceable>]</option></term>
+      <term><option>-o <replaceable>NOM</replaceable>[=<replaceable>VALEUR</replaceable>]</option></term>
+      <term><option>--option=<replaceable>NOM</replaceable>[=<replaceable>VALEUR</replaceable>]</option></term>
       <listitem>
        <para>
+        Fournit l'option <parameter>NOM</parameter> au plugin de sortie avec,
+        si spécifié, la valeur <parameter>VALEUR</parameter> pour cette option.
         Pass the option <parameter>NAME</parameter> to the output plugin with,
-        if specified, the option value <parameter>NAME</parameter>. Which
-        options exist and their effects depends on the used output plugin.
+        Les options existantes ainsi que leurs effets dépendent du plugin de
+        sortie utilisé.
        </para>
       </listitem>
      </varlistentry>
 
      <varlistentry>
-      <term><option>-F <replaceable>interval_seconds</replaceable></option></term>
-      <term><option>--fsync-interval=<replaceable>interval_seconds</replaceable></option></term>
+      <term><option>-F <replaceable>intervalle_en_seconde</replaceable></option></term>
+      <term><option>--fsync-interval=<replaceable>intervalle_en_seconde</replaceable></option></term>
       <listitem>
        <para>
-        How often should <application>pg_recvlogical</application> issue sync
-        commands to ensure the <parameter>--outputfile</parameter> is safely
-        flushed to disk without being asked by the server to do so. Specifying
-        an interval of <literal>0</literal> disables issuing fsyncs altogether,
-        while still reporting progress the server.  In this case, data may be
-        lost in the event of a crash.
+        À quelle fréquence <application>pg_recvlogical</application> devrait
+        effectuer des commandes sync pour s'assurer que <parameter>--outputfile
+        </parameter> est écrit sur disque de manière sûre sans que le serveur
+        ait besoin de le demander. Spécifier un intervalle de <literal>0
+        </literal> désactive entièrement les appels à fsync, bien que leurs
+        progressions soit toujours renvoyées au serveur.  Dans ce cas, des
+        données peuvent être perdues en cas de d'arrêt brutal.
        </para>
       </listitem>
      </varlistentry>
@@ -242,33 +250,34 @@ PostgreSQL documentation
       <term><option>--plugin=<replaceable>plugin</replaceable></option></term>
       <listitem>
        <para>
-        When creating a slot, use the logical decoding output
-        plugin. See <xref linkend="logicaldecoding"/>. This option has no
-        effect if the slot already exists.
+        Lors de la création du slot, utiliser la sortie de plugin de décodage
+        spécifiée. Voir <xref linkend="logicaldecoding"/>.  Cette option n'a
+        pas d'effêt si le slot existe déjà.
        </para>
       </listitem>
      </varlistentry>
 
      <varlistentry>
-      <term><option>-s <replaceable>interval_seconds</replaceable></option></term>
-      <term><option>--status-interval=<replaceable>interval_seconds</replaceable></option></term>
+      <term><option>-s <replaceable>intervalle_en_seconde</replaceable></option></term>
+      <term><option>--status-interval=<replaceable>intervalle_en_seconde</replaceable></option></term>
       <listitem>
        <para>
-        This option has the same effect as the option of the same name in <link
+        Cette option a le même effet que l'option du même nom dans <link
         linkend="app-pgreceivexlog"><application>pg_receivexlog</application></link>.
-        See the description there.
+        Voir la description à cet endroit.
        </para>
       </listitem>
      </varlistentry>
 
      <varlistentry>
-      <term><option>-S <replaceable>slot_name</replaceable></option></term>
-      <term><option>--slot=<replaceable>slot_name</replaceable></option></term>
+      <term><option>-S <replaceable>nom_slot</replaceable></option></term>
+      <term><option>--slot=<replaceable>nom_slot</replaceable></option></term>
       <listitem>
        <para>
-        In <option>--start</option> mode, use the existing logical replication slot named
-        <replaceable>slot_name</replaceable>. In <option>--create</option> mode, create the
-        slot with this name. In <option>--drop</option> mode, delete the slot with this name.
+        Dans le mode <option>--start</option>, utilie le slot de réplication
+        logique existant nommé <replaceable>slot_name</replaceable>. Dans le
+        mode <option>--create</option>, créer le slot de réplication avec ce
+        nom. Dans le mode <option>--drop</option>, supprimer le slot de ce nom.
        </para>
       </listitem>
      </varlistentry>
@@ -278,10 +287,10 @@ PostgreSQL documentation
       <term><option>--startpos=<replaceable>lsn</replaceable></option></term>
       <listitem>
        <para>
-        In <option>--start</option> mode, start replication from the given
-        LSN.  For details on the effect of this, see the documentation
-        in <xref linkend="logicaldecoding"/>
-        and <xref linkend="protocol-replication"/>. Ignored in other modes.
+        Dans le mode <option>--start</option>, démarrer la réplication depuis
+        le LSN donné. Pour plus de détail sur les effets de ce paramètre, voir
+        la documentation dans <xref linkend="logicaldecoding"/> et
+        <xref linkend="protocol-replication"/>.  Ignoré dans les autres modes.
        </para>
       </listitem>
      </varlistentry>
@@ -290,7 +299,7 @@ PostgreSQL documentation
    </para>
 
    <para>
-    The following additional options are available:
+    Les options supplémentaires suivantes sont disponibles&nbsp;:
 
     <variablelist>
 
@@ -299,7 +308,7 @@ PostgreSQL documentation
        <term><option>--verbose</option></term>
        <listitem>
        <para>
-        Enables verbose mode.
+        Active le mode verbeux.
        </para>
        </listitem>
      </varlistentry>
@@ -309,7 +318,8 @@ PostgreSQL documentation
        <term><option>--version</option></term>
        <listitem>
        <para>
-        Print the <application>pg_recvlogical</application> version and exit.
+        Affiche la version de <application>pg_recvlogical</application> puis
+        quitte..
        </para>
        </listitem>
      </varlistentry>
@@ -319,8 +329,8 @@ PostgreSQL documentation
       <term><option>--help</option></term>
        <listitem>
         <para>
-         Show help about <application>pg_recvlogical</application> command line
-         arguments, and exit.
+         Affiche l'aide sur les arguments en ligne de commande de <application>
+         pg_recvlogical</application>, puis quitte.
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
Traduction de :
- logicaldecoding.xml
- pgprewarm.xml
- ref/pg_recvlogical

A noter qu'il y a une typo dans la doc d'origine que j'ai corrigée :
"Pass the option <parameter>NAME</parameter> to the output plugin with,
if specified, the option value <parameter>NAME</parameter>."

NAME utilisé au lieu de VALUE pour la 2ème ligne (je ferais un patch pour corriger upstream),

et que la description du paramètre -W porte à confusion :
"Provide a password for this connection. Please use the pgservice file
(see <xref linkend="libpq-pgservice"/>) or an environment variable
instead of this option."

ce qui je trouve laisse sous-entendre que le mot de passe est fournit en ligne de commande, alors que d'après le code de pg_recvlogical c'est bien le comportement standard (i.e. force la demande de saisie d'un mot de passe). A ton avis patch aussi pour ce point là ?

Bon, sinon c'était des gros morceaux. J'ai relu rapidement mais il doit rester des typos et autre, bon courage :)
