### PR TITLE
Trad "Enum" et cohérence de l'exemple

### DIFF
--- a/postgresql/datatype.xml
+++ b/postgresql/datatype.xml
@@ -3103,11 +3103,11 @@ SELECT * FROM personne WHERE humeur_actuelle = 'heureux';
 
     <programlisting>
 INSERT INTO personne VALUES ('Larry', 'triste');
-INSERT INTO personne VALUES ('Curly', 'heureux');
+INSERT INTO personne VALUES ('Curly', 'ok');
 SELECT * FROM personne WHERE humeur_actuelle > 'triste';
  nom   | humeur_actuelle
 -------+-----------------
- Moe   | happy
+ Moe   | heureux
  Curly | ok
 (2 rows)
 
@@ -3115,7 +3115,7 @@ SELECT * FROM personne WHERE humeur_actuelle > 'triste' ORDER BY humeur_actuelle
  nom   | humeur_actuelle
 -------+--------------
  Curly | ok
- Moe   | happy
+ Moe   | heureux
 (2 rows)
 
 SELECT nom


### PR DESCRIPTION
Trad "Enum" et cohérence de l'exemple (présent sur les versions 8.X et 9.X).