### PR TITLE
Ajustement fonction classement

### DIFF
--- a/www-docs.postgresql.fr/search.php
+++ b/www-docs.postgresql.fr/search.php
@@ -197,13 +197,13 @@ $searchstring = preg_replace('/[\s\!\&\|]+$/', '', $searchstring);
 ## Remove unnecessary quotes around everything
 $searchstring = preg_replace('/^[\'"](.*)[\'"]$/', "$1", $searchstring);
 
-$query = "SELECT version, url, titre, ts_headline(contenu, q) AS resume, to_char(ts_rank(fti, q)*100, '999.99') AS score
-FROM pages, to_tsquery('".pg_escape_string($searchstring)."') AS q
+$query = "SELECT version, url, titre, ts_headline(contenu, q) AS resume, to_char(ts_rank_cd(fti, q,4)*100, '999.99') AS score
+FROM pages, to_tsquery('french','".pg_escape_string($searchstring)."') AS q
 WHERE fti @@ q ";
 if (array_key_exists($filtreversion, $version)) {
   $query .= "AND version=".pg_escape_string($filtreversion)." ";
 }
-$query .= "ORDER BY ts_rank(fti, q) DESC, version DESC
+$query .= "ORDER BY ts_rank_cd(fti, q,4) DESC, version DESC
 LIMIT 100";
 $result = pg_query($pgconn, $query);
 


### PR DESCRIPTION
Utilisation de la fonction `ts_rank_cd` avec le flag 4. On prend en compte la distance entre les mots.

Cela mérite quelques tests. Par exemple en effectuant la recherche `recherche plein texte`. Le premier résultat est "Fonctions et opérateurs de la recherche plein texte", en utilisant la fonction `ts_rank_cd` on obtient la page "Recherche plein texte" 👍 
`ts_rank` :
![ts_rank](https://user-images.githubusercontent.com/6862220/27997798-05cccd58-6500-11e7-8c7f-1b9e39c798b1.png)

`ts_rank_cd` :
![ts_rank_cd](https://user-images.githubusercontent.com/6862220/27997797-05c8fd04-6500-11e7-8910-470d022bf612.png)

Petite correction pour préciser la configuration Full Text Search à la fonction `to_tsquery`.
