### PR TITLE
fix a small typo in GRANT

### DIFF
--- a/postgresql/ref/grant.xml
+++ b/postgresql/ref/grant.xml
@@ -362,7 +362,7 @@ GRANT <replaceable class="PARAMETER">nom_rôle</replaceable> [, ...] TO <replace
         <quote>usage</quote> général du type, comme les valeurs du type
         apparaissant dans les requêtes. Il empêche seulement les objets
         d'être créés s'ils dépendent de ce type. Le but principal de ce
-        droit est de contrôler lrs utilisateurs pouvant créer des dépendances
+        droit est de contrôler les utilisateurs pouvant créer des dépendances
         sur un type, ce qui peut empêcher le propriétaire de changer le type
         après coup.)
        </para>


### PR DESCRIPTION
Fix a small type 'lrs' -> 'les' in GRANT