### PR TITLE
COALESCE - Cohérence avec l'exemple

### DIFF
--- a/postgresql/func.xml
+++ b/postgresql/func.xml
@@ -12162,7 +12162,7 @@ END</synopsis>
    affichage. Par exemple&nbsp;:
 <programlisting>SELECT COALESCE(description, description_courte, '(aucune)') ...</programlisting>
    Cela renvoie <varname>description</varname> si sa valeur est non NULL. Sinon
-   <varname>short_description</varname> s'il est lui-même non NULL, et enfin <literal>(none)</literal>.
+   <varname>description_courte</varname> s'il est lui-même non NULL, et enfin <literal>(aucune)</literal>.
   </para>
 
    <para>


### PR DESCRIPTION
COALESCE - Cohérence avec l'exemple (présent depuis la documentation 9.2)