### PR TITLE
Relecture perform.xml partie sur stats étendues

### DIFF
--- a/postgresql/perform.xml
+++ b/postgresql/perform.xml
@@ -78,7 +78,7 @@
     supplémentaires au-dessus des n&oelig;uds de parcours pour réaliser ces
     opérations. Encore une fois, il existe plus d'une façon de réaliser ces
     opérations, donc différents types de n&oelig;uds peuvent aussi apparaître
-    ici.  La sortie
+    ici. La sortie
     d'<command>EXPLAIN</command> comprend une ligne pour chaque n&oelig;ud dans
     l'arbre du plan, montrant le type de n&oelig;ud basique avec les estimations
     de coût que le planificateur a fait pour l'exécution de ce n&oelig;ud du
@@ -209,7 +209,7 @@ EXPLAIN UPDATE parent SET f2 = f2 + 1 WHERE f1 = 101;
    <para>
     Le <literal>Temps de planification (Planning time)</literal> affiché est
     le temps qu'il a fallu pour générer le plan d'exécution de la requête
-    analysée et pour l'optimiser.  Cela n'inclue pas le temps de réécriture
+    analysée et pour l'optimiser. Cela n'inclue pas le temps de réécriture
     ni le temps d'analyse.
    </para>
 
@@ -231,7 +231,7 @@ EXPLAIN UPDATE parent SET f2 = f2 + 1 WHERE f1 = 101;
     vous trouverez que <classname>tenk1</classname> a 358 pages disque et 10000
     lignes. Le coût estimé est calculé avec (nombre de pages lues *
     <xref linkend="guc-seq-page-cost"/>) + (lignes parcourues *
-    <xref linkend="guc-cpu-tuple-cost"/>).  Par défaut,
+    <xref linkend="guc-cpu-tuple-cost"/>). Par défaut,
     <varname>seq_page_cost</varname> vaut 1.0 et <varname>cpu_tuple_cost</varname>
     vaut 0.01. Donc le coût estimé est de (358 * 1.0) + (10000 * 0.01),
     soit 458.
@@ -323,7 +323,7 @@ EXPLAIN UPDATE parent SET f2 = f2 + 1 WHERE f1 = 101;
 
    <para>
     Dans certains cas, le planificateur préfèrera un plan <quote>simple</quote> de
-    d'index :
+    d'index&nbsp;:
 
 <screen>
 EXPLAIN SELECT * FROM tenk1 WHERE unique1 = 42;
@@ -424,7 +424,7 @@ WHERE t1.unique1 &lt; 10 AND t1.unique2 = t2.unique2;
     car la même clause <literal>WHERE</literal> <literal>unique1 &lt; 10</literal>
     est appliquée à ce n&oelig;ud.
     La clause <literal>t1.unique2 = t2.unique2</literal> n'a pas encore d'intérêt,
-    elle n'affecte donc pas le nombre de lignes du parcours externe.  Le n&oelig;ud
+    elle n'affecte donc pas le nombre de lignes du parcours externe. Le n&oelig;ud
     de jointure en boucle imbriquée s'exécutera sur le deuxième n&oelig;ud, ou
     n&oelig;ud <quote>interne</quote>, pour chaque ligne obtenue du n&oelig;ud externe.
     Les valeurs de colonne de la ligne externe courante peuvent être utilisées
@@ -523,7 +523,7 @@ WHERE t1.unique1 &lt; 100 AND t1.unique2 = t2.unique2;
    sondée pour faire correspondre chaque ligne. Notez encore une fois
    comment l'indentation reflète la structure du plan&nbsp;: le parcours d'index
    bitmap sur <literal>tenk1</literal> est l'entrée du n&oelig;ud de hachage,
-   qui construit la table de hachage.  C'est alors retourné au n&oelig;ud
+   qui construit la table de hachage. C'est alors retourné au n&oelig;ud
    de jointure de hachage, qui lit les lignes depuis le plan du fils externe
    et cherche dans la table de hachage pour chaque ligne.
    </para>
@@ -813,7 +813,7 @@ ROLLBACK;
     Comme vous pouvez le voir dans cet exemple, quand la requête contient une commande
     <command>INSERT</command>, <command>UPDATE</command> ou <command>DELETE</command>
     l'application des changements est fait au niveau du n&oelig;ud principal
