### PR TITLE
Revue indexam.xml

### DIFF
--- a/postgresql/indexam.xml
+++ b/postgresql/indexam.xml
@@ -17,7 +17,7 @@
  </para>
 
  <para>
-  Tous les index de <productname>PostgreSQL</productname> sont 
+  Tous les index de <productname>PostgreSQL</productname> sont
   techniquement des <firstterm>index secondaires</firstterm>&nbsp;; c'est-à-dire
   que l'index est séparé physiquement du fichier de la table qu'il décrit. Chaque index
   est stocké dans sa propre <firstterm>relation</firstterm> physique et est donc décrit
@@ -41,7 +41,7 @@
   récupérer une version d'une ligne particulière à partir de la table. Les index
   n'ont pas directement connaissance de l'existence éventuelle, à cause du MVCC,
   de plusieurs versions de la même ligne logique&nbsp;; pour un index, chaque ligne
-  est un objet indépendant qui a besoin de sa propre entrée. En conséquence, 
+  est un objet indépendant qui a besoin de sa propre entrée. En conséquence,
   la mise à jour d'une ligne crée toujours de nouvelles entrées
   dans l'index pour cette ligne, même si les valeurs de la clé ne changent pas.
   (Les lignes HOT sont une exception&nbsp;; mais les index ne s'en occupent pas).
@@ -55,8 +55,8 @@
   <para>
    Chaque méthode d'accès à un index est décrite par une ligne dans le
    catalogue système <link
-   linkend="catalog-pg-am"><structname>pg_am</structname></link>.Elle 
-   indique un nom et une <firstterm>fonction gestionnaire</firstterm> 
+   linkend="catalog-pg-am"><structname>pg_am</structname></link>.Elle
+   indique un nom et une <firstterm>fonction gestionnaire</firstterm>
    pour la méthode d'accès. Ces entrées peuvent être
    créées et supprimées en utilisant les commandes SQL <xref
    linkend="sql-create-access-method"/> et <xref
@@ -65,7 +65,7 @@
 
   <para>
    Une fonction gestionnaire de méthode d'accès aux index doit être déclarée
-   avec un seul argument de type <type>internal</type> et en retour 
+   avec un seul argument de type <type>internal</type> et en retour
    le pseudo-type <type>index_am_handler</type>. L'argument est une
    valeur sans utilité sinon pour empêcher les fonctions
    gestionnaires d'être appelées directement à partir d'une commande SQL. Le
@@ -75,10 +75,10 @@
    structure <structname>IndexAmRoutine</structname>, aussi appelée
    <firstterm>API struct</firstterm> de la méthode, inclut les champs spécifiant
    les propriétés fixes de la méthode d'accès, comme le support
-   des index multi-colonnes. Plus important, elle contient les pointeurs vers 
-   les fonctions de la méthode d'accès, qui se chargent de tout le travail 
+   des index multi-colonnes. Plus important, elle contient les pointeurs vers
+   les fonctions de la méthode d'accès, qui se chargent de tout le travail
    d'accès aux index. Ces fonctions de support sont de simples fonctions
-   en C et ne sont ni visibles ni appelables au niveau SQL. Elles sont 
+   en C et ne sont ni visibles ni appelables au niveau SQL. Elles sont
    décrites dans <xref linkend="index-functions"/>.
   </para>
 
@@ -90,8 +90,8 @@ typedef struct IndexAmRoutine
     NodeTag     type;
 
     /*
-     * Nombre total de stratégies (opérateurs) par lequels nous pouvons 
-     * traverser la méthode d'accès oy chercher dedans. Zéro si la méthode 
+     * Nombre total de stratégies (opérateurs) par lequels nous pouvons
+     * traverser la méthode d'accès oy chercher dedans. Zéro si la méthode
      * n'a pas de jeu de stratégies fixé.
      */
     uint16      amstrategies;
@@ -152,7 +152,7 @@ typedef struct IndexAmRoutine
    <link linkend="catalog-pg-opclass"><structname>pg_opclass</structname></link>,
    <link linkend="catalog-pg-amop"><structname>pg_amop</structname></link> et
    <link linkend="catalog-pg-amproc"><structname>pg_amproc</structname></link>.
-   Ces entrées permettent au planificateur de déterminer les types 
+   Ces entrées permettent au planificateur de déterminer les types
    de requêtes qui peuvent être utilisés avec les index de cette méthode d'accès.
    Les familles et classes d'opérateurs sont décrites dans <xref
    linkend="xindex"/>, qui est un élément requis pour comprendre ce chapitre.
@@ -167,11 +167,12 @@ typedef struct IndexAmRoutine
    et leur sémantique, telles que
    récupérées par les classes d'opérateurs associées. Les colonnes de
    l'index (valeurs clés) peuvent être de simples colonnes de la table
-   sous-jacente ou des expressions des lignes de la table. Habituellement,
+   sous-jacente ou des expressions des lignes. Habituellement,
    la méthode d'accès ne s'intéresse pas à la provenance
    des valeurs clés (elles lui arrivent toujours
-   pré-calculées), mais bien aux informations de la classe
-   d'opérateurs dans <structname>pg_index</structname>. On peut accéder aux entrées de ces deux
+   pré-calculées), mais plutôt aux informations de la classe
+   d'opérateurs dans <structname>pg_index</structname>.
+   On peut accéder aux entrées de ces deux
    catalogues via la structure de données
    <structname>Relation</structname> passée à toute opération sur l'index.
   </para>
@@ -182,7 +183,7 @@ typedef struct IndexAmRoutine
    sont discutés dans <xref linkend="index-unique-checks"/>.
    L'option <structfield>amcanmulticol</structfield> indique que la méthode
    d'accès supporte les index multi-colonnes alors que
-   <structfield>amoptionalkey</structfield> autorise des parcours 
+   <structfield>amoptionalkey</structfield> autorise des parcours
    lorsqu'aucune restriction indexable n'est fournie pour la première colonne
    de l'index. Quand <structfield>amcanmulticol</structfield> est faux,
    <structfield>amoptionalkey</structfield> indique essentiellement que la méthode
@@ -191,7 +192,7 @@ typedef struct IndexAmRoutine
    <emphasis>doivent</emphasis> supporter les parcours sans
    restriction sur une ou toutes les colonnes après la première&nbsp;;
    néanmoins, elles peuvent imposer une restriction sur la
-   première colonne de l'index, ce qui est signalé par 
+   première colonne de l'index, ce qui est signalé par
    <structfield>amoptionalkey</structfield> à false .
    Une raison pour une méthode d'accès d'index d'initialiser
    <structfield>amoptionalkey</structfield> à false est de ne pas indexer
@@ -199,14 +200,14 @@ typedef struct IndexAmRoutine
    sont stricts et ne peuvent donc pas renvoyer true pour des entrées NULL,
    à première vue on ne voudra pas stocker d'entrées pour les
    valeurs NULL&nbsp;: un parcours d'index ne peut de toute façon pas les
-   retourner. Néanmoins, cet argument tombe lorsqu'un parcours d'index
-   n'a pas de restriction pour une colonne d'index donnée. En pratique,
+   retourner. Néanmoins, cette raison ne vaut pas pour un parcours d'index
+   sans restriction pour une colonne d'index donnée. En pratique,
    cela signifie que les index avec <structfield>amoptionalkey</structfield> à
    true doivent indexer les valeurs NULL, car le planificateur peut décider
-   de les utiliser sans aucune clé de parcours. Une limite 
+   de les utiliser sans aucune clé de parcours. Une limite
    liée&nbsp;: une méthode d'accès qui supporte des colonnes
-   multiples <emphasis>doit</emphasis> supporter l'indexation des NULL dans les colonnes
-   après la première, car le planificateur supposera l'index 
+   multiples <emphasis>doit</emphasis> supporter l'indexation des NULL dans
+   les colonnes après la première, car le planificateur supposera l'index
    utilisable avec les requêtes ne restreignant pas ces colonnes. Par exemple,
    considérons un index sur (a,b) et une requête avec <literal>WHERE a =
     4</literal>. Le système supposera que l'index est utilisable pour
@@ -214,10 +215,10 @@ typedef struct IndexAmRoutine
    faux si l'index omet les lignes où <literal>b</literal> est NULL.
    Néanmoins, on peut omettre les lignes où la
    première colonne indexée est NULL. Du coup, une méthode d'accès d'index
-   ne s'occupant pas des valeurs NULL peut aussi affecter 
-   <structfield>amsearchnulls</structfield> à true, indiquant ainsi qu'elle supporte
-   les clauses <literal>IS NULL</literal> et <literal>IS NOT NULL</literal> dans
-   les conditions de recherche.
+   ne s'occupant pas des valeurs NULL peut aussi affecter
+   <structfield>amsearchnulls</structfield> à true, indiquant ainsi qu'elle
+   supporte les clauses <literal>IS NULL</literal> et
+   <literal>IS NOT NULL</literal> dans les conditions de recherche.
   </para>
 
  </sect1>
@@ -238,13 +239,13 @@ ambuild (Relation heapRelation,
          IndexInfo *indexInfo);
    </programlisting>
    Construit un nouvel index. La relation de l'index a été créée physiquement
-   mais elle est vide. Elle doit être remplie avec toute donnée fixe nécessaire
+   mais elle est vide. Elle doit être remplie avec toute donnée figée nécessaire
    à la méthode d'accès, ainsi que les entrées pour toutes les lignes existant
-   déjà dans la table. Habituellement, la fonction <function>ambuild</function> appelle
-   <function>IndexBuildHeapScan()</function> pour parcourir la table à la
-   recherche des lignes qui existent déjà et calculer les clés à insérer dans
-   l'index. La fonction doit renvoyer une structure allouée par palloc contenant
-   les statistiques du nouvel index.
+   déjà dans la table. Habituellement, la fonction <function>ambuild</function>
+   appelle  <function>IndexBuildHeapScan()</function> pour parcourir la table
+   à la recherche des lignes existantes et calculer les clés à insérer
+   dans l'index. La fonction doit renvoyer une structure allouée par palloc
+   contenant les statistiques du nouvel index.
   </para>
 
   <para>
@@ -253,9 +254,9 @@ void
 ambuildempty (Relation indexRelation);
    </programlisting>
    Construit un index vide et l'écrit dans le fichier d'initialisation
-   (<symbol>INIT_FORKNUM</symbol>) de la relation. Cette méthode n'est appelée que pour les
-   index non journalisés. L'index vide écrit dans ce fichier
-   remplacera le fichier de la relation à chaque redémarrage du serveur.
+   (<symbol>INIT_FORKNUM</symbol>) de la relation. Cette méthode n'est appelée
+   que pour les index non journalisés&nbsp;; l'index vide écrit dans ce fichier
+   écrasera le fichier de la relation à chaque redémarrage du serveur.
   </para>
 
   <para>
