### PR TITLE
traduction 9.5 ddl.xml

### DIFF
--- a/postgresql/ddl.xml
+++ b/postgresql/ddl.xml
@@ -1490,145 +1490,169 @@ ALTER TABLE produits ADD FOREIGN KEY (id_groupe_produit) REFERENCES groupes_prod
   </indexterm>
 
   <para>
-   In addition to the SQL-standard <link linkend="ddl-priv">privilege
-   system</link> available through <xref linkend="sql-grant"/>,
-   tables can have <firstterm>row security policies</firstterm> that restrict,
-   on a per-user basis, which rows can be returned by normal queries
-   or inserted, updated, or deleted by data modification commands.
-   This feature is also known as <firstterm>Row-Level Security</firstterm>.
-   By default, tables do not have any policies, so that if a user has
-   access privileges to a table according to the SQL privilege system,
-   all rows within it are equally available for querying or updating.
+   En addition <link linkend="ddl-priv">aux privilèges système</link>
+   standards du SQL disponibles via <xref linkend="sql-grant"/>, les
+   tables peuvent avoir des <firsterm>row level policies</firstterm>
+   qui restreignent, utilisateur par utilisateur, les lignes qui
+   peuvent être renvoyées par les requêtes d'interrogation ou les
+   commandes d''insertion, mises à jour ou de suppression. Cette
+   fonctionnalité est aussi connue sous le nom <firstterm>Row-Level
+   Security</firstterm>. Par défaut, les tables n'ont aucune police
+   de ce type, aussi si un utilisateur à accès à une table selon
+   le système SQL des privilèges, toutes les lignes de la table sont
+   accessibles aux requêtes ou mises à jour.
   </para>
 
   <para>