-    Insert, Update ou Delete du plan.  Les n&oelig;uds du plan sous celui-ci
+    Insert, Update ou Delete du plan. Les n&oelig;uds du plan sous celui-ci
     effectuent le travail de recherche des anciennes lignes et/ou le calcul
     des nouvelles données. Ainsi au-dessus, on peut voir les même tris de
     parcours de bitmap déjà vu précédemment, et leur sortie est envoyée
@@ -910,7 +910,7 @@ EXPLAIN ANALYZE SELECT * FROM tenk1 WHERE unique1 &lt; 100 AND unique2 &gt; 9000
     jusqu'à la fin. Mais en réalité le n&oelig;ud Limit arrête la
     récupération des lignes après la seconde, et donc le vrai nombre
     de lignes n'est que de 2 et le temps d'exécution est moins que
-    suggérait le coût estimé.  Ce n'est pas une erreur d'estimation,
+    suggérait le coût estimé. Ce n'est pas une erreur d'estimation,
     juste une contradiction entre la façon dont l'estimation et les
     valeurs réelles sont affichées.
    </para>
@@ -928,9 +928,9 @@ EXPLAIN ANALYZE SELECT * FROM tenk1 WHERE unique1 &lt; 100 AND unique2 &gt; 9000
     De même, si le fils externe (premier fils) contient des lignes avec
     des valeurs de clé dupliquées, le fils externe (second fils) est
     sauvegardé et les lignes correspondant à cette valeur clé sont
-    parcourues de nouveau.  <command>EXPLAIN ANALYZE</command> compte ces
+    parcourues de nouveau. <command>EXPLAIN ANALYZE</command> compte ces
     émissions répétées de même lignes internes comme si elles étaient
-    de vraies lignes supplémentaires.  Quand il y a de nombreux
+    de vraies lignes supplémentaires. Quand il y a de nombreux
     doublons externes, le nombre réel de lignes affiché pour le n&oelig;ud
     de plan du fils interne peut être significativement plus grand que le
     nombre de lignes qu'il y a vraiment dans la relation interne.
@@ -953,7 +953,7 @@ EXPLAIN ANALYZE SELECT * FROM tenk1 WHERE unique1 &lt; 100 AND unique2 &gt; 9000
   </indexterm>
 
   <sect2>
-   <title>Single-Column Statistics</title>
+   <title>Statistiques mono-colonne</title>
 
   <para>
    Comme nous avons vu dans la section précédente, le planificateur de requêtes
@@ -992,7 +992,7 @@ WHERE relname LIKE 'tenk1%';
   <para>
    Pour des raisons d'efficacité, <structfield>reltuples</structfield> et
    <structfield>relpages</structfield> ne sont pas mises à jour en temps réel, et
-   du coup, elles contiennent habituellement des valeurs un peu obsolètes. Elles
+   contiennent alors souvent des valeurs un peu obsolètes. Elles
    sont mises à jour par les commandes <command>VACUUM</command>, <command>ANALYZE</command>
    et quelques commandes DDL comme <command>CREATE INDEX</command>.
    Une opération <command>VACUUM</command>
@@ -1001,7 +1001,7 @@ WHERE relname LIKE 'tenk1%';
    la valeur de <structfield>reltuples</structfield> sur la base de la partie
    de la table qu'elle a parcouru, résultant en une valeur approximative.
    Dans tous les cas, le planificateur mettra à l'échelle
-   les valeurs qu'il aura trouver dans <structname>pg_class</structname> pour
+   les valeurs qu'il aura trouvées dans <structname>pg_class</structname> pour
    correspondre à la taille physique de la table, obtenant ainsi une
    approximation plus proche de la réalité.
   </para>
@@ -1020,8 +1020,8 @@ WHERE relname LIKE 'tenk1%';
    le catalogue système <link
    linkend="catalog-pg-statistic"><structname>pg_statistic</structname></link>.
    Les entrées de <structname>pg_statistic</structname> sont mises à jour par
-   les commandes <command>ANALYZE</command> et <command>VACUUM ANALYZE</command> et sont
-   toujours approximatives même si elles ont été mises à jour récemment.
+   les commandes <command>ANALYZE</command> et <command>VACUUM ANALYZE</command>
+   et sont toujours approximatives même si elles ont été mises à jour récemment.
   </para>
 
   <indexterm>