@@ -269,26 +270,25 @@ aminsert (Relation indexRelation,
    </programlisting>
    Insère une nouvelle ligne dans un index existant. Les tableaux
    <literal>values</literal> et <literal>isnull</literal> donnent les valeurs
-   de clés à indexer et
-   <literal>heap_tid</literal> est le TID à indexer. Si la méthode d'accès supporte les
+   de clés à indexer et  <literal>heap_tid</literal> est le TID à indexer.
+   Si la méthode d'accès supporte les
    index uniques (son drapeau <structfield>amcanunique</structfield>
    vaut true), alors <literal>checkUnique</literal> indique le type de
    vérification d'unicité nécessaire. Elle varie si la contrainte unique est
    déferrable ou non&nbsp;; voir <xref linkend="index-unique-checks"/> pour
    les détails. Normalement, la méthode d'accès a seulement besoin du
    paramètre <literal>heapRelation</literal> lors de la vérification
-   d'unicité (car elle doit vérifier la
-   visibilité de la ligne dans la table).
+   d'unicité (car elle doit vérifier la visibilité de la ligne dans la table).
   </para>
 
   <para>
    La valeur booléenne résultante n'a de sens
    que si <literal>checkUnique</literal> vaut
-   <literal>UNIQUE_CHECK_PARTIAL</literal>. Dans ce cas, un résultat TRUE
-   signifie que la nouvelle entrée est reconnue comme unique alors que FALSE
+   <literal>UNIQUE_CHECK_PARTIAL</literal>. Dans ce cas, un résultat true
+   signifie que la nouvelle entrée est reconnue comme unique alors que false
    indique qu'elle pourrait ne pas être unique (et une vérification d'unicité
-   déferrée doit être planifiée). Dans les autres cas, renvoyer une constante FALSE
-   est recommendé.
+   déferrée doit être planifiée). Dans les autres cas, renvoyer une constante
+   false est recommandé.
   </para>
 
   <para>