-   When row security is enabled on a table (with
-   <link linkend="sql-altertable">ALTER TABLE ... ENABLE ROW LEVEL
-   SECURITY</link>), all normal access to the table for selecting rows or
-   modifying rows must be allowed by a row security policy.  (However, the
-   table's owner is typically not subject to row security policies.)  If no
-   policy exists for the table, a default-deny policy is used, meaning that
-   no rows are visible or can be modified.  Operations that apply to the
-   whole table, such as <command>TRUNCATE</command> and <literal>REFERENCES</literal>,
-   are not subject to row security.
+   Lorsque les row level securities sont activées sur une table (avec
+   l'instruction <link linkend="sql-altertable">ALTER TABLE ... ENABLE
+   ROW LEVEL SECURITY</link>, tous les accès classiques à la table
+   pour sélectionner ou modifier des lignes doivent être permis par
+   une row security policy. (Cependant, le propriétaire de la table
+   n'est typiquement pas soumis aux row security policies). Si aucune
+   police n'existe pour la table, une police de rejet est utilisé
+   par défaut, ce qui signifie qu'aucune ligne n'est visible ou
+   ne peut être modifiée. Les opérations qui s'appliquent pour
+   la table dans sa globalité, comme <command>TRUNCATE</command>
+   et <literal>REFERENCES</literal>, ne sont pas soumis à ces
+   restrictions de niveau ligne.
   </para>
 
   <para>
-   Row security policies can be specific to commands, or to roles, or to
-   both.  A policy can be specified to apply to <literal>ALL</literal>
-   commands, or to <literal>SELECT</literal>, <literal>INSERT</literal>, <literal>UPDATE</literal>,
-   or <literal>DELETE</literal>.  Multiple roles can be assigned to a given
-   policy, and normal role membership and inheritance rules apply.
+   Les row security policies peuvent s'appliquer en particulier
+   à des commandes, ou à des rôles, ou aux deux. Une police
+   est indiquée comme s'appliquant à toutes les commandes par
+   <literal>ALL</literal>, ou seulement à <literal>SELECT</literal>,
+   <literal>INSERT</literal>, <literal>UPDATE</literal> ou
+   <literal>DELETE</literal>. Plusieurs rôles peuvent être assignés
+   à une police donnée, et les règles normales d'appartenance et
+   d'héritage s'appliquent.
   </para>
 
   <para>
-   To specify which rows are visible or modifiable according to a policy,
-   an expression is required that returns a Boolean result.  This
-   expression will be evaluated for each row prior to any conditions or
-   functions coming from the user's query.  (The only exceptions to this
-   rule are <literal>leakproof</literal> functions, which are guaranteed to
-   not leak information; the optimizer may choose to apply such functions
-   ahead of the row-security check.)  Rows for which the expression does
-   not return <literal>true</literal> will not be processed.  Separate expressions
-   may be specified to provide independent control over the rows which are
-   visible and the rows which are allowed to be modified.  Policy
-   expressions are run as part of the query and with the privileges of the
-   user running the query, although security-definer functions can be used
-   to access data not available to the calling user.
+   Pour indiquer quelles lignes sont visibles ou modifiables
+   selon une police, une expression renvoyant un booléen est
+   requise. Cette expression sera évaluée pour chaque ligne avant
+   toutes conditions ou fonctions qui seraient indiquées dans les
+   requêtes de l'utilisateur. (La seule exception à cette règle
+   sont les fonctions <literal>leakproof</literal>, qui annoncent ne
+   pas dévoiler d'information; l'optimiseur peut choisir d'appliquer
+   de telles fonctions avant les vérifications de sécurité niveau
+   ligne). Les lignes pour lesquelles l'expression ne renvoie pas
+   <literal>true</literal> ne sont pas traitées. Des expressions
+   différentes peuvent être indiquées pour fournir des contrôles
+   indépendants pour les lignes qui sont visibles et pour celles qui sont
+   modifiées. Les expressions attachées à la police sont exécutées
+   dans le cours de la requête et avec les privilèges de l'utilisateur
+   qui exécute la commande, bien que les fonctions définies avec
+   l'attribut SECURITY DEFINER peuvent être utilisées pour accèder à des
+   données qui ne seraient pas disponibles à l'utilisateur effectuant
+   la requête.
   </para>
 
   <para>
-   Superusers and roles with the <literal>BYPASSRLS</literal> attribute always
-   bypass the row security system when accessing a table.  Table owners
-   normally bypass row security as well, though a table owner can choose to
-   be subject to row security with <link linkend="sql-altertable">ALTER
-   TABLE ... FORCE ROW LEVEL SECURITY</link>.
+   Les superutilisateurs et les roles avec l'attribut
+   <literal>BYPASSRLS</literal> ne sont pas soumis au système de
+   sécurité niveau ligne lorsqu'ils accèdent une table. Il en
+   est de même par défaut du propriétaire d'une table, bien
+   qu'il puisse choisir de se soumettre à ces contrôles avec
+   <link linkend="sql-altertable">ALTER TABLE ... FORCE ROW LEVEL
+   SECURITY</link>.
   </para>
 
   <para>
-   Enabling and disabling row security, as well as adding policies to a
-   table, is always the privilege of the table owner only.
+   L'activation ou la désactivation de la sécurité niveau ligne,
+   comme de l'ajout des polices à une table, est toujours le privilège
+   du seul propriétaire de la table.
   </para>
 
   <para>
-   Policies are created using the <xref linkend="sql-createpolicy"/>
-   command, altered using the <xref linkend="sql-alterpolicy"/> command,
-   and dropped using the <xref linkend="sql-droppolicy"/> command.  To
-   enable and disable row security for a given table, use the
-   <xref linkend="sql-altertable"/> command.
+   Les polices sont créées en utilisant l'instruction <xref linkend="sql-createpolicy"/>, 
+   modifiées avec la commande <xref linkend="sql-alterpolicy"/>, 
+   et supprimées avec la commande <xref linkend="sql-droppolicy"/>. 
+   Pour activer et désactiver la sécurité niveau ligne pour une table
+   donnée, utilisez la commande <xref linkend="sql-altertable"/>.
   </para>
 
   <para>
-   Each policy has a name and multiple policies can be defined for a
-   table.  As policies are table-specific, each policy for a table must
-   have a unique name.  Different tables may have policies with the
-   same name.
+   Chaque police possède un nom et de multiples polices peuvent être
+   définies pour une table. Comme les polices sont spécifiques à
+   une table, chaque police pour une même table doit avoir un nom
+   différent. Différentes tables peuvent avoir des noms de police avec
+   le même nom.
   </para>
 
   <para>
-   When multiple policies apply to a given query, they are combined using
-   <literal>OR</literal>, so that a row is accessible if any policy allows
-   it.  This is similar to the rule that a given role has the privileges
-   of all roles that they are a member of.
+   Lorque plusieurs polices sont applicables pour une même requête,
+   elles sont combinées en utilisant <literal>OR</literal>, c'est à
+   dire qu'une ligne est accessible si une des polices le permet. Ceci
+   est similaire à la règle qui veut qu'un rôle donné possède les
+   privilèges de tous les rôles dont il est membre.
   </para>
 
   <para>
-   As a simple example, here is how to create a policy on
-   the <literal>account</literal> relation to allow only members of
-   the <literal>managers</literal> role to access rows, and only rows of their
-   accounts:
+   À titre de simple exemple, nous allons ici créer une police sur
+   la relation <literal>comptes</literal> pour autoriser seulement les
+   membres du role <literal>admins</literal> à accèder seulement aux
+   lignes de leurs propres comptes:
   </para>
 
 <programlisting>
-CREATE TABLE accounts (manager text, company text, contact_email text);
+CREATE TABLE comptes (admin text, societe text, contact_email text);
 
-ALTER TABLE accounts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE comptes ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY account_managers ON accounts TO managers
-    USING (manager = current_user);
+CREATE POLICY compte_admins ON comptes TO admins
+    USING (admin = current_user);
+</programlisting>
+
+<para>
+   Si aucun rôle n'est indiqué, ou le nom de rôle special
+   <literal>PUBLIC</literal> est utilisé, alors la police s'applique
+   à tous les utilisateurs du système. Pour autoriser tous les
+   utilisateurs à accèder à leurs propres lignes dans une table
+   <literal>utilisateurs</literal>, une simple police peut être
+   utilisée:
+  </para>
+
+<programlisting>
+CREATE POLICY police_utilisateur ON utilisateurs
+    USING (utilisateur = current_user);
 </programlisting>
 
   <para>
-   If no role is specified, or the special user name
-   <literal>PUBLIC</literal> is used, then the policy applies to all
-   users on the system.  To allow all users to access their own row in
-   a <literal>users</literal> table, a simple policy can be used:
+   Pour utiliser une police différente pour les lignes ajoutées à
+   la table de celle appliquées pour les lignes visibles, la clause
+   <literal>WITH CHECK</literal> peut être utilisée. Cette police
+   autorisera tous les utilisateurs à voir toutes les lignes de la
+   table <literal>utilisateurs</literal>, mais seulement à modifier
+   les leurs:
   </para>
 
 <programlisting>
-CREATE POLICY user_policy ON users
-    USING (user = current_user);
-</programlisting>
-
-  <para>
-   To use a different policy for rows that are being added to the table
-   compared to those rows that are visible, the <literal>WITH CHECK</literal>
-   clause can be used.  This policy would allow all users to view all rows
-   in the <literal>users</literal> table, but only modify their own:
-  </para>
-
-<programlisting>
-CREATE POLICY user_policy ON users
+CREATE POLICY police_utilisateur ON utilisateurs
     USING (true)
-    WITH CHECK (user = current_user);
+    WITH CHECK (utilisateur = current_user);
 </programlisting>
 
   <para>
-   Row security can also be disabled with the <command>ALTER TABLE</command>
-   command.  Disabling row security does not remove any policies that are
-   defined on the table; they are simply ignored.  Then all rows in the
-   table are visible and modifiable, subject to the standard SQL privileges
-   system.
+   La sécurité niveau ligne peut également être désactivée avec
+   la commande <command>ALTER TABLE</command>. La désactivation de la
+   sécurité niveau ligne ne supprime pas les polices qui sont définies
+   pour la table; elles sont simplement ignorées. L'ensemble des lignes
+   sont alors visibles et modifiables, selon le sysème standard des
+   privilèges SQL.
   </para>
 
   <para>
-   Below is a larger example of how this feature can be used in production
-   environments.  The table <literal>passwd</literal> emulates a Unix password
-   file:
+   Ci-dessous est un exemple plus conséquent de la manière dont
+   cette fonctionnalité peut être utilisée en production. La table
+   <literal>passwd</literal> simule le fichier des mots de passe d'un
+   système Unix.
   </para>
 
 <programlisting>
--- Simple passwd-file based example
+-- Simple exemple basée sur le fichier passwd
 CREATE TABLE passwd (
   username              text UNIQUE NOT NULL,
   pwhash                text,
@@ -1641,11 +1665,11 @@ CREATE TABLE passwd (
   shell                 text NOT NULL
 );
 
-CREATE ROLE admin;  -- Administrator
-CREATE ROLE bob;    -- Normal user
-CREATE ROLE alice;  -- Normal user
+CREATE ROLE admin;  -- Administrateur
+CREATE ROLE bob;    -- Utilisateur normal
+CREATE ROLE alice;  -- Utilisateur normal
 
--- Populate the table
+-- Chargement de la table
 INSERT INTO passwd VALUES
   ('admin','xxx',0,0,'Admin','111-222-3333',null,'/root','/bin/dash');
 INSERT INTO passwd VALUES
@@ -1653,16 +1677,16 @@ INSERT INTO passwd VALUES
 INSERT INTO passwd VALUES
   ('alice','xxx',2,1,'Alice','098-765-4321',null,'/home/alice','/bin/zsh');
 
--- Be sure to enable row level security on the table
+-- Assurez vous d'activer les row level security pour la table
 ALTER TABLE passwd ENABLE ROW LEVEL SECURITY;
 
--- Create policies
--- Administrator can see all rows and add any rows
+-- Créer les polices
+-- L'administrateur peut voir toutes les lignes et en ajouter comme il le souhaite
 CREATE POLICY admin_all ON passwd TO admin USING (true) WITH CHECK (true);
--- Normal users can view all rows
+-- Les utilisateurs normaux peuvent voir toutes les lignes
 CREATE POLICY all_view ON passwd FOR SELECT USING (true);
--- Normal users can update their own records, but
--- limit which shells a normal user is allowed to set
+-- Les utilisateurs normaux peuvent mettre à jour leurs propres lignes,
+-- tout en limitant les shells qu'ils peuvent choisir
 CREATE POLICY user_mod ON passwd FOR UPDATE
   USING (current_user = username)
   WITH CHECK (
@@ -1670,26 +1694,27 @@ CREATE POLICY user_mod ON passwd FOR UPDATE
     shell IN ('/bin/bash','/bin/sh','/bin/dash','/bin/zsh','/bin/tcsh')
   );
 
--- Allow admin all normal rights
+-- Donner à admin tous les droits normaux
 GRANT SELECT, INSERT, UPDATE, DELETE ON passwd TO admin;
--- Users only get select access on public columns
+-- Les utilisateurs ne peuvent uniquement que sélectionner des colonnes publiques
 GRANT SELECT
   (username, uid, gid, real_name, home_phone, extra_info, home_dir, shell)
   ON passwd TO public;
--- Allow users to update certain columns
+-- Autoriser les utilisateurs à mettre à jour certaines colonnes
 GRANT UPDATE
   (pwhash, real_name, home_phone, extra_info, shell)
   ON passwd TO public;
 </programlisting>
 
   <para>
-   As with any security settings, it's important to test and ensure that
-   the system is behaving as expected.  Using the example above, this
-   demonstrates that the permission system is working properly.
+   Comme avec tous les réglages de sécurité, il est important de
+   tester et de s'assurer que le système se comporte comme attendu. En
+   utilisant l'exemple ci-dessus, les manipulations ci-dessous montrent
+   que le système des permissions fonctionnent correctement
   </para>
 
 <programlisting>
--- admin can view all rows and fields
+-- admin peut voir toutes les lignes et les colonnes
 postgres=&gt; set role admin;
 SET
 postgres=&gt; table passwd;
@@ -1700,7 +1725,7 @@ postgres=&gt; table passwd;
  alice    | xxx    |   2 |   1 | Alice     | 098-765-4321 |            | /home/alice | /bin/zsh
 (3 rows)
 
--- Test what Alice is able to do
+-- Tester ce que Alice est capable de faire:
 postgres=&gt; set role alice;
 SET
 postgres=&gt; table passwd;
@@ -1715,7 +1740,7 @@ postgres=&gt; select username,real_name,home_phone,extra_info,home_dir,shell fro
 
 postgres=&gt; update passwd set username = 'joe';
 ERROR:  permission denied for relation passwd
--- Alice is allowed to change her own real_name, but no others
+-- Alice est autorisée à modifier son propre nom (real_name), mais pas celui des autres
 postgres=&gt; update passwd set real_name = 'Alice Doe';
 UPDATE 1
 postgres=&gt; update passwd set real_name = 'John Doe' where username = 'admin';
@@ -1726,148 +1751,166 @@ postgres=&gt; delete from passwd;
 ERROR:  permission denied for relation passwd
 postgres=&gt; insert into passwd (username) values ('xxx');
 ERROR:  permission denied for relation passwd
--- Alice can change her own password; RLS silently prevents updating other rows
+-- Alice peut modifier son propre mot de passe; RLS empêche silencieusement la mise à jour d'autres lignes
 postgres=&gt; update passwd set pwhash = 'abc';
 UPDATE 1
 </programlisting>
 
   <para>
-   Referential integrity checks, such as unique or primary key constraints
-   and foreign key references, always bypass row security to ensure that
-   data integrity is maintained.  Care must be taken when developing
-   schemas and row level policies to avoid <quote>covert channel</quote> leaks of
-   information through such referential integrity checks.
+   Les vérifications d'intégrité référentielle, tel que les
+   contraintes d'unicité ou de clefs primaires et les références
+   de clefs étrangères, passent toujours outre la sécurité niveau
+   ligne pour s'assurer que l'intégrité des données est maintenue. Une
+   attention particulière doit être prise lors de la mise en place des
+   schémas et des polices de sécurité de niveau ligne pour éviter le
+   <quote>covert channel</quote> dévoilant des informations à travers
+   de telles vérifications d'intégrité référentielle.
   </para>
 
   <para>
-   In some contexts it is important to be sure that row security is
-   not being applied.  For example, when taking a backup, it could be
-   disastrous if row security silently caused some rows to be omitted
-   from the backup.  In such a situation, you can set the
-   <xref linkend="guc-row-security"/> configuration parameter
-   to <literal>off</literal>.  This does not in itself bypass row security;
-   what it does is throw an error if any query's results would get filtered
-   by a policy.  The reason for the error can then be investigated and
-   fixed.
+   Dans certains contextes il est important d'être certain que la
+   sécurité niveau ligne n'est pas appliquée. Par exemple, lors d'une
+   sauvegarde, il peut être désastreux si la sécurité niveau ligne
+   a pour conséquence de soustraire silencieusement certaines lignes
+   de la sauvegarde. Dans une telle situation, vous pouvez positionner
+   le paramètre de configuration <xref linkend="guc-row-security"/>
+   à <literal>off</literal>. En lui même ce paramètre ne passe pas
+   outre la sécurité niveau ligne; ce qu'il fait c'est qu'il lève une
+   erreur si une des requêtes devait être filtrée par une police. La
+   raison de l'erreur peut alors être recherchée et résolue.
   </para>
 
   <para>
-   In the examples above, the policy expressions consider only the current
-   values in the row to be accessed or updated.  This is the simplest and
-   best-performing case; when possible, it's best to design row security
-   applications to work this way.  If it is necessary to consult other rows
-   or other tables to make a policy decision, that can be accomplished using
-   sub-<command>SELECT</command>s, or functions that contain <command>SELECT</command>s,
-   in the policy expressions.  Be aware however that such accesses can
-   create race conditions that could allow information leakage if care is
-   not taken.  As an example, consider the following table design:
+   Dans les exemple ci-dessus, les expressions attachées aux polices
+   considèrent uniquement les valeurs de la ligne courante accèdée
+   ou modifiée. C'est le plus simple et le plus performant des cas;
+   lorsque c'est possible, il est préférable de concevoir les
+   applications qui utilisent cette fonctionnalité de la sorte. Si
+   il est nécessaire de consulter d'autres lignes ou tables pour que
+   la police puisse prendre une décision, ceci peut être réalisé
+   en utilisant dans les expressions des polices des sous-requêtes
+   <command>SELECT</command>, ou des fonctions qui contiennent des
+   commandes <command>SELECT</command>. Cependant faites attention que
+   de tels accès peuvent créer des accès concurrents qui pourraient
+   permettre de dévoiler des informations si aucune précaution n'est
+   prise. À titre d'exemple, considérez la création de la table
+   suivante:
   </para>
 
 <programlisting>
--- definition of privilege groups
-CREATE TABLE groups (group_id int PRIMARY KEY,
-                     group_name text NOT NULL);
+-- définition des privilèges de groupes
+CREATE TABLE groupes (groupe_id int PRIMARY KEY,
+                     nom_groupe text NOT NULL);
 
-INSERT INTO groups VALUES
-  (1, 'low'),
-  (2, 'medium'),
-  (5, 'high');
+INSERT INTO groupes VALUES
+  (1, 'bas'),
+  (2, 'moyen'),
+  (5, 'haut');
 
-GRANT ALL ON groups TO alice;  -- alice is the administrator
-GRANT SELECT ON groups TO public;
+GRANT ALL ON groupes TO alice;  -- alice est l'administratrice
+GRANT SELECT ON groupes TO public;
 
--- definition of users' privilege levels
-CREATE TABLE users (user_name text PRIMARY KEY,
-                    group_id int NOT NULL REFERENCES groups);
+-- définition des niveaux de privilèges utilisateurs
+CREATE TABLE utilisateurs (nom_utilisateur text PRIMARY KEY,
+                    groupe_id int NOT NULL REFERENCES groupes);
 
-INSERT INTO users VALUES
+INSERT INTO utilisateurs VALUES
   ('alice', 5),
   ('bob', 2),
   ('mallory', 2);
 
-GRANT ALL ON users TO alice;
-GRANT SELECT ON users TO public;
+GRANT ALL ON utilisateurs TO alice;
+GRANT SELECT ON utilisateurs TO public;
 
--- table holding the information to be protected
+-- table contenant l'information à protéger
 CREATE TABLE information (info text,
-                          group_id int NOT NULL REFERENCES groups);
+                          groupe_id int NOT NULL REFERENCES groupes);
 
 INSERT INTO information VALUES
-  ('barely secret', 1),
-  ('slightly secret', 2),
-  ('very secret', 5);
+  ('peu secret', 1),
+  ('légèrement secret', 2),
+  ('très secret', 5);
 
 ALTER TABLE information ENABLE ROW LEVEL SECURITY;
 
--- a row should be visible to/updatable by users whose security group_id is
--- greater than or equal to the row's group_id
+-- une ligne devrait être visible et modifiable pour les utilisateurs dont le groupe_id est
+-- égal ou plus grand au groupe_id de la ligne
 CREATE POLICY fp_s ON information FOR SELECT
-  USING (group_id &lt;= (SELECT group_id FROM users WHERE user_name = current_user));
+  USING (groupe_id &lt;= (SELECT groupe_id FROM utilisateurs WHERE nom_utilisateur = current_user));
 CREATE POLICY fp_u ON information FOR UPDATE
-  USING (group_id &lt;= (SELECT group_id FROM users WHERE user_name = current_user));
+  USING (groupe_id &lt;= (SELECT groupe_id FROM utilisateurs WHERE nom_utilisateur = current_user));
 
--- we rely only on RLS to protect the information table
+-- nous comptons sur les RLS pour protéger la table information
 GRANT ALL ON information TO public;
 </programlisting>
 
   <para>
-   Now suppose that <literal>alice</literal> wishes to change the <quote>slightly
-   secret</quote> information, but decides that <literal>mallory</literal> should not
-   be trusted with the new content of that row, so she does:
+   Maintenant supposez qu'<literal>alice</literal> souhaite modifier
+   l'information <quote>légèrement secret</quote>, mais décide que
+   <literal>mallory</literal> ne devrait pas pouvoir obtenir ce nouveau
+   contenu, aussi elle fait:
   </para>
 
 <programlisting>
 BEGIN;
-UPDATE users SET group_id = 1 WHERE user_name = 'mallory';
-UPDATE information SET info = 'secret from mallory' WHERE group_id = 2;
+UPDATE utilisateurs SET groupe_id = 1 WHERE nom_utilisateur = 'mallory';
+UPDATE information SET info = 'caché à mallory' WHERE groupe_id = 2;
 COMMIT;
 </programlisting>
 
-  <para>
-   That looks safe; there is no window wherein <literal>mallory</literal> should be
-   able to see the <quote>secret from mallory</quote> string.  However, there is
-   a race condition here.  If <literal>mallory</literal> is concurrently doing,
-   say,
+<para>
+   Ceci semble correct, il n'y a pas de fenêtre pendant laquelle
+   <literal>mallory</literal> devrait pouvoir accèder à la chaîne
+   <quote>caché à mallory</quote>. Cependant il y a une situation de
+   compétition ici. Si <literal>mallory</literal> fait en parallèle,
+   disons,
 <programlisting>
-SELECT * FROM information WHERE group_id = 2 FOR UPDATE;
+SELECT * FROM information WHERE groupe_id = 2 FOR UPDATE;
 </programlisting>
-   and her transaction is in <literal>READ COMMITTED</literal> mode, it is possible
-   for her to see <quote>secret from mallory</quote>.  That happens if her
-   transaction reaches the <structname>information</structname> row just
-   after <literal>alice</literal>'s does.  It blocks waiting
-   for <literal>alice</literal>'s transaction to commit, then fetches the updated
-   row contents thanks to the <literal>FOR UPDATE</literal> clause.  However, it
-   does <emphasis>not</emphasis> fetch an updated row for the
-   implicit <command>SELECT</command> from <structname>users</structname>, because that
-   sub-<command>SELECT</command> did not have <literal>FOR UPDATE</literal>; instead
-   the <structname>users</structname> row is read with the snapshot taken at the start
-   of the query.  Therefore, the policy expression tests the old value
-   of <literal>mallory</literal>'s privilege level and allows her to see the
-   updated row.
+   et sa transaction est en mode <literal>READ COMMITED</literal>, il est
+   possible qu'elle voit <quote>caché à mallory</quote>. Cela est possible
+   si sa transaction accède la ligne <structname>information</structname>
+   juste après qu'<literal>alice</literal> l'ai fait. Elle est
+   bloquée en attendant que la transaction d'<literal>alice</literal>
+   valide, puis récupère la ligne mise à jour grâce à la clause
+   <literal>FOR UPDATE</literal>. Cependant, elle ne récupère
+   <emphasis>pas</emphasis> une ligne mise à jour pour la commande
+   implicite <command>SELECT</command> sur la table utilisateurs, parce
+   que cette sous-commande n'a pas la clause <literal>FOR UPDATE</literal>;
+   à la place la ligne <structname>utilisateurs</structname> est lue avec
+   une image de la base de données prise au début de la requête. Aussi
+   l'expression de la police teste l'ancienne valeur du niveau de privilège
+   de <literal>mallory</literal> et l'autorise à voir la valeur mise
+   à jour.
   </para>
 
   <para>
-   There are several ways around this problem.  One simple answer is to use
-   <literal>SELECT ... FOR SHARE</literal> in sub-<command>SELECT</command> in row
-   security policies.  However, that requires granting <literal>UPDATE</literal>
-   privilege on the referenced table (here <structname>users</structname>) to the
-   affected users, which might be undesirable.  (But another row security
-   policy could be applied to prevent them from actually exercising that
-   privilege; or the sub-<command>SELECT</command> could be embedded into a security
-   definer function.)  Also, heavy concurrent use of row share locks on the
-   referenced table could pose a performance problem, especially if updates
-   of it are frequent.  Another solution, practical if updates of the
-   referenced table are infrequent, is to take an exclusive lock on the
-   referenced table when updating it, so that no concurrent transactions
-   could be examining old row values.  Or one could just wait for all
-   concurrent transactions to end after committing an update of the
-   referenced table and before making changes that rely on the new security
-   situation.
+   Il y'a plusieurs solutions à ce problème. Une simple réponse
+   est d'utiliser <literal>SELECT ... FOR SHARE</literal> dans
+   la sous-commande <command>SELECT</command> de la police de
+   sécurité niveau ligne. Cependant ceci demande à donner le
+   privilège <literal>UPDATE</literal> sur la table référencée (ici
+   <structname>utilisateurs</strucname>) aux utilisateurs concernés, ce
+   qui peut ne pas être souhaité. (Mais une autre police de sécurité
+   niveau ligne pourrait être mise en place pour les empêcher d'exercer ce
+   privilège; ou la sous-commande <command>SELECT</command> pourrait
+   être incluse dans une fonction « security definer »). Aussi,
+   l'utilisation intensive concurrente de verrous paratagés sur les
+   lignes de la table référencée pourrait poser un problème de
+   performance, spécialement si des mises à jour de cette table sont
+   fréquentes. Une autre solution envisageable si les mises à jour de
+   la table référencée ne sont pas fréquentes, est de prendre un
+   verrou exclusif sur la table référencée lors des mises à jour,
+   de telle manière qu'aucune autre transaction concurrente ne pourrait
+   consulter d'anciennes valeurs. Ou une transaction pourrait attendre que
+   toutes les transactions se terminent après avoir validées une mise
+   à jour de la table référencée et avant de faire des modifications
+   qui reposent sur la nouvelle police de sécurité.
   </para>
 
   <para>
-   For additional details see <xref linkend="sql-createpolicy"/>
-   and <xref linkend="sql-altertable"/>.
+   Pour plus de détails voir <xref linkend="sql-createpolicy" /> 
+   et <xref linkend="sql-altertable"/>.
   </para>
 
  </sect1>
@@ -2464,13 +2507,14 @@ WHERE v.altitude &gt; 500 AND v.tableoid = p.oid;</programlisting>
   </para>
 
   <para>
-   Another way to get the same effect is to use the <type>regclass</type>
-   pseudo-type, which will print the table OID symbolically:
+   Une autre manière d'obtenir le même effet est d'utiliser le
+   pseudo-type <type>regclass</type> qui affichera l'OID de la table de
+   façon symbolique:
 
 <programlisting>
-SELECT c.tableoid::regclass, c.name, c.altitude
-FROM cities c
-WHERE c.altitude &gt; 500;
+SELECT v.tableoid::regclass, v.nom, v.altitude
+FROM villes v
+WHERE v.altitude &gt; 500;
 </programlisting>
   </para>
 
@@ -2575,11 +2619,13 @@ VALUES ('Albany', NULL, NULL, 'NY');</programlisting>
   </para>
 
   <para>
-   Foreign tables (see <xref linkend="ddl-foreign-data"/>) can also
-   be part of inheritance hierarchies, either as parent or child
-   tables, just as regular tables can be.  If a foreign table is part
-   of an inheritance hierarchy then any operations not supported by
-   the foreign table are not supported on the whole hierarchy either.
+   Les table étrangères (voir <xref linkend="ddl-foreign-data"/>
+   peuvent aussi participer aux hiérarchies d'héritage, soit comme
+   table parente soit comme table enfant, comme les tables régulières
+   peuvent l'être. Si une table étrangère fait partie d'une hiérarchie
+   d'héritage toutes les opérations non supportées par la table
+   étrangère ne sont pas non plus supportées sur l'ensemble de la
+   hiérarchie.
   </para>
 
  <sect2 id="ddl-inherit-caveats">
@@ -3333,10 +3379,12 @@ ANALYZE mesure;
 
    <listitem>
     <para>
-     <command>INSERT</command> statements with <literal>ON CONFLICT</literal>
-     clauses are unlikely to work as expected, as the <literal>ON CONFLICT</literal>
-     action is only taken in case of unique violations on the specified
-     target relation, not its child relations.
+     Les commandes <command>INSERT</command> avec des clauses
+     <literal>ON CONFLICT</literal> ont probablement peu de chances
+     de fonctionner comme attendu, dans la mesure où l'action du
+     <literal>ON CONFLICT</literal> est uniquement effectuée dans le
+     cas de viloations qui sont uniques à la table cible, pas à ses
+     tables enfants.
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
Bonjour Guillaume,

ci-joint la proposition de traduction pour ddl.xml

La "grosse" partie concernant les row level securities m'a posé quelques soucis relativement à la traduction ou pas du terme. Je suis parti dans l'idée de respecter le choix fait sur https://framadate.org/fvyGOEo2A8E5axCT (c'est à dire pas de traduction). Mais en avançant je me suis aperçu qu'il y'a plein de termes dérivés et que de tenir cette position me semblait difficile/pas correct. C'est pourquoi sur ces termes dérivés j'ai souvent traduit en me basant sur l'expression "sécurité niveau ligne". Tu en fais ce que tu en veux, n'hésites pas à modifier.

   --
Éric