@@ -1030,16 +1030,16 @@ WHERE relname LIKE 'tenk1%';
 
   <para>
    Plutôt que de regarder directement dans
-   <structname>pg_statistic</structname>, il est mieux de visualiser sa vue
+   <structname>pg_statistic</structname>, il vaut mieux voir sa vue
    <link linkend="view-pg-stats"><structname>pg_stats</structname></link>
-   lors de l'examen manuel des statistiques.
+   lors d'un examen manuel des statistiques.
    <structname>pg_stats</structname> est conçu pour être plus facilement
    lisible. De plus, <structname>pg_stats</structname> est lisible par tous
    alors que <structname>pg_statistic</structname> n'est lisible que par un
    superutilisateur (ceci empêche les utilisateurs non privilégiés d'apprendre
    certains choses sur le contenu des tables appartenant à d'autres personnes à
    partir des statistiques. La vue <structname>pg_stats</structname> est restreinte
-   pour afficher seulement les lignes des tables lisibles par l'utilisateur courant).
+   pour n'afficher que les lignes des tables lisibles par l'utilisateur courant).
    Par exemple, nous pourrions lancer&nbsp;:
 
 <screen>SELECT attname, inherited, n_distinct,
@@ -1071,20 +1071,20 @@ WHERE tablename = 'road';
   </para>
 
   <para>
-   Le nombre d'informations stockées dans
+   Les informations stockées dans
    <structname>pg_statistic</structname> par <command>ANALYZE</command>,
    en particulier le nombre maximum
    d'éléments dans les tableaux <structfield>most_common_vals</structfield> et
-   <structfield>histogram_bounds</structfield> pour chaque colonne, peut être initialisé
-   sur une base colonne-par-colonne en utilisant la commande <command>ALTER
+   <structfield>histogram_bounds</structfield> pour chaque colonne, peut être
+   défini colonne par colonne en utilisant la commande <command>ALTER
     TABLE SET STATISTICS</command> ou globalement en initialisant la variable de
    configuration <xref linkend="guc-default-statistics-target"/>. La limite par
-   défaut est actuellement de cent entrées. Augmenter la limite pourrait
+   défaut est actuellement de 100 entrées. Augmenter la limite pourrait
    permettre des estimations plus précises du planificateur, en particulier
    pour les colonnes ayant des distributions de données irrégulières, au prix
    d'un plus grand espace consommé dans <structname>pg_statistic</structname> et
-   en un temps plus long pour calculer les estimations. En revanche, une limite
-   plus basse pourrait être suffisante pour les colonnes à distributions de
+   d'un temps plus long pour calculer les estimations. En revanche, une limite
+   plus basse pourrait être suffisante pour des colonnes avec des distributions de
    données simples.
   </para>
 
@@ -1115,43 +1115,43 @@ WHERE tablename = 'road';
    <para>
     Il est habituel de voire des requêtes lentes tourner avec de mauvais plans
     d'exécution car plusieurs colonnes utilisées dans les clauses de la requête
-    sont corrélées.  L'optimiseur part normalement du principe que toutes les
+    sont corrélées. L'optimiseur part normalement du principe que toutes les
     conditions sont indépendantes les unes des autres, ce qui est faux quand
-    les valeurs des colonnes sont corrélées.  Les statistiques classiques, du
+    les valeurs des colonnes sont corrélées. Les statistiques classiques, du
     fait qu'il s'agit par nature de statistique sur une seule colonne, ne
     peuvent pas capturer d'information sur la corrélation entre colonnes.
-    Toutefois, <productname>PostgreSQL</productname> à la possibilité de
+    Toutefois, <productname>PostgreSQL</productname> a la possibilité de
     calculer des <firstterm>statistiques multivariées</firstterm>, qui peuvent
     capturer une telle information.
    </para>
 
    <para>
     Comme le nombre de combinaisons de colonnes est très important, il n'est
-    pas possible de calculer les statistiques multivariées automatiquement.  À
+    pas possible de calculer les statistiques multivariées automatiquement. À
     la place, des <firstterm>objets statistiques étendus</firstterm>, plus
     souvent appelés simplement <firstterm>objets statistiques</firstterm>,
-    peuvent être crée pour faire savoir au serveur qu'il faut obtenir des
+    peuvent être créés pour indiquer au serveur qu'il faut obtenir des
     statistiques sur un ensemble intéressant de colonnes.
    </para>
 
    <para>
     Les objets statistiques sont crées en utilisant <xref
         linkend="sql-createstatistics"/>, que vous pouvez consulter pour plus