@@ -307,26 +307,27 @@ ambulkdelete (IndexVacuumInfo *info,
    Supprime un ou des tuple(s) de l'index. Il s'agit d'une opération de
    <quote>suppression en masse</quote> à implémenter par un parcours complet de
    l'index et la vérification de chaque entrée pour voir si elle
-   doit être supprimée. La fonction <literal>callback</literal> en argument doit être
-   appelée, sous la forme <literal>callback(<replaceable>TID</replaceable>, callback_state)
+   doit être supprimée. La fonction <literal>callback</literal> en argument
+   doit être appelée, sous la forme
+   <literal>callback(<replaceable>TID</replaceable>, callback_state)
    returns bool</literal>, pour déterminer si une entrée d'index particulière,
    identifiée par son TID, doit être supprimée. Elle doit retourner NULL
    ou une structure issue d'un palloc contenant des statistiques sur les
    effets de la suppression.
-   La fonction peut renvoyer NULL si aucune information ne doit être envoyée à
-   <function>amvacuumcleanup</function>.
+   La fonction peut renvoyer NULL si aucune information n'a besoin d'être
+   envoyée à <function>amvacuumcleanup</function>.
   </para>
 
   <para>
    À cause d'un <varname>maintenance_work_mem</varname> limité, la
-   suppression de nombreux tuples impose d'appeler
+   suppression de nombreux tuples peut nécessiter d'appeler
    <function>ambulkdelete</function> à plusieurs reprises.
-   L'argument <literal>stats</literal> est le résultat du dernier appel pour cet index
-   (il est NULL au premier appel dans une opération
-   <command>VACUUM</command>). Ceci permet à la méthode d'accumuler des statistiques
-   sur toute l'opération. Typiquement, <function>ambulkdelete</function>
-   modifie et renvoie la même structure si le <literal>stats</literal> fourni
-   n'est pas NULL.
+   L'argument <literal>stats</literal> est le résultat du dernier appel pour
+   cet index  (il est NULL au premier appel dans une opération
+   <command>VACUUM</command>). Ceci permet à la méthode d'accumuler des
+   statistiques sur toute l'opération. Typiquement,
+   <function>ambulkdelete</function>  modifie et renvoie la même structure
+   si le <literal>stats</literal> fourni n'est pas NULL.
   </para>
 
   <para>
@@ -338,14 +339,15 @@ amvacuumcleanup (IndexVacuumInfo *info,
    appels à <function>ambulkdelete</function>). La fonction n'a pas d'autre but
    que de retourner des statistiques sur les index, mais elle peut réaliser
    un nettoyage en masse (réclamer les pages d'index vides, par exemple).
-   <literal>stats</literal> est le retour de l'appel à <function>ambulkdelete</function>,
-   ou NULL si
-   <function>ambulkdelete</function> n'a pas été appelée car aucune ligne n'avait
-   besoin d'être supprimée. Si le résultat n'est pas NULL, il s'agit d'une structure
-   allouée par palloc. Les statistiques qu'elle contient seront utilisées pour
-   mettre à jour <structname>pg_class</structname>, et sont rapportées par
-   <command>VACUUM</command> si <literal>VERBOSE</literal> est indiqué. La
-   fonction peut retourner NULL si l'index n'a pas été modifié lors de l'opération
+   <literal>stats</literal> est le retour de l'appel à
+   <function>ambulkdelete</function>,  ou NULL si
+   <function>ambulkdelete</function> n'a pas été appelée car aucune ligne
+   n'avait  besoin d'être supprimée. Si le résultat n'est pas NULL, il s'agit
+   d'une structure  allouée par palloc. Les statistiques qu'elle contient
+   seront utilisées pour  mettre à jour <structname>pg_class</structname>,
+   et sont rapportées par  <command>VACUUM</command> si
+   <literal>VERBOSE</literal> est indiqué. La  onction peut retourner NULL
+   si l'index n'a pas été modifié lors de l'opération
    de <command>VACUUM</command> mais, dans le cas contraire, il faut retourner
    des statistiques correctes.
   </para>
@@ -358,7 +360,7 @@ amvacuumcleanup (IndexVacuumInfo *info,
    ignorée. Ce cas peut être repéré en vérifiant
    <literal>info-&gt;analyze_only</literal>. Il est recommandé que la méthode
    d'accès ne fasse rien en dehors du nettoyage après insertion pour ce type
-   d'appel, et cela seulement dans un processus de travail autovacuum.
+   d'appel, et cela seulement au sein d'un processus autovacuum.
   </para>
 
   <para>
@@ -371,9 +373,9 @@ amcanreturn (Relation indexRelation, int attno);
    seul</firstterm></link> sur la colonne indiquée, en renvoyant les valeurs
    des colonnes pour un enregistrement d'index sous forme d'un
    <structname>IndexTuple</structname>. Les numéros des attributs commencent
-   à 1 (c'est-à-dire que la valeur de attno pour la première colonne est 1). Renvoie TRUE si
-   c'est supporté, sinon FALSE. Si la méthode d'accès ne supporte pas du
-   tout les parcours d'index seul, le champ
+   à 1 (c'est-à-dire que la valeur de attno pour la première colonne est 1).
+   Renvoie true si c'est supporté, sinon false. Si la méthode d'accès ne
+   supporte pas du tout les parcours d'index seul, le champ
    <structfield>amcanreturn</structfield> de la structure
    <structname>IndexAmRoutine</structname> peut être mis à NULL.
   </para>
@@ -389,8 +391,8 @@ amcostestimate (PlannerInfo *root,
                 Selectivity *indexSelectivity,
                 double *indexCorrelation);
    </programlisting>
-   Estime les coûts d'un parcours d'index. Cette fonction est décrite complètement
-   dans <xref linkend="index-cost-estimation"/>, ci-dessous.
+   Estime les coûts d'un parcours d'index. Cette fonction est décrite
+   complètement dans <xref linkend="index-cost-estimation"/> ci-dessous.
   </para>
 
   <para>
@@ -416,7 +418,7 @@ amoptions (ArrayType *reloptions,
    (<parameter>validate</parameter> est faux lors du chargement d'options déjà
    stockées dans <structname>pg_catalog</structname>&nbsp;; une entrée invalide
    ne peut se trouver que si la méthode d'accès a modifié ses règles pour
-   les options et, dans ce cas, ignorer les entrées obsolètes est approprié.)
+   les options et, dans ce cas, il faut ignorer les entrées obsolètes.)
    Pour obtenir le comportement par défaut, il suffit de retourner NULL.
   </para>
 
@@ -445,35 +447,35 @@ amproperty (Oid index_oid, int attno,
    <function>pg_index_column_has_property</function>.
    <parameter>prop</parameter> est une valeur enum identifiant la propriété
    testée, alors que <parameter>propname</parameter> est le nom de la
-   propriété originale. Si le code du c&oelig;ur ne reconnaît pas le nom de la
+   propriété originale. Si le code principal ne reconnaît pas le nom de la
    propriété, alors <parameter>prop</parameter> vaut
    <literal>AMPROP_UNKNOWN</literal>. Les méthodes d'accès peuvent définir les
-   noms des propriétés personnalisées en vérifiant la correspondance avec
+   noms de propriétés personnalisées en cherchant une correspondance avec
    <parameter>propname</parameter> (utilisez
-   <function>pg_strcasecmp</function> pour la correspondance, par cohérence
-   avec le code du c&oelig;ur)&nbsp;; pour les noms connus du code du
-   c&oelig;ur, il est préférable d'inspecter <parameter>prop</parameter>. Si
+   <function>pg_strcasecmp</function> pour être cohérent
+   avec le code principal)&nbsp;; pour les noms connus du code principal,
+   il est préférable d'inspecter <parameter>prop</parameter>. Si
    la méthode <structfield>amproperty</structfield> renvoit
-   <literal>true</literal>, alors il a déterminé le résultat du test de
-   propriété&nbsp;: il doit configurer <literal>*res</literal> à la valeur
-   booléenne à renvoyer ou configurer <literal>*isnull</literal> à
+   <literal>true</literal>, alors elle a passé le test de
+   propriété&nbsp;: elle doit renvoyer le booléen <literal>*res</literal>
+   ou mettre <literal>*isnull</literal> à
    <literal>true</literal> pour renvoyer un NULL. (Les deux variables
    référencées sont initialisées à <literal>false</literal> avant l'appel.) Si
    la méthode <structfield>amproperty</structfield> renvoit
-   <literal>false</literal>, alors le code du c&oelig;ur procédera avec sa
-   logique habituelle pour déterminer le résultat du test de propriété.
+   <literal>false</literal>, alors le code principal continuera avec sa
+   logique habituelle pour tester la propriété.
   </para>
 
   <para>
    Les méthodes d'accès supportant les opérateurs de tri devraient implémenter
-   le test de la propriété <literal>AMPROP_DISTANCE_ORDERABLE</literal> car le
-   code du c&oelig;ur ne sait pas le faire et renverra NULL. Il pourrait aussi
-   être avantageux d'implémenter le test de
+   le test de <literal>AMPROP_DISTANCE_ORDERABLE</literal> car le
+   code principal ne sait pas le faire et renverra NULL. Il pourrait aussi
+   être avantageux d'implémenter un test sur
    <literal>AMPROP_RETURNABLE</literal> si cela peut être fait de façon plus
    simple que d'ouvrir l'index et d'appeler
-   <structfield>amcanreturn</structfield>, ce qui est le comportement par
-   défaut du code du c&oelig;ur. Les autres propriétés doivent avoir un
-   comportement par défaut satisfaisant.
+   <structfield>amcanreturn</structfield>, comme le fait
+   le code principal. Le comportement par défaut devrait être
+   satisfaisant pour toutes les autres propriétés standard.
   </para>
 
   <para>
@@ -481,20 +483,20 @@ amproperty (Oid index_oid, int attno,
 bool
 amvalidate (Oid opclassoid);
 </programlisting>
-   Valide les entrées du catalogue pour la classe d'opérateur spécifiée, à
+   Valide les entrées du catalogue pour la classe d'opérateur indiquée, à
    condition que la méthode d'accès puisse le faire raisonnablement. Par
    exemple, ceci pourrait inclure le test de la présence de toutes les
-   fonctions de support requises. La fonction
+   fonctions de support. La fonction
    <function>amvalidate</function> doit renvoyer false si la classe d'opérateur
-   est invalide. Les problèmes devraient être reportés avec les messages
+   est invalide. Les problèmes devraient être rapportés avec les messages
    <function>ereport</function>.
   </para>
 
 
   <para>
-   Le but d'un index est de supporter les parcours de lignes
-   qui correspondent à une condition <literal>WHERE</literal> indexable, souvent appelée
-   <firstterm>qualificateur</firstterm>
+   Le but d'un index est bien sûr de supporter les parcours de lignes
+   qui correspondent à une condition <literal>WHERE</literal> indexable,
+   souvent appelée  <firstterm>qualificateur</firstterm>
    (<foreignphrase>qualifier</foreignphrase>) ou <firstterm>clé de
     parcours</firstterm> (<foreignphrase>scan key</foreignphrase>). La sémantique
    du parcours d'index est décrite plus complètement dans <xref linkend="index-scanning"/>,

--- a/postgresql/indexam.xml
+++ b/postgresql/indexam.xml
@@ -90,55 +90,56 @@ typedef struct IndexAmRoutine
     NodeTag     type;
 
     /*
-     * Total number of strategies (operators) by which we can traverse/search
-     * this AM.  Zero if AM does not have a fixed set of strategy assignments.
+     * Nombre total de stratégies (opérateurs) par lequels nous pouvons 
+     * traverser la méthode d'accès oy chercher dedans. Zéro si la méthode 
+     * n'a pas de jeu de stratégies fixé.
      */
     uint16      amstrategies;
-    /* total number of support functions that this AM uses */
+    /* nombre total de fonctions support utilisées par cette méthode d'accès */
     uint16      amsupport;
-    /* does AM support ORDER BY indexed column's value? */
+    /* la méthode supporte-t-elle un ORDER BY sur la colonne indexée ? */
     bool        amcanorder;
-    /* does AM support ORDER BY result of an operator on indexed column? */
+    /* la méthode supporte-t-elle un ORDER BY sur le résultat d'un opérateur appliqué à une colonne indexée ? */
     bool        amcanorderbyop;
-    /* does AM support backward scanning? */
+    /* la méthode support-t-elle le parcours à rebours ? */
     bool        amcanbackward;
-    /* does AM support UNIQUE indexes? */
+    /* la méthode supporte-t-elle les indexes UNIQUE ? */
     bool        amcanunique;
-    /* does AM support multi-column indexes? */
+    /* la méthde supporte-t-elle les index multi-colonnes ? */
     bool        amcanmulticol;
-    /* does AM require scans to have a constraint on the first index column? */
+    /* la méthode exige-t-elle un parcours pour une contrainte sur la première colonne de l'index ? */
     bool        amoptionalkey;
-    /* does AM handle ScalarArrayOpExpr quals? */
+    /* la méthode gère-t-elle les qualitificatifs ScalarArrayOpExpr ? */
     bool        amsearcharray;
-    /* does AM handle IS NULL/IS NOT NULL quals? */
+    /* la méthode gère-elle les qualificatifs IS NULL/IS NOT NULL ? */
     bool        amsearchnulls;
-    /* can index storage data type differ from column data type? */
+    /* le type de la valeur dans l'index peut-elle différer du type de la colonne ? */
     bool        amstorage;
-    /* can an index of this type be clustered on? */
+    /* un index de ce type peut-ili servir à un cluster ? */
     bool        amclusterable;
-    /* does AM handle predicate locks? */
+    /* la méthode gèreètelle les locks sur prédicat ? */
     bool        ampredlocks;
-    /* type of data stored in index, or InvalidOid if variable */
+    /* type de données stockés dans l'index, ou InvalidOid si variable */
     Oid         amkeytype;
 
-    /* interface functions */
+    /* fonctions d'interfaçage */
     ambuild_function ambuild;
     ambuildempty_function ambuildempty;
     aminsert_function aminsert;
     ambulkdelete_function ambulkdelete;
     amvacuumcleanup_function amvacuumcleanup;
-    amcanreturn_function amcanreturn;   /* can be NULL */
+    amcanreturn_function amcanreturn;   /* peut être NULL */
     amcostestimate_function amcostestimate;
     amoptions_function amoptions;
-    amproperty_function amproperty;     /* can be NULL */
+    amproperty_function amproperty;     /* peut être NULL */
     amvalidate_function amvalidate;
     ambeginscan_function ambeginscan;
     amrescan_function amrescan;
-    amgettuple_function amgettuple;     /* can be NULL */
-    amgetbitmap_function amgetbitmap;   /* can be NULL */
+    amgettuple_function amgettuple;     /* peut être NULL */
+    amgetbitmap_function amgetbitmap;   /* peut être NULL */
     amendscan_function amendscan;
-    ammarkpos_function ammarkpos;       /* can be NULL */
-    amrestrpos_function amrestrpos;     /* can be NULL */
+    ammarkpos_function ammarkpos;       /* peut être NULL */
+    amrestrpos_function amrestrpos;     /* peut être NULL */
 } IndexAmRoutine;
 </programlisting>
   </para>

--- a/postgresql/indexam.xml
+++ b/postgresql/indexam.xml
@@ -35,7 +35,7 @@
  <para>
   Dans les faits, un index est une correspondance entre certaines valeurs de données clés
   et les  identifiants des lignes (<firstterm>tuple identifiers</firstterm>, ou <acronym>TIDs</acronym>),
-  dans leurs différentes versions,  dans la table parent de l'index. Un TID consiste en un
+  dans leurs différentes versions,  dans la table parente de l'index. Un TID consiste en un
   numéro de bloc et un numéro d'élément dans ce bloc (voir <xref
   linkend="storage-page-layout"/>). L'information est suffisante pour
   récupérer une version d'une ligne particulière à partir de la table. Les index
@@ -373,7 +373,7 @@ amcanreturn (Relation indexRelation, int attno);
    seul</firstterm></link> sur la colonne indiquée, en renvoyant les valeurs
    des colonnes pour un enregistrement d'index sous forme d'un
    <structname>IndexTuple</structname>. Les numéros des attributs commencent
-   à 1 (c'est-à-dire que la valeur de attno pour la première colonne est 1).
+   à 1 (c'est-à-dire : pour la première colonne attno vaut 1).
    Renvoie true si c'est supporté, sinon false. Si la méthode d'accès ne
    supporte pas du tout les parcours d'index seul, le champ
    <structfield>amcanreturn</structfield> de la structure
@@ -401,10 +401,10 @@ bytea *
 amoptions (ArrayType *reloptions,
            bool validate);
    </programlisting>
-   Analyser et valider le tableau reloptions d'un index. Cette fonction
+   Analyse et valide le tableau reloptions d'un index. Cette fonction
    n'est appelée que lorsqu'il existe un tableau reloptions non NULL pour l'index.
    <parameter>reloptions</parameter> est un tableau
-   contenant des entrées de type <type>text</type> et de la forme
+   avec des entrées de type <type>text</type> et de la forme
    <replaceable>nom</replaceable><literal>=</literal><replaceable>valeur</replaceable>.
    La fonction doit construire une valeur de type <type>bytea</type> à
    copier dans le <structfield>rd_options</structfield> de l'entrée relcache
@@ -429,21 +429,20 @@ amproperty (Oid index_oid, int attno,
             IndexAMProperty prop, const char *propname,
             bool *res, bool *isnull);
 </programlisting>
-   Permet aux méthodes d'accès aux
-   index de surcharger le comportement par défaut de
+   Permet aux méthodes d'accès de surcharger le comportement par défaut de
    <function>pg_index_column_has_property</function> et des fonctions
-   liées. Si la méthode d'accès n'a pas de comportement spécial pour les
-   demandes des propriétés d'index, le champ
+   liées. Si la méthode d'accès n'a pas de comportement spécial lors des
+   demandes de propriétés d'index, le champ
    <structfield>amproperty</structfield> dans sa structure
-   <structname>IndexAmRoutine</structname> peut être configuré à NULL. Dans le
+   <structname>IndexAmRoutine</structname> peut être NULL. Dans le
    cas contraire, la méthode <function>amproperty</function> sera appelée avec
    <parameter>index_oid</parameter> et <parameter>attno</parameter> tous les
-   deux à zéro pour les appels <function>pg_indexam_has_property</function>,
+   deux à zéro pour les appels à <function>pg_indexam_has_property</function>,
    ou avec un <parameter>index_oid</parameter> valide et
-   <parameter>attno</parameter> à zéro pour les appels
+   <parameter>attno</parameter> à zéro pour les appels à
    <function>pg_index_has_property</function>, ou avec un
    <parameter>index_oid</parameter> valide et un <parameter>attno</parameter>
-   supérieur à zéro pour les appels
+   supérieur à zéro pour les appels à
    <function>pg_index_column_has_property</function>.
    <parameter>prop</parameter> est une valeur enum identifiant la propriété
    testée, alors que <parameter>propname</parameter> est le nom de la
@@ -501,7 +500,8 @@ amvalidate (Oid opclassoid);
     parcours</firstterm> (<foreignphrase>scan key</foreignphrase>). La sémantique
    du parcours d'index est décrite plus complètement dans <xref linkend="index-scanning"/>,
    ci-dessous. Une méthode d'accès à l'index peut supporter les parcours d'accès
-   standards (<quote>plain</quote>), les parcours d'index <quote>bitmap</quote>
+   standards (<quote>plain index scan</quote>),
+   les parcours d'index <quote>bitmap</quote>
    ou les deux. Les fonctions liées au parcours qu'une méthode d'accès à
    l'index doit ou devrait fournir sont&nbsp;:
   </para>
@@ -514,16 +514,16 @@ ambeginscan (Relation indexRelation,
    </programlisting>
    Prépare un parcours d'index. Les paramètres <literal>nkeys</literal> et
    <literal>norderbys</literal> indiquent le nombre de qualificateurs et
-   d'opérateurs de tri qui seront utilisés dans le parcours. Cela pourrait se
-   révéler utile pour l'allocation d'espace. Notez que les valeurs actuelles
+   d'opérateurs de tri qui seront utilisés dans le parcours. Ils peuvent
+   servir pour l'allocation d'espace. Notez que les valeurs réelles
    des clés de parcours ne sont pas encore fournies. Le résultat doit être
-   une structure allouée avec la fonction palloc. Pour des raisons
+   une structure palloc. Pour des raisons
    d'implémentation, la méthode d'accès à l'index <emphasis>doit</emphasis>
    créer cette structure en appelant
    <function>RelationGetIndexScan()</function>. Dans la plupart des cas,
-   <function>ambeginscan</function> fait peu en dehors de cet appel et,
-   peut-être, d'aquérir des verrous&nbsp;; les parties intéressantes de début
-   de parcours d'index sont dans <function>amrescan</function>.
+   <function>ambeginscan</function> ne fait pas grand-chose d'autre que cet appel et
+   parfois l'acquisition de verrous&nbsp;; les parties intéressantes du début
+   du parcours sont dans <function>amrescan</function>.
   </para>
 
   <para>
@@ -535,15 +535,15 @@ amrescan (IndexScanDesc scan,
           ScanKey orderbys,
           int norderbys);
    </programlisting>
-   Démarre ou relance un parcours d'index, possiblement avec des nouvelles
-   clés d'index. (Pour relancer en utilisant des clés déjà passées, NULL est
-   passé pour <literal>keys</literal> et/ou <literal>orderbys</literal>.) Notez
-   qu'il n'est pas autorisé que le nombre de clés ou d'opérateurs de tri
-   soit plus grande que celui passé à la fonction
-   <function>ambeginscan</function>. En pratique, la fonctionnalité de
-   relancement est utilisée quand une nouvelle ligne externe est sélectionnée
-   par une jointure de boucle imbriquée, et donc une nouvelle valeur de
-   comparaison de clé est requise, mais la structure de clé de parcours reste
+   Démarre ou relance un parcours d'index, possiblement avec de nouvelles
+   clés d'index. (Pour relancer en utilisant des clés déjà passées,
+   passer NULL à <literal>keys</literal> et/ou <literal>orderbys</literal>.) Notez
+   que le nombre de clés ou d'opérateurs de tri
+   ne doit pas être plus grand que ce qui a été passé à la fonction
+   <function>ambeginscan</function>. En pratique, le
+   relancement est utilisé quand une nouvelle ligne externe est sélectionnée
+   par une jointure de boucle imbriquée, donc avec une nouvelle valeur de
+   comparaison, mais la structure de clé de parcours reste
    la même.
   </para>
 
@@ -553,31 +553,31 @@ amgettuple (IndexScanDesc scan,
             ScanDirection direction);
    </programlisting>
    Récupérer la prochaine ligne d'un parcours donné, dans la direction donnée
-   (vers l'avant ou l'arrière de l'index). Renvoie TRUE si une ligne a
-   été obtenue, FALSE s'il ne reste aucune ligne. Dans le cas
-   TRUE, le TID de la ligne est stocké dans la structure
-   <literal>scan</literal>. <quote>success</quote> signifie uniquement que
+   (vers l'avant ou l'arrière de l'index). Renvoie true si une ligne a
+   été obtenue, false s'il ne reste aucune ligne. Dans le cas
+   true, le TID de la ligne est stocké dans la structure
+   <literal>scan</literal>. <quote>success</quote> signifie juste que
    l'index contient une entrée qui correspond aux clés de parcours, pas que
-   la ligne existe toujours dans la pile ou qu'elle peut réussir le test
-   d'instantané de l'appelant. En cas de succès, <function>amgettuple</function>
-   doit aussi configuré <literal>scan-&gt;xs_recheck</literal> à TRUE ou FALSE.
-   FALSE signifie qu'il est certain que l'entrée de l'index correspond aux clés
-   de parcours. TRUE signifie que ce n'est pas certain et que les conditions
+   la ligne existe toujours dans la table ou qu'elle sera visible
+   dans l'instantané (<foreignphrase>snapshot</foreignphrase>)
+   de l'appelant. En cas de succès, <function>amgettuple</function>
+   doit passer <literal>scan-&gt;xs_recheck</> à true ou false.
+   True signifie que ce n'est pas certain et que les conditions
    représentées par les clés de parcours doivent être de nouveau vérifiées sur
-   la ligne de la table après l'avoir récupéré. Cette différence permet de
-   supporter les opérateurs d'index <quote>à perte</quote>. Notez que la nouvelle
-   vérification s'étendra seulement aux conditions de parcours&nbsp;; un prédicat
-   partiel d'index n'est jamais vérifié par les appelants à
+   la ligne dans la table après récupération. Cette différence permet de
+   supporter les opérateurs d'index <quote>à perte</quote>. Notez que cela
+   ne s'appliquera qu'aux conditions de parcours&nbsp;; un prédicat
+   partiel d'index n'est jamais revérifié par les appelants à
    <function>amgettuple</function>.
   </para>
 
   <para>
    Si l'index supporte les <link linkend="indexes-index-only-scans">parcours
    d'index seul</link> (c'est-à-dire que
-   <function>amcanreturn</function> renvoit TRUE), alors, en cas de succès,
+   <function>amcanreturn</function> renvoit true), alors, en cas de succès,
    la méthode d'accès doit aussi vérifier
-   <literal>scan-&gt;xs_want_itup</literal>, et si ce dernier est TRUE, elle
-   doit renvoyer les données indexées originales pour l'entrée d'index, sous
+   <literal>scan-&gt;xs_want_itup</literal>, et si ce dernier est true, elle
+   doit renvoyer les données indexées originales de cette entrée d'index, sous
    la forme d'un pointeur d'<structname>IndexTuple</structname> stocké
    dans <literal>scan-&gt;xs_itup</literal>, avec un descripteur de lignes
    dans <literal>scan-&gt;xs_itupdesc</literal>.
@@ -592,7 +592,7 @@ amgettuple (IndexScanDesc scan,
    La fonction <function>amgettuple</function> a seulement besoin d'exister
    si la méthode d'accès supporte les parcours d'index standards. Si ce n'est
    pas le cas, le champ <structfield>amgettuple</structfield> de la structure
-   <structname>IndexAmRoutine</structname> doit être configuré à NULL.
+   <structname>IndexAmRoutine</structname> doit être NULL.
   </para>
 
   <para>
@@ -602,7 +602,7 @@ amgetbitmap (IndexScanDesc scan,
              TIDBitmap *tbm);
    </programlisting>
    Récupère toutes les lignes du parcours sélectionné et les ajoute au
-   <type>TIDBitmap</type> fournit par l'appelant (c'est-à-dire un OU de l'ensemble des
+   <type>TIDBitmap</type> fourni par l'appelant (c'est-à-dire un OU de l'ensemble des
    identifiants de ligne dans l'ensemble où se trouve déjà le bitmap). Le
    nombre de lignes récupérées est renvoyé (cela peut n'être qu'une estimation
    car certaines méthodes d'accès ne détectent pas les duplicats). Lors de
@@ -610,22 +610,22 @@ amgetbitmap (IndexScanDesc scan,
    peut indiquer que la vérification des conditions du parcours est requis pour
    des identifiants précis de transactions. C'est identique au paramètre de sortie
    <literal>xs_recheck</literal> de <function>amgettuple</function>. Note&nbsp;:
-   dans l'implantation actuelle, le support de cette fonctionnalité peut
-   beaucoup ressembler au support du stockage à perte du bitmap lui-même, et du coup
-   les appelants vérifient les conditions du parcours et le prédicat de l'index
-   partiel (si disponible) pour les lignes vérifiables à nouveau. Cela pourrait
-   ne pas toujours être vrai. <function>amgetbitmap</function> et
+   dans l'implémentation actuelle, le support de cette fonctionnalité
+   est fusionné avec le support du stockage à perte du bitmap lui-même, et du coup
+   les appelants revérifient à la fois les conditions du parcours et le prédicat de l'index
+   partiel (si c'en est un) pour les lignes à revérifier. Cela ne
+   sera pas forcément toujours vrai. <function>amgetbitmap</function> et
    <function>amgettuple</function> ne peuvent pas être utilisés dans le même
    parcours d'index&nbsp;; il existe d'autres restrictions lors de l'utilisation
-   de <function>amgetbitmap</function>, comme expliquées dans <xref
+   de <function>amgetbitmap</function>, comme expliqué dans <xref
    linkend="index-scanning"/>.
   </para>
 
   <para>
-   La fonction <function>amgetbitmap</function> doit seulement exister si la
+   La fonction <function>amgetbitmap</function> ne doit exister que si la
    méthode d'accès supporte les parcours d'index <quote>bitmap</quote>. Dans le
    cas contraire, le champ <structfield>amgetbitmap</structfield> de la structure
-   <structname>IndexAmRoutine</structname> doit être configuré à NULL.
+   <structname>IndexAmRoutine</structname> doit être NULL.
   </para>
 
   <para>
@@ -633,7 +633,7 @@ amgetbitmap (IndexScanDesc scan,
 amendscan (IndexScanDesc scan);
    </programlisting>
    Terminer un parcours et libérer les ressources. La structure <literal>scan</literal>
-   elle-même ne doit pas être libérée, mais tout verrou pris en interne par
+   elle-même ne doit pas être libérée, mais tout verrou posé en interne par
    la méthode d'accès doit être libéré.
   </para>
 
@@ -641,8 +641,15 @@ amendscan (IndexScanDesc scan);
    <programlisting>void
 ammarkpos (IndexScanDesc scan);
    </programlisting>
-   Marquer la position courante du parcours. La méthode d'accès ne mémorise
+   Marquer la position courante du parcours. La méthode d'accès n'a besoin de mémoriser
    qu'une seule position par parcours.
+  </para>
+
+  <para>
+   La fonction <function>ammarkpos</function> n'a besoin d'être fournie que
+   si la méthode supporte les parcours ordonnés. Dans le cas contraire, le champ
+   <structfield>ammarkpos</structfield> dans sa structure
+   <structname>IndexAmRoutine</structname> peut être NULL.
   </para>
 
   <para>
@@ -652,49 +659,39 @@ amrestrpos (IndexScanDesc scan);
    Restaurer le parcours à sa plus récente position marquée.
   </para>
 
-  <para>
-   La fonction <function>ammarkpos</function> a seulement besoin d'être proposée
-   si la méthode supporte les parcours ordonnés. Dans le cas contraire, le champ
-   <structfield>ammarkpos</structfield> dans sa structure
-   <structname>IndexAmRoutine</structname> peut être configuré à NULL.
-  </para>
-
  </sect1>
 
  <sect1 id="index-scanning">
   <title>Parcours d'index</title>
 
-  <!-- régurgitation est un drôle de terme dans ce contexte. L'auteur a-t-il
-voulu mettre en avant une idée négative du fonctionnement du parcours ? -->
   <para>
-   Dans un parcours d'index, la méthode d'accès à l'index retourne les TID
-   de toutes les lignes annoncées correspondre
+   Dans un parcours d'index, la responsabilité de la méthode d'accès
+   est de recracher tous les TID de toutes les lignes qu'on lui a dit correspondre
    aux <firstterm>clés de parcours</firstterm>. La méthode d'accès n'est
    impliquée <emphasis>ni</emphasis> dans la récupération de ces lignes dans la
-   table parent de l'index, ni dans les tests de qualification temporelle ou autre.
+   table parente de l'index, <emphasis>ni</emphasis> dans les tests de
+   qualification temporelle ou autre.
   </para>
 
   <para>
    Une clé de parcours est une représentation interne d'une clause
    <literal>WHERE</literal> de la forme <replaceable>clé_index</replaceable>
    <replaceable>opérateur</replaceable> <replaceable>constante</replaceable>,
-   où la clé d'index est une des colonnes de l'index et l'opérateur est un des
-   membres de la famille d'opérateur associée avec cette colonne d'index. Un
-   parcours d'index contient entre aucune et plusieurs clés de parcours qui sont assemblées
+   où la clé est une des colonnes de l'index et l'opérateur un des
+   membres de la famille d'opérateurs associée à cette colonne. Un
+   parcours d'index a entre zéro et plusieurs clés de parcours assemblées
    implicitement avec des AND &mdash; les lignes renvoyées doivent satisfaire
    toutes les conditions indiquées.
   </para>
 
-  <!-- lossy: à pertes ? c'est valable quand on parle de compression, qui
-supprime des données, mais dans le cas de l'index ? -->
   <para>
    La méthode d'accès peut indiquer que l'index est <firstterm>à
     perte</firstterm> ou nécessite une vérification pour une requête
    particulière&nbsp;; ceci implique que le parcours d'index renvoie toutes les
-   entrées qui correspondent à la clé de parcours, avec éventuellement des
+   entrées qui correspondent à la clé de parcours, plus éventuellement des
    entrées supplémentaires qui ne correspondent pas. La machinerie du parcours
-   d'index du système principal applique alors les conditions de l'index au
-   tuple pour vérifier s'il doit bien effectivement être retenu. Si l'option
+   d'index du système principal applique alors les conditions de l'index à
+   la ligne pour vérifier si elle doit effectivement être retenue. Si l'option
    de vérification n'est pas indiquée, le parcours d'index doit renvoyer
    exactement l'ensemble d'entrées correspondantes.
   </para>
@@ -703,11 +700,13 @@ supprime des données, mais dans le cas de l'index ? -->
    La méthode d'accès doit s'assurer
    qu'elle trouve correctement toutes les entrées correspondantes aux clés de
    parcours données, et seulement celles-ci. De plus, le système principal
-   transfert toutes les clauses <literal>WHERE</literal> qui correspondent aux clés d'index
+   se contente de transférer toutes les clauses <literal>WHERE</literal>
+   qui correspondent aux clés d'index
    et aux familles d'opérateurs, sans analyse sémantique permettant de
-   déterminer si elles sont redondantes ou contradictoires. Par exemple, étant donné
-   <literal>WHERE x &gt; 4 AND x &gt; 14</literal> où <literal>x</literal> est une colonne
-   indexée B-tree, c'est à la fonction B-tree <function>amrescan</function>
+   déterminer si elles sont redondantes ou contradictoires. Par exemple, avec
+   <literal>WHERE x &gt; 4 AND x &gt; 14</literal>, où <literal>x</literal>
+   est une colonne
+   indexée par B-tree, c'est à la fonction B-tree <function>amrescan</function>
    de déterminer que la première clé de parcours est redondante et peut être
    annulée. Le supplément de pré-traitement nécessaire lors de
    <function>amrescan</function> dépend du niveau de réduction des clés de
@@ -724,7 +723,7 @@ supprime des données, mais dans le cas de l'index ? -->
     <listitem>
      <para>
       Les méthodes d'accès qui renvoient toujours les entrées dans l'ordre
-      naturel (comme les B-tree) doivent configurer
+      naturel des données (comme les B-tree) doivent configurer
       <structfield>amcanorder</structfield> à
       true. Actuellement, ces méthodes d'accès doivent utiliser des nombres
       de stratégie compatibles avec les B-tree pour les opérateurs d'égalité
@@ -740,16 +739,16 @@ supprime des données, mais dans le cas de l'index ? -->
       <replaceable>clé_index</replaceable> <replaceable>opérateur</replaceable>
       <replaceable>constante</replaceable>. Les modificateurs de parcours de
       cette forme peuvent être passés à <function>amrescan</function> comme
-      décrits précédemment
-      previously.
+      décrit précédemment.
      </para>
     </listitem>
    </itemizedlist>
   </para>
 
   <para>
-   La fonction <function>amgettuple</function> dispose d'un argument <literal>direction</literal>,
-   qui peut être soit <literal>ForwardScanDirection</literal> (le cas normal) soit
+   La fonction <function>amgettuple</function> dispose d'un argument
+   <literal>direction</literal>,
+   qui peut être soit <literal>ForwardScanDirection</literal> (le cas normal), soit
    <literal>BackwardScanDirection</literal>. Si le premier appel après
    <function>amrescan</function> précise <literal>BackwardScanDirection</literal>, alors
    l'ensemble des entrées d'index correspondantes est à parcourir de l'arrière
@@ -768,7 +767,7 @@ supprime des données, mais dans le cas de l'index ? -->
   <para>
    Les méthodes d'accès qui supportent les parcours ordonnés doivent supporter
    le <quote>marquage</quote> d'une position dans un parcours pour retourner
-   plus tard à la position marquée. La même position pourrait être restaurée
+   plus tard à la position marquée. La même position peut être restaurée
    plusieurs fois. Néanmoins, seule une position par parcours a besoin d'être
    conservée en mémoire&nbsp;; un nouvel appel à <function>ammarkpos</function>
    surcharge la position anciennement marquée. Une méthode d'accès qui ne
@@ -781,23 +780,24 @@ supprime des données, mais dans le cas de l'index ? -->
   <para>
    Les positions du parcours et du marquage doivent être conservées de façon
    cohérente dans le cas d'insertions et de suppressions concurrentes dans
-   l'index. Il est tout à fait correct qu'une entrée tout juste insérée ne soit
-   pas retournée par un parcours, qui si l'entrée avait existé au démarrage du
-   parcours, aurait été retournée. De même est-il correct qu'un parcours
+   l'index. Il est acceptable qu'une entrée tout juste insérée ne soit
+   pas retournée par un parcours qui l'aurait trouvée
+   si l'entrée avait existé au démarrage du
+   parcours. De même est-il correct qu'un parcours
    retourne une telle entrée lors d'un re-parcours ou d'un retour arrière,
-   alors même qu'il ne l'a pas retourné lors du parcours initial.
-   À l'identique, une suppression concurrente peut être, ou non, visible dans
+   alors même qu'il ne l'a pas retournée lors du parcours initial.
+   De même, une suppression concurrente peut être, ou non, visible dans
    les résultats d'un parcours. Il est primordial qu'insertions et suppressions
    ne conduisent pas le parcours à oublier ou dupliquer des entrées qui ne sont
-   pas elles-même insérées ou supprimées.
+   pas insérées ou supprimées.
   </para>
 
   <para>
    Si l'index stocke les valeurs originales des données indexées (et pas une
-   représentation à perte des données), il est utile de supporter les <link
+   représentation à perte), il est utile de supporter les <link
    linkend="indexes-index-only-scans">parcours d'index seul</link>, pour
    lesquels l'index renvoie la donnée réelle et non pas
-   seulement le TID de la ligne dans la table. Ceci va seulement éviter des I/O
+   juste le TID de la ligne dans la table. Ceci n'évitera des I/O que
    si la carte de visibilité montre que le TID est sur une page dont toutes
    les lignes sont visibles par toutes les transactions en cours. Sinon, la
    ligne de la table doit être visitée de toute façon pour s'assurer de
@@ -806,10 +806,10 @@ supprime des données, mais dans le cas de l'index ? -->
   </para>
 
   <para>
-   <function>amgetbitmap</function> peut être utilisé à la place de
-   <function>amgettuple</function> pour un parcours d'index. Cela permet de
-   récupérer toutes les lignes en un appel. Cette méthode peut s'avérer
-   notablement plus efficace que <function>amgettuple</function> parce qu'elle
+   Un parcours d'index peut utiliser <function>amgetbitmap</function> à la place de
+   <function>amgettuple</function> pour
+   récupérer toutes les lignes en un unique appel. Cette méthode peut s'avérer
+   nettement plus efficace que <function>amgettuple</function> parce qu'elle
    permet d'éviter les cycles de verrouillage/déverrouillage à l'intérieur de la
    méthode d'accès. En principe, <function>amgetbitmap</function> a les mêmes
    effets que des appels répétés à <function>amgettuple</function>, mais
@@ -819,20 +819,19 @@ supprime des données, mais dans le cas de l'index ? -->
    pas supporté. Ensuite, les lignes sont renvoyées dans un bitmap qui n'a pas
    d'ordre spécifique, ce qui explique pourquoi <function>amgetbitmap</function>
    ne prend pas de <literal>direction</literal> en argument. (Les opérateurs
-   de tri ne seront jamais fournis pour un tel parcours.)
+   de tri ne seront jamais fournis non plus pour un tel parcours.)
    De plus, il n'existe aucune disposition pour les parcours d'index seul avec
    <function>amgetbitmap</function> car il n'y a aucun moyen de renvoyer le
    contenu des lignes d'index.
-   Enfin,
-   <function>amgetbitmap</function> ne garantit pas le verrouillage
+   Enfin, <function>amgetbitmap</function> ne garantit pas le verrouillage
    des lignes renvoyées, avec les implications précisées dans <xref
    linkend="index-locking"/>.
   </para>
 
   <para>
-   Notez qu'il est permis à une méthode d'accès d'implanter seulement
+   Notez qu'il est permis à une méthode d'accès d'implémenter seulement
    <function>amgetbitmap</function> et pas <function>amgettuple</function>, ou
-   vice versa, si son implantation interne ne convient qu'à une seule des API.
+   vice versa, si son fonctionnement interne ne convient qu'à une seule des API.
   </para>
 
  </sect1>
@@ -843,20 +842,20 @@ supprime des données, mais dans le cas de l'index ? -->
   <para>
    Les méthodes d'accès aux index doivent gérer des mises à jour
    concurrentes de l'index par plusieurs processus.
-   Le système principal <productname>PostgreSQL</productname> obtient
+   Le système principal de <productname>PostgreSQL</productname> obtient
    <literal>AccessShareLock</literal> sur l'index lors d'un parcours d'index et
    <literal>RowExclusiveLock</literal> lors de sa mise à jour (ce qui inclut le
    <command>VACUUM</command> simple). Comme ces types de
    verrous ne sont pas conflictuels, la méthode d'accès est responsable de la
    finesse du verrouillage dont elle a besoin. Un verrou exclusif sur
-   l'intégralité de l'index entier n'est pris qu'à la création de l'index, sa destruction
-   ou dans une opération <literal>REINDEX</literal>.
+   l'intégralité de l'index entier n'est posé qu'à la création de l'index, sa destruction
+   ou lors d'un <literal>REINDEX</literal>.
   </para>
 
   <para>
    Construire un type d'index qui supporte les mises à jour concurrentes
-   requiert une analyse complète et subtile du comportement requis. Pour les
-   types d'index B-tree et hash, on peut lire les implication sur les décisions
+   requiert une analyse complète et subtile. Pour les
+   types d'index B-tree et hash, on peut lire les implications sur les décisions
    de conception dans
    <filename>src/backend/access/nbtree/README</filename> et
    <filename>src/backend/access/hash/README</filename>.
@@ -864,110 +863,112 @@ supprime des données, mais dans le cas de l'index ? -->
 
   <para>
    En plus des besoins de cohérence interne de l'index, les mises à jour
-   concurrentes créent des problèmes de cohérence entre la table parent
-   (l'<firstterm>en-tête</firstterm>, ou <foreignphrase>heap</foreignphrase>)
-   et l'index. Comme <productname>PostgreSQL</productname> sépare les accès et les mises à
-   jour de l'en-tête de ceux de l'index, il existe des fenêtres temporelles
+   concurrentes créent des problèmes de cohérence entre la table parente
+   (<foreignphrase>heap</foreignphrase>)
+   et l'index. Comme <productname>PostgreSQL</productname> sépare les accès
+   et les mises à
+   jour de la table et ceux de l'index, il existe des fenêtres temporelles
    pendant lesquelles l'index et l'en-tête peuvent être incohérents. Ce problème
    est géré avec les règles suivantes&nbsp;:
 
    <itemizedlist>
     <listitem>
      <para>
-      une nouvelle entrée dans l'en-tête est effectuée avant son entrée
+      une nouvelle entrée dans la table est effectuée avant son entrée
       dans l'index. (Un parcours d'index concurrent peut alors ne pas
-      voir l'entrée dans l'en-tête. Ce n'est pas gênant dans la mesure où un
+      voir l'entrée dans la table. Ce n'est pas gênant dans la mesure où un
       lecteur de l'index ne s'intéresse pas à une ligne non validée. Voir
-      <xref linkend="index-unique-checks"/>);
+      <xref linkend="index-unique-checks"/>)&nbsp;;
      </para>
     </listitem>
     <listitem>
      <para>
-      Lorsqu'entrée de l'en-tête va être supprimée (par <command>VACUUM</command>),
-      toutes les entrées de l'index doivent d'abord être supprimées&nbsp;;
+      lorsqu'entrée de la table va être supprimée (par <command>VACUUM</command>),
+      on doit d'abord supprimer toutes les entrées d'index&nbsp;;
      </para>
     </listitem>
     <listitem>
      <para>
       un parcours d'index doit maintenir
       un lien sur la page d'index contenant le dernier élément renvoyé par
-      <function>amgettuple</function>, et <function>ambulkdelete</function> ne peut pas
+      <function>amgettuple</function>, et <function>ambulkdelete</function> ne peut
       supprimer des entrées de pages liées à d'autres processus. La
-      raison de cette règle est expliquée plus bas.
+      raison figure ci-dessous.
      </para>
     </listitem>
    </itemizedlist>
 
-   Sans la troisième règle, il est possible qu'un lecteur d'index voit
+   Sans la troisième règle il serait possible qu'un lecteur d'index voit
    une entrée dans l'index juste avant qu'elle ne soit supprimée par un
-   <command>VACUUM</command>, et arrive à l'entrée correspondante de
-   l'en-tête après sa suppression par le <command>VACUUM</command>.
-   Cela ne pose aucun problème sérieux si ce numéro d'élément
-   est toujours inutilisé quand le lecteur l'atteint, car tout emplacement d'élément
+   <command>VACUUM</command> et arrive à l'entrée correspondante de
+   la table après sa suppression par le <command>VACUUM</command>.
+   Cela ne pose aucun problème sérieux si cet élément
+   est toujours inutilisé quand le lecteur l'atteint, car tout emplacement
    vide est ignoré par <function>heap_fetch()</function>. Mais que se passe-t-il si
    un troisième moteur a déjà ré-utilisé l'emplacement de l'élément pour quelque
-   chose d'autre&nbsp;? Lors de l'utilisation d'un instantané compatible MVCC, il n'y
+   chose d'autre&nbsp;? Lors de l'utilisation d'un instantané (<foreignphrase>snapshot</foreignphrase>) compatible MVCC, il n'y
    a pas de problème car le nouvel occupant de l'emplacement est certain d'être
-   trop récent pour réussir le test de l'insstantané. En revanche, avec un
+   trop récent pour apparaître dans l'instantané.
+   En revanche, avec un
    instantané non-compatible MVCC (tel que <literal>SnapshotAny</literal>), une
    ligne qui ne correspond pas aux clés de parcours peut être acceptée ou
    retournée. Ce scénario peut être évité en imposant que les clés de parcours
-   soient re-confrontées à la ligne d'en-tête dans tous les cas, mais cela est
+   soient re-confrontées à la table dans tous les cas, mais cela est
    trop coûteux. À la place, un lien sur une page d'index est utilisé comme
    <foreignphrase>proxy</foreignphrase> pour indiquer que le
-   lecteur peut être <quote>en parcours</quote> entre l'entrée de
-   l'index et l'entrée de l'en-tête correspondante. Bloquer <function>ambulkdelete</function>
+   lecteur peut être <quote>en route</quote> depuis l'entrée
+   d'index vers l'entrée de table correspondante. Bloquer <function>ambulkdelete</function>
    sur un tel lien assure que <command>VACUUM</command> ne peut pas supprimer
-   l'entrée de l'en-tête avant que le lecteur n'en ait terminé avec elle. Cette
+   l'entrée de la table avant que le lecteur n'en ait terminé avec elle. Cette
    solution est peu coûteuse en temps d'exécution, et n'ajoute de surcharge du
-   fait du blocage que dans de rares cas réellement un conflictuels.
+   fait du blocage que dans les rares cas où il y a vraiment un conflit.
   </para>
 
   <para>
    Cette solution requiert que les parcours d'index soient
-   <quote>synchrones</quote>&nbsp;: chaque ligne d'en-tête doit être récupérée
-   immédiatement après le parcours de l'entrée d'index correspondante.
-   C'est coûteux pour plusieurs raisons. Un parcours <quote>asynchrone</quote> dans
-   lequel de nombreux TID sont récupérés de l'index, et pour lequel
-   les en-têtes de lignes ne sont visités que plus tard, requiert moins de
-   surcharge de verrouillage d'index et autorise un modèle d'accès à
-   l'en-tête plus efficace. D'après l'analyse ci-dessus,
-   l'approche synchronisée doit être utilisée pour les instantanés non compatibles avec
+   <quote>synchrones</quote>&nbsp;: chaque ligne de la table doit être récupérée
+   immédiatement après récupération de l'entrée d'index correspondante.
+   Cela est coûteux pour plusieurs raisons. Un parcours <quote>asynchrone</quote>,
+   où l'ont récupère de nombreux TID depuis l'index et où l'on ne visite la table
+   que plus tard, requiert moins de
+   surcharge de verrouillage de l'index et autorise un modèle d'accès à
+   la table plus efficace. D'après l'analyse ci-dessus,
+   l'approche synchrone doit être utilisée pour les instantanés non compatibles avec
    MVCC, mais un parcours asynchrone est possible pour une requête utilisant
-   une instantané MVCC.
+   un instantané MVCC.
   </para>
 
   <para>
    Dans un parcours d'index <function>amgetbitmap</function>, la méthode d'accès
-   ne conserve pas de lien à l'index sur quelque ligne
-   renvoyée. C'est pourquoi, il est préférable d'utiliser de tels parcours
-   avec les instantanés compatibles MVCC.
+   ne bloque l'index pour aucune des lignes
+   renvoyées. C'est pourquoi de tels parcours ne sont fiables
+   qu'avec les instantanés compatibles MVCC.
   </para>
 
   <para>
-   Quand le drapeau <structfield>ampredlocks</structfield> n'est pas configuré,
-   tout parcours utilisant cette méthode d'accès de l'index dans une transaction
-   sérialisable acquèrera un verrou prédicat non bloquant sur l'index
-   complet. Ceci génèrera un conflit en lecture/écriture avec l'insertion d'une
+   Quand le drapeau <structfield>ampredlocks</structfield> n'est pas en place,
+   tout parcours par cette méthode d'accès au sein d'une transaction
+   sérialisable acquerra un verrou prédicat non bloquant sur l'index
+   complet. Ceci génèrera un conflit de lecture/écriture à l'insertion d'une
    ligne dans cet index par une transaction sérialisable concurrente. Si
-   certains motifs de conflit en lecture/écriture sont détectés parmi un
+   certains motifs de tels conflits sont détectés dans un
    ensemble de transactions sérialisables concurrentes, une de ces transactions
-   pourrait être annulée pour protéger l'intégrité des données. Quand le
-   drapeau est configuré, cela indique que la méthode d'accès de l'index
+   peut être annulée pour protéger l'intégrité des données. Quand le
+   drapeau est en place, il indique que la méthode d'accès
    implémente un verrou prédicat plus fin, qui tend à réduire la fréquence
-   d'annulations de telles requêtes.
+   d'annulation de telles requêtes.
   </para>
 
  </sect1>
 
  <sect1 id="index-unique-checks">
-  <title>Vérification de l'unicité de l'index</title>
+  <title>Vérification de l'unicité par les index</title>
 
   <!-- SAS :: L'index n'est pas unique, il garantit l'unicité -->
   <para>
    <productname>PostgreSQL</productname> assure les contraintes d'unicité SQL
-   en utilisant des <firstterm>index d'unicité</firstterm>, qui sont des index qui refusent
-   les entrées multiples à clés identiques. Une méthode d'accès qui
+   par des <firstterm>index uniques</firstterm>, qui sont des index qui refusent
+   des entrées multiples pour un même clé. Une méthode d'accès qui
    supporte cette fonctionnalité initialise
    <structfield>amcanunique</structfield> à
    true. (À ce jour, seul B-tree le supporte).
@@ -975,11 +976,11 @@ supprime des données, mais dans le cas de l'index ? -->
 
   <para>
    Du fait de MVCC, il est toujours nécessaire de permettre à des entrées dupliquées
-   d'exister physiquement dans un index&nbsp;: les entrées peuvent faire
-   référence à des versions successives d'une même ligne logique. Le comportement
-   qu'il est réellement souhaitable d'assurer est qu'aucune image MVCC n'inclut deux
-   lignes avec les mêmes clés d'index. Cela se résume aux cas suivants, qu'il
-   est nécessaire de vérifier à l'insertion d'une nouvelle ligne dans un index
+   d'exister physiquement dans un index&nbsp;: elles peuvent faire
+   référence à des versions successives d'une même ligne logique.
+   Nous voulons garantir qu'aucune image MVCC n'inclut deux
+   lignes avec les mêmes clés d'index. Cela se résume aux cas suivants,
+   à vérifier à l'insertion d'une nouvelle ligne dans un index
    d'unicité&nbsp;:
 
    <itemizedlist>
@@ -992,22 +993,20 @@ supprime des données, mais dans le cas de l'index ? -->
      </para>
     </listitem>
     <listitem>
-     <!-- dans toto ? kesako ? in toto (locution latine) : en entier, intégralement cf.
-     http://www.merriam-webster.com/dictionary/in+toto -->
      <para>
       si une ligne conflictuelle a été insérée par une transaction non encore
       validée, l'inséreur potentiel doit attendre de voir si la transaction
-      est validée. Si la transaction est annulée, alors il n'y a pas de conflit.
-      Si la transaction est validée sans que la ligne conflictuelle soit
-      supprimée, il y a violation de la contrainte d'unicité. (En pratique,
+      est validée. Si elle est annulée, alors il n'y a pas de conflit.
+      Si elle est validée sans avoir supprimé la ligne conflictuelle,
+      il y a violation de la contrainte d'unicité. (En pratique,
       on attend que l'autre transaction finisse et le contrôle de visibilité
       est effectué à nouveau dans son intégralité)&nbsp;;
      </para>
     </listitem>
     <listitem>
      <para>
-      de façon similaire, si une ligne valide conflictuelle est supprimée par
-      une transaction non encore validée, l'inserant potentiel doit attendre la
+      de façon similaire, si une ligne conflictuelle validée est supprimée par
+      une transaction encore non validée, l'inséreur potentiel doit attendre la
       validation ou l'annulation de cette transaction et recommencer le test.
      </para>
     </listitem>
@@ -1018,7 +1017,7 @@ supprime des données, mais dans le cas de l'index ? -->
    De plus, immédiatement avant de lever une violation d'unicité
    en fonction des règles ci-dessus, la méthode d'accès doit
    revérifier l'état de la ligne en cours d'insertion. Si elle
-   est validée tout en étant morte, alors aucune erreur ne
+   est validée mais est déjà morte, alors aucune erreur ne
    survient. (Ce cas ne peut pas survenir lors du scénario ordinaire
    d'insertion d'une ligne tout juste créée par la
    transaction en cours. Cela peut néanmoins arriver lors d'un
@@ -1027,31 +1026,32 @@ supprime des données, mais dans le cas de l'index ? -->
 
   <para>
    La méthode d'accès à l'index doit appliquer elle-même ces tests,
-   ce qui signifie qu'elle doit accéder à l'en-tête pour vérifier le
-   statut de validation de toute ligne présentée avec une clé dupliquée
-   au regard du contenu de l'index. C'est sans aucun doute moche et non
+   ce qui signifie qu'elle doit accéder à la table pour vérifier le
+   statut de validation de toute ligne présentant une clé dupliquée
+   au regard du contenu de l'index. C'est sans doute moche et non
    modulaire, mais cela permet d'éviter un travail redondant&nbsp;: si un test
-   séparé est effectué, alors la recherche d'une ligne conflictuelle dans
-   l'index est en grande partie répétée lors de la recherche d'une place pour
-   insérer l'entrée d'index de la nouvelle ligne. Qui plus, est, il n'y a pas
-   de façon triviale d'éviter les conflits, sauf si la recherche de conflit
-   est partie intégrante de l'insertion de la nouvelle entrée d'index.
+   séparé était effectué, alors la recherche d'une ligne conflictuelle dans
+   l'index serait en grande partie répétée lors de la recherche d'une place pour
+   la nouvelle entrée d'index. Qui plus, est, il n'y a pas
+   de façon évidente d'éviter des <foreignphrase>race conditions</foreignphrase>,
+   sauf si la recherche de conflit
+   est partie intégrante de l'insertion d'une nouvelle entrée d'index.
   </para>
 
   <para>
    Si la contrainte unique est déferrable, il y a une complication
    supplémentaire&nbsp;: nous devons être capable d'insérer une entrée d'index
-   pour une nouvelle ligne mais de déferrer toute erreur de violation de
-   l'unicité jusqu'à la fin de l'instruction, voire même après. Pour éviter
-   des recherches répétées et inutiles de l'index, la méthode d'accès de
-   l'index doit faire une vérification préliminaire d'unicité lors de
-   l'insertion initiale. Si cela montre qu'il n'y a pas de conflit avec une
+   pour une nouvelle ligne mais devons déferrer toute erreur de violation de
+   l'unicité jusqu'à la fin de l'instruction, voire après. Pour éviter
+   des recherches répétées et inutiles dans l'index, la méthode d'accès
+   doit faire une vérification préliminaire d'unicité dès
+   l'insertion initiale. Si elle ne montre pas de conflit avec une
    ligne visible, nous avons terminé. Sinon, nous devons planifier une
-   nouvelle vérification quand il sera temps de forcer la contrainte. Si, au
-   moment de la nouvelle vérification, la ligne insérée et d'autres lignes de
-   la même clé sont vivantes, alors l'erreur doit être reportée. (Notez que,
+   nouvelle vérification quand il sera temps de forcer la contrainte. Si
+   lors de la nouvelle vérification la ligne insérée et d'autres lignes de
+   la même clé sont vivantes, alors l'erreur doit être rapportée. (Notez que,
    dans ce contexte, <quote>vivant</quote> signifie réellement <quote>toute
-    ligne dans la chaine HOT de l'entrée de l'index est vivante</quote>.)
+   ligne dans la chaîne HOT de l'entrée d'index est vivante</quote>.)
    Pour implanter ceci, la fonction <function>aminsert</function> reçoit un
    paramètre <literal>checkUnique</literal> qui peut avoir une des valeurs
    suivantes&nbsp;:
@@ -1059,8 +1059,8 @@ supprime des données, mais dans le cas de l'index ? -->
    <itemizedlist>
     <listitem>
      <para>
-      <literal>UNIQUE_CHECK_NO</literal> indicates that no uniqueness checking
-      should be done (this is not a unique index).
+      <literal>UNIQUE_CHECK_NO</literal> indique qu'aucun test d'unicité
+      ne doit être fait (ce n'est pas un index unique).
      </para>
     </listitem>
     <listitem>
@@ -1092,26 +1092,26 @@ supprime des données, mais dans le cas de l'index ? -->
     </listitem>
     <listitem>
      <para>
-      <literal>UNIQUE_CHECK_EXISTING</literal> indique que c'est une
-      revérification déferrée d'une ligne qui a été rapportée comme en
-      violation potentielle d'unicité. Bien que cela soit implanté par un
+      <literal>UNIQUE_CHECK_EXISTING</literal> indique qu'une
+      revérification déferrée d'une ligne a été rapportée en
+      violation potentielle d'unicité. Bien que cela soit implémenté par un
       appel à <function>aminsert</function>, la méthode d'accès ne doit
       <emphasis>pas</emphasis> insérer une nouvelle entrée d'index dans ce
       cas. L'entrée d'index est déjà présente. À la place, la méthode d'accès
       doit vérifier s'il existe une autre entrée d'index vivante. Si c'est le
       cas et que la ligne cible est toujours vivante, elle doit rapporter
-      une erreur.
+      l'erreur.
      </para>
 
      <para>
       Il est recommendé que, dans un appel à
       <literal>UNIQUE_CHECK_EXISTING</literal>, la méthode d'accès vérifie en
       plus que la ligne cible ait réellement une entrée existante dans l'index
-      et de rapporter une erreur si ce n'est pas le cas. C'est une bonne idée
+      et de lever une erreur si ce n'est pas le cas. C'est une bonne idée
       car les valeurs de la ligne d'index passées à
       <function>aminsert</function> auront été recalculées. Si la définition
       de l'index implique des fonctions qui ne sont pas vraiment immutables,
-      nous pourrions vérifier la mauvaise aire de l'index. Vérifier que la
+      nous pourrions être en train de vérifier une mauvaise partie de l'index. Vérifier que la
       ligne cible est trouvée dans la revérification permet de s'assurer que
       nous recherchons les mêmes valeurs de la ligne comme elles ont été
       utilisées lors de l'insertion originale.
@@ -1126,18 +1126,18 @@ supprime des données, mais dans le cas de l'index ? -->
   <title>Fonctions d'estimation des coûts d'index</title>
 
   <para>
-   La fonction <function>amcostestimate</function> se voit donner des
+   La fonction <function>amcostestimate</function> reçoit des
    informations décrivant un parcours d'index possible, incluant des listes
-   de clauses WHERE et ORDER BY qui ont été déterminées pour être utilisables
+   de clauses WHERE et ORDER BY considérées comme utilisables
    avec l'index. Elle doit renvoyer une
    estimation du coût de l'accès à l'index et de la sélectivité des clauses
-   WHERE (c'est-à-dire la fraction des lignes de la table parent qui seront
-   récupérées lors du parcours de l'index). Pour les cas simples, pratiquement
+   WHERE (c'est-à-dire la fraction des lignes de la table parente qui seront
+   récupérées lors du parcours de l'index). Dans les cas simples, pratiquement
    tout le travail de l'estimateur de coût peut être effectué en appelant des
-   routines standard dans l'optimiseur&nbsp;; la raison d'avoir une fonction
-   <function>amcostestimate</function> est d'autoriser les méthodes d'accès aux index à fournir
-   une connaissance spécifique au type d'index, au cas où il serait possible
-   d'améliorer les estimations standard.
+   routines standard dans l'optimiseur&nbsp;; la justification d'une fonction
+   <function>amcostestimate</function> est de permettre aux méthodes d'accès de fournir
+   des connaissances spécifiques liées au type d'index, au cas où il serait possible
+   d'améliorer les estimations standards.
   </para>
 
   <para>
@@ -1179,13 +1179,13 @@ amcostestimate (PlannerInfo *root,
      <term><parameter>loop_count</parameter></term>
      <listitem>
       <para>
-       Le nombre de répétitions du parcours d'index qui devrait être
-       pris en compte dans les estimations de coût. Cela sera généralement
+       Le nombre de répétitions du parcours d'index à
+       prendre en compte dans les estimations de coût. Il sera généralement
        supérieur à 1 lors d'un parcours avec paramètres à utiliser à
        l'intérieur d'une jointure de boucle imbriquée. Notez que l'estimation
        de coût doit toujours être pour un seul parcours&nbsp;; une valeur plus
-       importante de <parameter>loop_count</parameter> signifie qu'il pourrait
-       être approprié de permettre des effets de cache avec plusieurs parcours.
+       importante de <parameter>loop_count</parameter> signifie qu'on pourrait
+       constater l'effet du cache avec plusieurs parcours.
       </para>
      </listitem>
     </varlistentry>
@@ -1193,14 +1193,14 @@ amcostestimate (PlannerInfo *root,
   </para>
 
   <para>
-   Les quatre derniers paramètres sont les sorties passées par référence&nbsp;:
+   Les quatre derniers paramètres sont les sorties, passées par référence&nbsp;:
 
    <variablelist>
     <varlistentry>
      <term><parameter>*indexStartupCost</parameter></term>
      <listitem>
       <para>
-       Initialisé au coût du lancement du traitement de l'index.
+       Renvoie le coût du lancement du traitement de l'index.
       </para>
      </listitem>
     </varlistentry>
@@ -1209,7 +1209,7 @@ amcostestimate (PlannerInfo *root,
      <term><parameter>*indexTotalCost</parameter></term>
      <listitem>
       <para>
-       Initialisé au coût du traitement total de l'index.
+       Renvoie le coût du traitement total de l'index.
       </para>
      </listitem>
     </varlistentry>
@@ -1218,7 +1218,7 @@ amcostestimate (PlannerInfo *root,
      <term><parameter>*indexSelectivity</parameter></term>
      <listitem>
       <para>
-       Initialisé à la sélectivité de l'index.
+       Renvoie la sélectivité de l'index.
       </para>
      </listitem>
     </varlistentry>
@@ -1227,7 +1227,7 @@ amcostestimate (PlannerInfo *root,
      <term><parameter>*indexCorrelation</parameter></term>
      <listitem>
       <para>
-       Initialisé au coefficient de corrélation entre l'ordre du parcours de
+       Renvoie le coefficient de corrélation entre l'ordre de parcours de
        l'index et l'ordre sous-jacent de la table.
       </para>
      </listitem>
@@ -1237,41 +1237,40 @@ amcostestimate (PlannerInfo *root,
 
   <para>
    Les fonctions d'estimation de coûts doivent être écrites en C, pas
-   en SQL ou dans tout autre langage de procédure, parce qu'elles doivent accéder
+   en SQL ou dans tout autre langage procédural, parce qu'elles doivent accéder
    aux structures de données internes du planificateur/optimiseur.
   </para>
 
   <para>
-   Les coûts d'accès aux index doivent être calculés en utilisant les paramètres
+   Les coûts d'accès aux index doivent être calculés avec les paramètres
    utilisés par <filename>src/backend/optimizer/path/costsize.c</filename>&nbsp;: la
    récupération d'un bloc disque séquentiel a un coût de <varname>seq_page_cost</varname>,
    une récupération non séquentielle a un coût de <varname>random_page_cost</varname>, et le coût de
    traitement d'une ligne d'index doit habituellement être considéré comme
    <varname>cpu_index_tuple_cost</varname>. De plus, un multiple approprié de
-   <varname>cpu_operator_cost</varname> doit être chargé pour tous les opérateurs
+   <varname>cpu_operator_cost</varname> doit être ajouté pour tous les opérateurs
    de comparaison impliqués lors du traitement de l'index (spécialement
    l'évaluation des <literal>indexQuals</literal>).
   </para>
 
   <para>
-   Les coûts d'accès doivent inclure tous les coûts dûs aux disques et aux CPU
-   associés au parcours d'index lui-même, mais <emphasis>pas</emphasis> les coûts de
-   récupération ou de traitement des lignes de la table parent qui sont
+   Les coûts d'accès doivent inclure tous les coûts dus aux disques et aux CPU
+   associés au parcours d'index proprement dit, mais <emphasis>pas</emphasis> les coûts de
+   récupération ou de traitement des lignes de la table parente
    identifiées par l'index.
   </para>
 
   <para>
    Le <quote>coût de lancement</quote> est la partie du coût total de parcours
    à dépenser avant de commencer à récupérer la première ligne.
-   Pour la plupart des index, cela s'évalue à zéro, mais un type
-   d'index avec un grand coût de lancement peut vouloir le configurer à
-   une autre valeur que zéro.
+   Pour la plupart des index on peut prendre zéro, mais un type
+   d'index avec un grand coût au démarrage peut nécessiter une valeur supérieure à zéro.
   </para>
 
   <para>
-   <parameter>indexSelectivity</parameter> doit être initialisé à la fraction estimée des lignes
-   de la table parent qui sera récupérée lors du parcours d'index. Dans le cas
-   d'une requête à perte, c'est typiquement plus élevé que la
+   <parameter>indexSelectivity</parameter> doit être la fraction estimée des lignes
+   de la table parente qui sera récupérée lors du parcours d'index. Dans le cas
+   d'une requête à perte, ce sera typiquement plus élevé que la
    fraction des lignes qui satisfont les conditions de qualification données.
   </para>
 
@@ -1279,7 +1278,7 @@ amcostestimate (PlannerInfo *root,
    <parameter>indexCorrelation</parameter> doit être initialisé à la corrélation (valeur entre
    -1.0 et 1.0) entre l'ordre de l'index et celui de la table. Cela permet
    d'ajuster l'estimation du coût de récupération des lignes de la table
-   parent.
+   parente.
   </para>
 
   <para>
@@ -1295,10 +1294,10 @@ amcostestimate (PlannerInfo *root,
 
    <step>
     <para>
-     Estime et renvoie la fraction des lignes de la table parent
+     Estime et renvoie la fraction des lignes de la table parente
      visitées d'après les conditions de qualification données. En l'absence de toute
-     connaissance spécifique sur le type de l'index, on utilise la fonction
-     de l'optimiseur standard <function>clauselist_selectivity()</function>:
+     connaissance spécifique sur le type d'index, on utilise la fonction standard
+     de l'optimiseur <function>clauselist_selectivity()</function>:
 
      <programlisting>+*indexSelectivity = clauselist_selectivity(root, path-&gt;indexquals,
                                            path-&gt;indexinfo-&gt;rel-&gt;relid,
@@ -1321,8 +1320,8 @@ amcostestimate (PlannerInfo *root,
    <step>
     <para>
      Estime le nombre de pages d'index récupérées pendant le parcours.
-     Ceci peutt être simplement <parameter>indexSelectivity</parameter>
-     multiplié par la taille de l'index en pages.
+     Ceci peut être simplement <parameter>indexSelectivity</parameter>
+     multiplié par la taille en pages de l'index.
     </para>
    </step>
 
@@ -1332,10 +1331,10 @@ amcostestimate (PlannerInfo *root,
      faire ainsi&nbsp;:
 
      <programlisting>    /*
-     * Our generic assumption is that the index pages will be read
-     * sequentially, so they have cost seq_page_cost each, not random_page_cost.
-     * Also, we charge for evaluation of the indexquals at each index row.
-     * All the costs are assumed to be paid incrementally during the scan.
+     * On suppose généralement que les pages d'index sont lues
+     * séquentiellement, elles coûtent donc seq_page_cost each, et pas random_page_cost.
+     * Nous ajoutons l'évaluation des qualificateurs pour chaque ligne d'index.
+     * Tous les coûts sont supposés être payés de manière incrémentale pendant le parcours.
      */
     cost_qual_eval(&amp;index_qual_cost, path-&gt;indexquals, root);
     *indexStartupCost = index_qual_cost.startup;
@@ -1344,15 +1343,15 @@ amcostestimate (PlannerInfo *root,
      </programlisting>
 
      Néanmoins, le calcul ci-dessus ne prend pas en compte l'amortissement des
-     lectures des index à travers les parcours répétés d'index.
+     lectures des index à travers des parcours répétés.
     </para>
    </step>
 
    <step>
     <para>
      Estime la corrélation de l'index. Pour un index ordonné sur un seul champ,
-     cela peut s'extraire de pg_statistic. Si la corrélation est inconnue,
-     l'estimation conservative est zéro (pas de corrélation).
+     cela peut se trouver dans pg_statistic. Si la corrélation est inconnue,
+     l'estimation conservatrice est zéro (pas de corrélation).
     </para>
    </step>
   </procedure>


### PR DESCRIPTION
Traduction des quelques commentaires de codes non traduits. Allègement de style (notamment les répétitions). 
TRUE/FALSE remplacé par true/false comme dans le reste de la doc. 
Une poignée de faux sens et d'oublis par rapport à la VO.