### PR TITLE
Relecture

### DIFF
--- a/postgresql/pgprewarm.xml
+++ b/postgresql/pgprewarm.xml
@@ -10,7 +10,7 @@
 
  <para>
   Le module <filename>pg_prewarm</filename> fournit un moyen pratique
-  de charger des données de relations dans le cache de données du système
+  de charger des données des relations dans le cache de données du système
   d'exploitation ou dans le cache de données de
   <productname>PostgreSQL</productname>.
  </para>
@@ -25,14 +25,14 @@ pg_prewarm(regclass, mode text default 'buffer', fork text default 'main',
   </synopsis>
 
   <para>
-   Le premier argument correspond à la relation qui doit être préchargée. Le
-   second argument correspond à la méthode de préchargement à utiliser,
-   comme cela sera vu plus bas. Le troisième argument correspond au type de
-   fichier à précharger (généralement <literal>main</literal>).  Le quatrième
-   argument correspond au numéro du premier bloc à précharger
+   Le premier argument est la relation qui doit être préchargée. Le
+   second est la méthode de préchargement à utiliser,
+   comme décrit plus bas. Le troisième argument correspond au type de
+   fichier à précharger (généralement <literal>main</literal>). Le quatrième
+   argument est le numéro du premier bloc à précharger
    (<literal>NULL</literal> est accepté comme synonyme de zéro). Le cinquième
    argument correspond au dernier numéro de bloc à précharger
-   (<literal>NULL</literal> signifie de précharger jusqu'au dernier bloc trouvé
+   (<literal>NULL</literal> signifie que l'on précharge jusqu'au dernier bloc
    dans la relation). La valeur retournée correspond au nombre de blocs
    préchargés.
   </para>
@@ -50,16 +50,16 @@ pg_prewarm(regclass, mode text default 'buffer', fork text default 'main',
 
   <para>
    Il est à noter qu'avec n'importe laquelle de ces méthodes, tenter de
-   précharger plus de blocs que'il est possible de mettre en cache &mdash; par
+   précharger plus de blocs qu'il n'est possible de mettre en cache &mdash; par
    le système d'exploitation en utilisant <literal>prefetch</literal> ou
    <literal>read</literal>, ou par <productname>PostgreSQL</productname> en
    utilisant <literal>buffer</literal> &mdash; aura probablement pour effet
    d'expulser du cache les blocs de numéro inférieur au fur et à mesure que
-   les blocs de numéros supérieurs seront lus.  De plus, le préchargement de
-   données apprécie qu'aucune protection contre l'expulsion de données du
-   cache ne soit présente. Il est donc possible que d'autres activités du
+   les blocs de numéros supérieurs seront lus. De plus, les données
+   préchargées ne bénéficient d'aucune protection spécifique contre l'éviction
+   du cache. Il est donc possible que d'autres activités du
    système d'exploitation puissent évincer du cache les données fraîchement
-   préchargées peu de temps après leur préchargement. Pour toutes ces
+   préchargées peu après leur lecture. Pour toutes ces
    raisons, le préchargement est typiquement plus utile au démarrage, quand
    les caches sont majoritairement vides.
   </para>


### PR DESCRIPTION
Détails de formulation, dont un faux sens ou traduction pas mises à jour sur la non-protection contre l'éviction du cache.