-    de détails.  La création de tels objets crée seulement une entrée dans le
-    catalogue pour exprimer l'intérêt dans cette statistique.  La vraie
+    de détails. La création de tels objets crée seulement une entrée dans le
+    catalogue pour exprimer l'intérêt dans cette statistique. La vraie
     récupération de données est effectuée par <command>ANALYZE</command> (soit
-    une commande manuelle, soit une analyse automatique en tâche de fond).  Les
+    une commande manuelle, soit une analyse automatique en tâche de fond). Les
     valeurs collectées peuvent être examinées dans le catalogue <link
         linkend="catalog-pg-statistic-ext"><structname>pg_statistic_ext</structname></link>.
    </para>
- 
+
    <para>
     <command>ANALYZE</command> calcule des statistiques étendues basées sur le
     même ensemble de lignes de la table qu'il utilise pour calculer les
-    statistiques standard sur une seule colonne.  Puisque la taille
-    d'échantillon peut être augmentée en augmentant la cible de statistique de
-    la table ou de n'importe laquelle de ses colonnes (comme c'est décrit dans
-    la section précédente), une plus grande cible de statistique donnera
+    statistiques standard sur une seule colonne. Puisque la taille
+    d'échantillon peut être augmentée en augmentant la cible de statistiques de
+    la table ou de n'importe laquelle de ses colonnes (comme décrit dans
+    la section précédente), une plus grande cible de statistiques donnera
     normalement des statistiques étendues plus précises, mais nécessitera
     également plus de temps pour les calculer.
    </para>
@@ -1167,18 +1167,18 @@ WHERE tablename = 'road';
     <para>
      Le type le plus simple de statistiques étendues trace les
      <firstterm>dépendances fonctionnelles </firstterm>, un concept utilisé
-     dans les définitions des formes normales des bases de données.  On dit qu'une colonne
+     dans les définitions des formes normales des bases de données. On dit qu'une colonne
      <structfield>b</structfield> est fonctionnellement dépendante d'une
      colonne <structfield>a</structfield> si la connaissance de la valeur de
      <structfield>a</structfield> est suffisante pour déterminer la valeur de
      <structfield>b</structfield>, et donc qu'il n'existe pas deux lignes ayant
      la même valeur de <structfield>a</structfield> mais avec des valeurs
-     différentes de <structfield>b</structfield>.  Dans une base de données
+     différentes de <structfield>b</structfield>. Dans une base de données
      complètement normalisée, les dépendances fonctionnelles ne devraient
-     exister que sur la clé primaire et les superclés.  Toutefois, dans la
+     exister que sur la clé primaire et les superclés. Toutefois, dans la
      pratique beaucoup d'ensembles de données ne sont pas totalement normalisés
-     pour de nombreuses raisons; une dénormalisation intentionnelle pour des
-     raisons de performances est un exemple courant.  Même dans une base de
+     pour de nombreuses raisons&nbsp;; une dénormalisation intentionnelle pour des
+     raisons de performances est un exemple courant. Même dans une base de
      données totalement normalisée, il peut y avoir une corrélation partielle
      entre des colonnes, qui peuvent être exprimées comme une dépendance
      fonctionnelle partielle.
@@ -1186,32 +1186,31 @@ WHERE tablename = 'road';
 
     <para>
      L'existence de dépendances fonctionnelles a un impact direct sur la
-     précision de l'estimation pour certaines requêtes.  Si une requête
+     précision de l'estimation pour certaines requêtes. Si une requête
      contient des conditions à la fois sur des colonnes indépendantes et sur des
      colonnes dépendantes, les conditions sur les colonnes dépendantes ne
-     réduisent plus la taille du résultat; mais sans la connaissance de cette
+     réduisent plus la taille du résultat&nbsp;; mais sans la connaissance de cette
      dépendance fonctionnelle, l'optimiseur de requêtes supposera que les
      conditions sont indépendantes, avec pour résultat une taille de résultat
-     sous estimée.
+     sous-estimée.
     </para>
 
     <para>
      Pour informer l'optimiseur des dépendances fonctionnelles,
      <command>ANALYZE</command> peut collecter des mesures sur des dépendances
