### PR TITLE
Compatilité php 7

### DIFF
--- a/www-docs.postgresql.fr/index.php
+++ b/www-docs.postgresql.fr/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $recherche = $_REQUEST['q'];
 $filtreversion = $_REQUEST['v'];
 
@@ -96,7 +96,7 @@ $version['906'] = '9.6';
       <h2><label for="q">Rechercher</label></h2>
       <input id="q" name="q" type="text" size="16" maxlength="255" onfocus="if( this.value=='Rechercher' ) this.value='';" value="<?= strlen($_REQUEST['q'])>0 ? $_REQUEST['q'] : 'Rechercher' ?>" accesskey="s" />
   <select id="v" name="v">
-<?
+<?php
   $query = "SELECT version, count(*) as nb FROM pages GROUP BY version ORDER BY version DESC";
   $result = pg_query($pgconn, $query);
 

--- a/www-docs.postgresql.fr/search.php
+++ b/www-docs.postgresql.fr/search.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $recherche = $_REQUEST['q'];
 $filtreversion = $_REQUEST['v'];
 
@@ -97,7 +97,7 @@ $version['906'] = '9.6';
       <h2><label for="q">Rechercher</label></h2>
       <input id="q" name="q" type="text" size="16" maxlength="255" onfocus="if( this.value=='Rechercher' ) this.value='';" value="<?= strlen($_REQUEST['q'])>0 ? $_REQUEST['q'] : 'Rechercher' ?>" accesskey="s" />
   <select id="v" name="v">
-<?
+<?php
   $query = "SELECT version, count(*) as nb FROM pages GROUP BY version ORDER BY version DESC";
   $result = pg_query($pgconn, $query);
 
@@ -123,10 +123,10 @@ $version['906'] = '9.6';
   <div id="pgContentWrap">
   <div id="pgDownloadsWrap">
   <div id="content">
-<?
-$like[0]="'sql-%".pg_escape_string(ereg_replace(' ','',$recherche))."%.html'";
-$like[1]="'app-%".pg_escape_string(ereg_replace('_','',$recherche))."%.html'";
-$like[2]="'app-%".pg_escape_string(ereg_replace('_','-',$recherche))."%.html'";
+<?php
+$like[0]="'sql-%".pg_escape_string(preg_replace('/ /','',$recherche))."%.html'";
+$like[1]="'app-%".pg_escape_string(preg_replace('/_/','',$recherche))."%.html'";
+$like[2]="'app-%".pg_escape_string(preg_replace('/_/','-',$recherche))."%.html'";
 
 $query = "SELECT version, url, titre
 FROM pages
@@ -141,7 +141,7 @@ if (pg_num_rows($result) > 0) {
 		<div style="text-align:left;text-weight:normal;">
 <h1>Pages man</h1>
 <ol>
-<?
+<?php
 
 while ($ligne = pg_fetch_array($result)) {
   echo '<li>
@@ -152,15 +152,16 @@ while ($ligne = pg_fetch_array($result)) {
 ?>
 </ol>
 		</div>
-<?
+<?php
 }
 ?>
 		<div style="text-align:left;text-weight:normal;">
 <h1>Résultats complets</h1>
 <ol>
-<?
+<?php
 
 $searchstring = '';
+
 if( preg_match_all('/([-!]?)(\S+)\s*/', $recherche, $m, PREG_SET_ORDER ) ) {
   foreach( $m as $terms ) {
     if (strlen($terms[1])) {
@@ -181,6 +182,7 @@ if( preg_match_all('/([-!]?)(\S+)\s*/', $recherche, $m, PREG_SET_ORDER ) ) {
     }
   }
 }
+
 
 ## Strip out leading junk
 $searchstring = preg_replace('/^[\s\&\|]+/', '', $searchstring);

--- a/www-docs.postgresql.fr/tools/addrelease.php
+++ b/www-docs.postgresql.fr/tools/addrelease.php
@@ -1,5 +1,5 @@
 #! /usr/bin/php -qC
-<?
+<?php
 
 function usage() {
   echo '
@@ -41,6 +41,9 @@ $PGPASSWORD = getenv('PGPASSWORD');
 $g_passwordrequired = false;
 $tags1 = '';
 $tags2 = '';
+
+$titre = '';
+$corps = '';
 
 // Déchiffrage des options en ligne de commande
 for ($i = 1; $i < $_SERVER["argc"]; $i++) {
@@ -182,7 +185,7 @@ pg_query($pgconn, $query);
 
 // lecture du répertoire
 if ($handle = opendir($dir)) {
-  echo "Traitement du répertoire : ";
+  echo "Traitement du répertoire : $dir";
 
   $result = pg_query($pgconn, 'BEGIN');
 
@@ -200,10 +203,10 @@ if ($handle = opendir($dir)) {
         $titre = $matches[1];
         $titre = preg_replace('#\s+#',' ',$titre);
       }
-      $titre = trim(ereg_replace('[0-9A-Z.]*\&nbsp;', '', $titre));
-      $titre = ereg_replace('Chapitre', '', $titre);
-      $titre = ereg_replace('Annexe', '', $titre);
-      $titre = ereg_replace('Partie', '', $titre);
+      $titre = trim(preg_replace('/[0-9A-Z.]*\&nbsp;/', '', $titre));
+      $titre = preg_replace('/Chapitre/', '', $titre);
+      $titre = preg_replace('/Annexe/', '', $titre);
+      $titre = preg_replace('/Partie/', '', $titre);
       $titre = html_entity_decode($titre,ENT_COMPAT,'utf-8');
       // récup des mots clés d'index
       if (preg_match('#<em class="firstterm"[^>]*>([^<]+)</em[^>]*>#si', $contenu, $matches)) {
@@ -252,6 +255,7 @@ if ($handle = opendir($dir)) {
       $corps = strip_tags($corps);
       $corps = preg_replace('#\s+#',' ',$corps);
       $corps = html_entity_decode($corps,ENT_COMPAT,'utf-8');
+
       // préparation de la requête...
       $query = "INSERT INTO pages (url, version, titre, tags1, tags2, contenu) VALUES (
                '".pg_escape_string($file)."',


### PR DESCRIPTION
Correction de la balise `<?` pour `<?php`. La balise courte étant déconseillée : http://php.net/manual/fr/language.basic-syntax.phptags.php

Remplacement de `ereg_replace` par `preg_replace`. `ereg_replace` étant dépréciée : http://php.net/manual/fr/function.ereg-replace.php