### PR TITLE
Traduction de la moyenne harmonique

### DIFF
--- a/postgresql/textsearch.xml
+++ b/postgresql/textsearch.xml
@@ -1159,7 +1159,7 @@ SELECT phraseto_tsquery('english', 'The Fat &amp; Rats:C');
      </listitem>
      <listitem>
       <para>
-       4 divise le score par "mean harmonic distance between extents"
+       4 divise le score par la moyenne harmonique de la distance entre les mots
        (ceci est implémenté seulement par <function>ts_rank_cd</function>)
       </para>
      </listitem>


### PR DESCRIPTION
Voici une correction pour le terme "mean harmonic". Celui-ci a une vraie signification qui correspond à la [Moyenne Harmonique](https://fr.wikipedia.org/wiki/Moyenne_harmonique).