-     entre des colonnes.  Évaluer le degré de dépendance entre tous les
+     entre colonnes. Évaluer le degré de dépendance entre tous les
      ensembles de colonnes aurait un coût prohibitif, c'est pourquoi la
      collecte de données est limitée aux groupes de colonnes apparaissant
      ensemble dans un objet statistiques défini avec l'option
-     <literal>dependencies</literal>.  Il est conseillé de ne créer des
-     <literal>dépendences</literal> statistiques que pour les groupes de
-     colonnes qui sont fortement corrélés, pour éviter un surcout à la fois
+     <literal>dependencies</literal>. Il est conseillé de ne créer des
+     <literal>dépendences</literal> statistiques que pour des groupes de
+     colonnes fortement corrélées, pour éviter un surcoût à la fois
      dans <command>ANALYZE</command> et plus tard lors de la planification de
      requête.
     </para>
 
     <para>
-     Voici un exemple de collecte de statistiques fonctionnellement dépendantes
-     :
+     Voici un exemple de collecte de statistiques fonctionnellement dépendantes&nbsp;:
 <programlisting>
 CREATE STATISTICS stts (dependencies) ON zip, city FROM zipcodes;
 
@@ -1220,7 +1219,7 @@ ANALYZE zipcodes;
 SELECT stxname, stxkeys, stxdependencies
   FROM pg_statistic_ext
   WHERE stxname = 'stts';
- stxname | stxkeys |             stxdependencies               
+ stxname | stxkeys |             stxdependencies
 ---------+---------+------------------------------------------
  stts    | 1 5     | {"1 => 5": 1.000000, "5 => 1": 0.423130}
 (1 row)
@@ -1245,7 +1244,7 @@ SELECT stxname, stxkeys, stxdependencies
      <para>
       Les dépendances fonctionnelles sont pour le moment uniquement appliquées
       pour les conditions sur une simple égalité entre une colonne et une
-      valeur constante.  Elles ne sont pas utilisées pour améliorer
+      valeur constante. Elles ne sont pas utilisées pour améliorer
       l'estimation sur les conditions d'égalité entre deux colonnes ou la
       comparaison d'une colonne avec une expression, ni pour les clauses
       d'intervalle, <literal>LIKE</literal> ou tout autre type de condition.
@@ -1254,28 +1253,29 @@ SELECT stxname, stxkeys, stxdependencies
      <para>
       Lors d'une estimation avec des dépendances fonctionnelles, l'optimiseur
       part du principe que les conditions sur les colonnes impliquées sont
-      compatibles et donc redondantes.  Si elles sont incompatibles,
+      compatibles et donc redondantes. Si elles sont incompatibles,
       l'estimation correcte devrait être zéro ligne, mais cette possibilité
-      n'est pas envisagée.  Par exemple, une requête telle que
+      n'est pas envisagée. Par exemple, dans une requête telle que
 <programlisting>
 SELECT * FROM zipcodes WHERE city = 'San Francisco' AND zip = '94105';
 </programlisting>
       l'optimiseur négligera la clause <structfield>city</structfield>
-      puisqu'elle ne changera pas la sélectivité, ce qui est correct.  Par
+      puisqu'elle ne changera pas la sélectivité, ce qui est correct. Par
       contre, il fera la même supposition pour
 <programlisting>
 SELECT * FROM zipcodes WHERE city = 'San Francisco' AND zip = '90210';
 </programlisting>
-      bien qu'il n'y aura en réalité aucune ligne satisfaisant cette requête.
+      bien qu'il n'y ait en réalité aucune ligne satisfaisant cette requête.
       Toutefois, les statistiques de dépendances fonctionnelles ne fournissent
-      pas suffisamment d'information pour arriver à cette conclusion.
+      pas suffisamment d'information pour en arriver à cette conclusion.
      </para>
 
      <para>
       Pour beaucoup de situations pratiques, cette supposition est généralement
-      correcte; par exemple, il pourrait y avoir une GUI dans l'application qui
+      correcte&nbsp;; par exemple, l'application pourrait contenir une interface
+      graphique qui
       n'autorise que la sélection de villes et code postaux compatibles pour
-      l'utilisation dans une requête.  Mais si ce n'est pas le cas, les
+      l'utilisation dans une requête. Mais si ce n'est pas le cas, les
       dépendances fonctionnelles pourraient ne pas être une solution viable.
      </para>
     </sect4>
@@ -1286,7 +1286,7 @@ SELECT * FROM zipcodes WHERE city = 'San Francisco' AND zip = '90210';
 
     <para>
      Les statistiques sur une seule colonne stockent le nombre de valeurs
-     distinctes pour chaque colonne.  Les estimations du nombre de valeurs
+     distinctes pour chaque colonne. Les estimations du nombre de valeurs
      distinctes combinant plus d'une colonne (par exemple, pour
      <literal>GROUP BY a, b</literal>) sont souvent fausses quand l'optimiseur
      ne dispose que de données statistiques par colonne, avec pour conséquence
@@ -1295,18 +1295,18 @@ SELECT * FROM zipcodes WHERE city = 'San Francisco' AND zip = '90210';
 
     <para>
      Afin d'améliorer de telles estimations, <command>ANALYZE</command> peut
-     collecter des statistiques n-distinct pour des groupes de colonne.  Comme
-     précédemment, ce n'est pas envisageable de le faire pour toutes les
-     regroupements de colonnes possibles, ainsi les données ne sont collectées
-     que pour les groupes de colonnes apparaissant ensemble dans un objet
-     statistiques défini avec l'option <literal>ndistinct</literal>.  Des
+     collecter des statistiques n-distinct pour des groupes de colonne. Comme
+     précédemment, il n'est pas envisageable de le faire pour tous les
+     regroupements possibles, ainsi les données ne sont collectées
+     que pour ceux apparaissant ensemble dans un objet
+     statistiques défini avec l'option <literal>ndistinct</literal>. Des
      données seront collectées pour chaque combinaison possible de deux
      colonnes ou plus dans l'ensemble de colonnes listées.
     </para>
 
     <para>
      En continuant avec l'exemple précédent, le nombre n-distinct dans une
-     table de code postaux pourrait ressember à ceci :
+     table de code postaux pourrait ressember à ceci&nbsp;:
 <programlisting>
 CREATE STATISTICS stts2 (ndistinct) ON zip, state, city FROM zipcodes;
 
@@ -1321,20 +1321,20 @@ nd | {"1, 2": 33178, "1, 5": 33178, "2, 5": 27435, "1, 2, 5": 33178}
 (1 row)
 </programlisting>
      Cela indique qu'il y a trois combinaisons de colonnes qui ont 33178
-     valeurs distincte : le code postal et l'état; le code postal et la
+     valeurs distincte&nbsp;: le code postal et l'état; le code postal et la
      ville; et le code postal, la ville et l'état (le fait qu'ils soient tous
      égaux est attendu puisque que le code postal seul est unique dans cette
-     table).  D'un autre côté, la combinaison de la ville et de l'état n'a que
+     table). D'un autre côté, la combinaison de la ville et de l'état n'a que
      27435 valeurs distinctes.
     </para>
 
     <para>
      Il est conseillé de créer des objets statistiques
      <literal>ndistinct</literal> uniquement sur les combinaisons de colonnes
-     qui sont réellement utilisées pour des regroupement, et pour lesquelles
+     réellement utilisées pour des regroupement, et pour lesquelles
      les mauvaises estimations du nombre de groupe a pour conséquence de
-     mauvais plans.  Sinon, le temps passé par <command>ANALYZE</command> est
-     uniquement gâché.
+     mauvais plans. Sinon le temps consommé par <command>ANALYZE</command>
+     serait gaspillé.
     </para>
    </sect3>
   </sect2>
@@ -1909,7 +1909,7 @@ WHERE quelquechosedautre;</programlisting>
 
      <listitem>
       <para>
-       Désactiver <xref linkend="guc-synchronous-commit"/>&nbsp;;  il n'est pas
+       Désactiver <xref linkend="guc-synchronous-commit"/>&nbsp;; il n'est pas
        forcément nécessaire d'écrire les journaux de transactions
        <acronym>WAL</acronym> à chaque validation de transaction. Ce
        paramètre  engendre un risque de perte de transactions (mais pas de


### PR DESCRIPTION
Relecture de la partie sur les statistiques étendues. 
Correction de quelques fautes, tentative d'allègement de formulations. 
Une traduction de titre oubliée.
Ajouté des &nbsp; et viré des double espaces après un point qui sont un américanisme (même si je ne pense que le HTML final affiche une différence).