### PR TITLE
Relecture planstat.xml

### DIFF
--- a/postgresql/planstats.xml
+++ b/postgresql/planstats.xml
@@ -20,7 +20,7 @@
  <para>
   Le but de ce chapitre n'est pas de documenter le code en détail mais plutôt
   de présenter un aperçu du
-  fonctionnement. Ceci aidera peut-être la phase d'apprentissage pour quelqu'un
+  fonctionnement. Ceci facilitera peut-être l'apprentissage de quelqu'un
   souhaitant lire le code.
  </para>
 
@@ -33,9 +33,9 @@
   </indexterm>
 
   <para>
-   Les exemples montrés ci-dessous utilisent les tables de la base de tests de
+   Les exemples ci-dessous utilisent les tables de la base des tests de
    régression de <productname>PostgreSQL</productname>. Les affichages indiqués
-   sont pris depuis la version 8.3. Le comportement des versions précédentes
+   sont issus de la version 8.3. Le comportement des versions précédentes
    (ou ultérieures) pourraient varier. Notez aussi que, comme
    <command>ANALYZE</command> utilise un échantillonage statistique lors de
    la réalisation des statistiques, les résultats peuvent changer légèrement
@@ -64,13 +64,13 @@
 ----------+-----------
       358 |     10000
    </programlisting>
-   Ces nombres sont corrects à partir du dernier <command>VACUUM</command> ou
+   Ces nombres sont corrects à la date du dernier <command>VACUUM</command> ou
    <command>ANALYZE</command> sur la table. Le planificateur récupère
-   ensuite le nombre de pages actuel dans la table (c'est une opération peu
-   coûteuse, ne nécessitant pas un parcours de table). Si c'est différent de
+   ensuite le nombre de pages réel courant dans la table (c'est une opération peu
+   coûteuse, ne nécessitant pas un parcours de table). S'il diffère de
    <structfield>relpages</structfield>, alors
-   <structfield>reltuples</structfield> est modifié en accord pour arriver à
-   une estimation actuelle du nombre de lignes. Dans cet exemple, la valeur de
+   <structfield>reltuples</structfield> est modifié en proportion pour arriver à
+   une estimation actualisée du nombre de lignes. Dans cet exemple, la valeur de
    <structfield>relpages</structfield> est mise à jour, donc l'estimation
    du nombre de lignes est identique à
    <structfield>reltuples</structfield>.
@@ -91,10 +91,10 @@
    </programlisting>
 
    Le planificateur examine la condition de la clause <literal>WHERE</literal>
-   et cherche la fonction de sélectivité à partir de l'opérateur
-   <literal>&lt;</literal> dans <structname>pg_operator</structname>. C'est
-   contenu dans la colonne <structfield>oprrest</structfield> et le résultat,
-   dans ce cas, est <function>scalarltsel</function>. La fonction
+   et cherche la fonction de sélectivité pour l'opérateur
+   <literal>&lt;</literal> dans <structname>pg_operator</structname>. Il est
+   contenu dans la colonne <structfield>oprrest</structfield> et le résultat
+   est ici <function>scalarltsel</function>. La fonction
    <function>scalarltsel</function> récupère l'histogramme pour
    <structfield>unique1</structfield> à partir de
    <classname>pg_statistic</classname>. Pour les requêtes manuelles, il est
@@ -131,7 +131,7 @@ WHERE tablename='tenk1' AND attname='unique1';
 
    <programlisting>rows = rel_cardinality * selectivity
      = 10000 * 0.100697
-     = 1007  (rounding off)
+     = 1007  (arrondi)
    </programlisting>
 
   </para>
@@ -197,10 +197,10 @@ most_common_freqs | {0.00333333,0.003,0.003,0.003,0.003,0.003,0.003,0.003,0.003,
    Filter: (stringu1 = 'xxx'::name)
    </programlisting>
 
-   C'est un problème assez différent, comment estimer la sélectivité quand la
+   C'est un problème assez différent&nbsp;: comment estimer la sélectivité quand la
    valeur n'est <emphasis>pas</emphasis> dans la liste <acronym>MCV</acronym>.
    L'approche est d'utiliser le fait que la valeur n'est pas dans la liste,
-   combinée avec la connaissance des fréquences pour tout les
+   combinée avec la connaissance des fréquences pour tous les
    <acronym>MCV</acronym>&nbsp;:
 
    <programlisting>
@@ -228,20 +228,20 @@ rows = 10000 * 0.0014559
    sur-simplification de ce que <function>scalarltsel</function> faisait
    réellement&nbsp;; maintenant que nous avons vu un exemple de l'utilisation
    des MCV, nous pouvons ajouter quelques détails supplémentaires. L'exemple
-   était correct aussi loin qu'il a été car, comme
+   jusque là était correct&nbsp;: comme
    <structfield>unique1</structfield> est une colonne unique, elle n'a pas de
-   MCV (évidemment, n'avoir aucune valeur n'est pas plus courant que toute
-   autre valeur). Pour une colonne non unique, il y a normalement un histogramme
+   MCV (évidemment, aucune valeur n'y est plus commune qu'une autre).
+   Pour une colonne non unique, il y a normalement un histogramme
    et une liste MCV, et <emphasis>l'histogramme n'inclut pas la portion de la
-    population de colonne représentée par les MCV</emphasis>. Nous le faisons
+    population de la colonne représentée par les MCV</emphasis>. Nous le faisons
    ainsi parce que cela permet une estimation plus précise. Dans cette
    situation, <function>scalarltsel</function> s'applique directement à la
    condition (c'est-à-dire <quote>&lt; 1000</quote>) pour chaque valeur de la
    liste MCV, et ajoute les fréquence des MCV pour lesquelles la condition
    est vérifiée. Ceci donne une estimation exacte de la sélectivité dans la
-   portion de la table qui est MCV. L'histogramme est ensuite utilisée de la
+   portion de la table qui est MCV. L'histogramme est ensuite utilisé de la
    même façon que ci-dessus pour estimer la sélectivité dans la portion de la
-   table qui n'est pas MCV, et ensuite les deux nombres sont combinées pour
+   table qui n'est pas MCV, et ensuite les deux nombres sont combinés pour
    estimer la sélectivité. Par exemple, considérez
 
    <programlisting>
@@ -276,12 +276,12 @@ selectivity = sum(relevant mvfs)
             = 0.01833333
    </programlisting>
 
-   Additionner toutes les MFC nous indique aussi que la fraction totale de
-   la population représentée par les MCV est de 0.03033333, et du coup la
+   Additionner toutes les MCF nous indique aussi que la fraction totale de
+   la population représentée par les MCV est de 0.03033333, et donc la
    fraction représentée par l'histogramme est de 0.96966667 (encore une fois,
    il n'y a pas de NULL, sinon nous devrions les exclure ici). Nous pouvons
-   voir que la valeur <literal>IAAAAA</literal> tombe près de la fin du
-   troisième jeton d'histogramme. En utilisant un peu de suggestions sur la
+   voir que la valeur <literal>IAAAAA</literal> tombe près de la fin de la
+   troisième partie de l'histogramme. En utilisant un peu de suggestions sur la
    fréquence des caractères différents, le planificateur arrive à
    l'estimation 0.298387 pour la portion de la population de l'histogramme
    qui est moindre que <literal>IAAAAA</literal>. Ensuite nous combinons les
@@ -293,14 +293,14 @@ selectivity = mcv_selectivity + histogram_selectivity * histogram_fraction
             = 0.307669
 
 rows        = 10000 * 0.307669
-            = 3077  (rounding off)
+            = 3077  (arrondi)
    </programlisting>
 
    Dans cet exemple particulier, la correction à partir de la liste MCV est
-   très petit car la distribution de la colonne est réellement assez plat
+   très petite car la distribution de la colonne est réellement assez plate
    (les statistiques affichant ces valeurs particulières comme étant plus
-   communes que les autres sont principalement dûes à une erreur
-   d'échantillonage). Dans un cas plus typique où certaines valeurs sont
+   communes que les autres sont principalement un artefact
+   de l'échantillonage). Dans un cas plus typique où certaines valeurs sont
    significativement plus communes que les autres, ce processus compliqué
    donne une amélioration utile dans la précision car la sélectivité pour les
    valeurs les plus communes est trouvée exactement.
@@ -335,7 +335,7 @@ rows        = 10000 * 0.0001466
             = 1  (rounding off)
    </programlisting>
 
-   Notez que le nombre de lignes estimé être renvoyées à partir bitmap
+   Notez que le nombre de lignes estimé en retour du bitmap
    index scan reflète seulement la condition utilisée avec l'index&nbsp;; c'est
    important car cela affecte l'estimation du coût pour les récupérations
    suivantes sur la table.
@@ -371,7 +371,7 @@ WHERE t1.unique1 &lt; 50 AND t1.unique2 = t2.unique2;
             = 0.005035
 
 rows        = 10000 * 0.005035
-            = 50  (rounding off)
+            = 50  (arrondi)
    </programlisting>
 
    La restriction pour la jointure est <literal>t2.unique2 =
@@ -393,21 +393,21 @@ tablename  | null_frac | n_distinct | most_common_vals
  tenk2     |         0 |         -1 |
    </programlisting>
 
-   Dans ce cas, il n'y a pas d'information <acronym>MCV</acronym> pour
+   Dans cet exemple il n'y a pas d'information <acronym>MCV</acronym> pour
    <structfield>unique2</structfield> parce que toutes les valeurs semblent
-   être unique, donc nous utilisons un algorithme qui relie seulement le
-   nombre de valeurs distinctes pour les deux relations ensembles avec leur
-   fractions NULL&nbsp;:
+   uniques, donc nous utilisons un algorithme qui utilise seulement le
+   nombre de valeurs distinctes pour les deux relations ainsi que leurs
+   fractions de NULL&nbsp;:
 
    <programlisting>selectivity = (1 - null_frac1) * (1 - null_frac2) * min(1/num_distinct1, 1/num_distinct2)
             = (1 - 0) * (1 - 0) / max(10000, 10000)
             = 0.0001
    </programlisting>
 
-   C'est-à-dire, soustraire la fraction NULL pour chacune des relations, et
-   divisez par le maximum du nombre de valeurs distinctes. Le nombre de
-   lignes que la jointure pourrait émettre est calculé comme la cardinalité du
-   produit cartésien de deux inputs, multiplié par la sélectivité&nbsp;:
+   C'est-à-dire&nbsp; soustraire la fraction NULL de 1 pour chaque relation, et
+   diviser par le maximum du nombre de valeurs distinctes. Le nombre de
+   lignes que la jointure est supposée émettre est calculé comme la cardinalité
+   du produit cartésien de deux inputs, multiplié par la sélectivité&nbsp;:
 
    <programlisting>
 rows = (outer_cardinality * inner_cardinality) * selectivity
@@ -420,22 +420,22 @@ rows = (outer_cardinality * inner_cardinality) * selectivity
    S'il y avait eu des listes MCV pour les deux colonnes,
    <function>eqjoinsel</function> aurait utilisé une comparaison directe des
    listes MCV pour déterminer la sélectivité de jointure à l'intérieur de la
-   aprtie des populations de colonne représentées par les MCV. L'estimation
+   partie des populations de colonne représentées par les MCV. L'estimation
    pour le reste des populations suit la même approche affichée ici.
   </para>
 
   <para>
-   Notez que nous montrons <literal>inner_cardinality</literal> comme 10000,
+   Notez que nous afrfichons <literal>inner_cardinality</literal> à 10000,
    c'est-à-dire la taille non modifiée de <structname>tenk2</structname>. Il
    pourrait apparaître en inspectant l'affichage <command>EXPLAIN</command>
-   que l'estimation des lignes jointes vient de 50 * 1, c'est-à-dire que le
+   que l'estimation des lignes jointes vient de 50 * 1, c'est-à-dire le
    nombre de lignes externes multiplié par le nombre estimé de lignes obtenu
    par chaque parcours d'index interne sur <structname>tenk2</structname>.
    Mais ce n'est pas le cas&nbsp;: la taille de la relation jointe est
    estimée avant tout plan de jointure particulier considéré. Si tout
    fonctionne si bien, alors les deux façons d'estimer la taille de la jointure
    produiront la même réponse mais, à cause de l'erreur d'arrondi et d'autres
-   facteurs, ils divergent quelque fois significativement.
+   facteurs, ils divergent parfois significativement.
   </para>
 
   <para>
@@ -462,9 +462,9 @@ rows = (outer_cardinality * inner_cardinality) * selectivity
    <title>Dépendances fonctionnelles</title>
 
    <para>
-    La corrélation multivariée peut être démontrée avec un jeu de test très
+    La corrélation multivariée peut être montrée avec un jeu de test très
     simple &mdash; une table avec deux colonnes, chacune contenant les même
-    valeurs :
+    valeurs&nbsp;:
 
 <programlisting>
 CREATE TABLE t (a INT, b INT);
@@ -474,7 +474,7 @@ ANALYZE t;
 
     Comme expliqué dans <xref linkend="planner-stats"/>, l'optimiseur peut
     déterminer la cardinalité de <structname>t</structname> en utilisant le
-    nombre de pages et de lignes obtenues dans
+    nombre de pages et de lignes obtenus dans
     <structname>pg_class</structname> :
 
 <programlisting>
@@ -485,35 +485,35 @@ SELECT relpages, reltuples FROM pg_class WHERE relname = 't';
        45 |     10000
 </programlisting>
 
-    La distribution des données est très simple; il n'y a que 100 valeurs
+    La distribution des données est très simple&nbsp;; il n'y a que 100 valeurs
     différentes dans chaque colonne, distribuées de manière uniforme.
    </para>
 
    <para>
-    L'exemple suivant montre le résultat de l'estimation d'une conditino
-    <literal>WHERE</literal> sur la colonne <structfield>a</structfield> :
+    L'exemple suivant montre le résultat de l'estimation d'une condition
+    <literal>WHERE</literal> sur la colonne <structfield>a</structfield>&nbsp;:
 
 <programlisting>
 EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1;
-                                 QUERY PLAN                                  
+                                 QUERY PLAN
 -------------------------------------------------------------------------------
  Seq Scan on t  (cost=0.00..170.00 rows=100 width=8) (actual rows=100 loops=1)
    Filter: (a = 1)
    Rows Removed by Filter: 9900
 </programlisting>
 
-    L'optimiseur examine la condtion et détermine que la sélectivité de cette
-    clause est d' 1%.  En comparant cette estimation avec le nombre de ligne
-    réelle, on voit que l'estimaation est très précise (elle est en fait exact,
-    car la table est très petite).  En changeant la clause
+    L'optimiseur examine la condition et détermine que la sélectivité de cette
+    clause est de 1 %. En comparant cette estimation avec le nombre de lignes
+    réelle, on voit que l'estimation est très précise (et même exacte,
+    car la table est très petite). En changeant la clause
     <literal>WHERE</literal> pour utiliser la colonne
-    <structfield>b</structfield>, un plan identique est généré.  Mais observons
+    <structfield>b</structfield>, un plan identique est généré. Mais observons
     ce qui arrive si nous appliquons la même condition sur chacune des
     colonnes, en les combinant avec <literal>AND</literal> :
 
 <programlisting>
 EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
-                                 QUERY PLAN                                  
+                                 QUERY PLAN
 -----------------------------------------------------------------------------
  Seq Scan on t  (cost=0.00..195.00 rows=1 width=8) (actual rows=100 loops=1)
    Filter: ((a = 1) AND (b = 1))
@@ -521,24 +521,24 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
 </programlisting>
 
     L'optimiseur estime la sélectivité pour chaque condition individuellement,
-    en arrivant à la même estimation d'1% comme au dessus.  Puis il part du
-    principe que les conditions sont indépendantes, et multiple donc leurs
+    en arrivant à la même estimation d'1 % comme ci-dessus. Puis il part du
+    principe que les conditions sont indépendantes, et multiplie donc leurs
     sélectivité, produisant une estimation de sélectivité finale d'uniquement
-    0.01%.  C'est une sous estimation importante, puisque le nombre réel de
-    lignes correspondant aux conditions (100) est d'un ordre de grandeur deux
-    fois plus haut.
+    0.01 %. C'est une sous-estimation importante, puisque le nombre réel de
+    lignes correspondant aux conditions (100) est plus élevé de deux ordres
+    de grandeur.
    </para>
 
    <para>
-    Ce problème peut être corrigé en créant un objet statistiques qui demandera
-    à <command>ANALYZE</command> de calculer des statistiques multivariée de
-    dépendances fonctionnelles sur les deux colonnes :
+    Ce problème peut être corrigé en créant un objet statistique qui demandera
+    à <command>ANALYZE</command> de calculer des statistiques multivariées de
+    dépendances fonctionnelles sur les deux colonnes&nbsp;:
 
 <programlisting>
 CREATE STATISTICS stts (dependencies) ON a, b FROM t;
 ANALYZE t;
 EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
-                                  QUERY PLAN                                   
+                                  QUERY PLAN
 -------------------------------------------------------------------------------
  Seq Scan on t  (cost=0.00..195.00 rows=100 width=8) (actual rows=100 loops=1)
    Filter: ((a = 1) AND (b = 1))
@@ -553,23 +553,24 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT * FROM t WHERE a = 1 AND b = 1;
    <para>
     Un problème similaire apparaît avec l'estimation de la cardinalité d'un
     ensemble de plusieurs colonnes, tel que le nombre de groupes qu'une clause
-    <command>GROUP BY</command> générerait.  Quand <command>GROUP BY</command>
+    <command>GROUP BY</command> générerait. Quand <command>GROUP BY</command>
     liste une seule colonne, l'estimation n-distinct (qui est visible comme le
-    nombre de lignes estimé par le nœud HashAggregate) est très précis :
+    nombre de lignes estimé par le n&oelig;ud HashAggregate) est très
+    précise&nbsp;:
 <programlisting>
 EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a;
-                                       QUERY PLAN                                        
+                                       QUERY PLAN
 -----------------------------------------------------------------------------------------
  HashAggregate  (cost=195.00..196.00 rows=100 width=12) (actual rows=100 loops=1)
    Group Key: a
    -&gt;  Seq Scan on t  (cost=0.00..145.00 rows=10000 width=4) (actual rows=10000 loops=1)
 </programlisting>
-    Mais sans statistiques multivariées, l'estimation du nombre de groupe dans
-    une requête ayant deux colonnes dans le <command>GROUP BY</command>, comme
+    Mais sans statistiques multivariées, l'estimation du nombre de groupes dans
+    une requête ayant deux colonnes dans un <command>GROUP BY</command>, comme
     dans l'exemple suivant, est faux d'un ordre de grandeur :
 <programlisting>
 EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
-                                       QUERY PLAN                                        
+                                       QUERY PLAN
 --------------------------------------------------------------------------------------------
  HashAggregate  (cost=220.00..230.00 rows=1000 width=16) (actual rows=100 loops=1)
    Group Key: a, b
@@ -582,14 +583,14 @@ DROP STATISTICS stts;
 CREATE STATISTICS stts (dependencies, ndistinct) ON a, b FROM t;
 ANALYZE t;
 EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
-                                       QUERY PLAN                                        
+                                       QUERY PLAN
 --------------------------------------------------------------------------------------------
  HashAggregate  (cost=220.00..221.00 rows=100 width=16) (actual rows=100 loops=1)
    Group Key: a, b
    -&gt;  Seq Scan on t  (cost=0.00..145.00 rows=10000 width=8) (actual rows=10000 loops=1)
 </programlisting>
    </para>
- 
+
   </sect2>
  </sect1>
 
@@ -598,8 +599,8 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
 
   <para>
    L'accès à la table <structname>pg_statistic</structname> est restreint aux
-   superutilisateurs pour que les autres utilisateurs ne puissent apprendre le
-   contenu des tables des autres utilisateurs. Certaines fonctions
+   superutilisateurs pour que les autres utilisateurs ne puissent rien
+   apprendre du contenu des tables des autres utilisateurs. Certaines fonctions
    d'estimation de la sélectivité utiliseront un opérateur fourni par
    l'utilisateur (soit l'opérateur apparaissant dans la requête, soit un
    opérateur lié) pour analyser les statistiques enregistrées. Par exemple,
@@ -608,7 +609,7 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
    pour comparer la constante de la requête avec la valeur enregistrée. De ce
    fait, la donnée dans <structname>pg_statistic</structname> est
    potentielement fournie aux opérateurs définis par l'utilisateur. Un
-   opérateur créé de façon approprié peut intentionnellement donner les
+   opérateur créé de façon approprié peut intentionnellement révéler les
    opérandes fournis (par exemple en les enregistrant ou en les écrivant dans
    une table différente) ou en les exposant par erreur en affichant leur
    valeurs dans des messages d'erreur, auxquels cas il pourrait exposer les
@@ -635,12 +636,13 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
    l'utilisateur est en train de lire une vue avec une barrière de sécurité,
    alors le planificateur pourrait souhaiter de vérifier les statistiques de
    la table sous-jacente qui n'est normalement pas accessible par
-   l'utilisateur. Dans ce cas, l'opérateur devra être sans fuite. Dans le cas
-   contraire, les statistiques ne seront pas utilisées. Il n'y a pas de retour
-   direct sur cela, en dehors du fait que le plan pourrait être non optimal.
-   Si un utilisateur suspecte que cela lui arrive, il pourrait exécuter la
-   requête avec un utilisateur disposant de plus de droits pour voir si cela
-   cause la génération d'un autre plan.
+   l'utilisateur. Dans ce cas, l'opérateur devra être
+   <literal>LEAKPROOF</literal>. Dans le cas contraire, les statistiques ne
+   seront pas utilisées. Il n'y a pas d'information explicite sur cela,
+   en dehors du fait que le plan pourrait être non optimal.
+   Si on suspecte que cela arrive, on peut tenter d'exécuter la
+   requête avec un utilisateur disposant de plus de droits pour voir si
+   un autre plan est généré.
   </para>
 
   <para>
@@ -649,7 +651,7 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
    plusieurs valeurs de <structname>pg_statistic</structname>. De ce fait, le
    planificateur a l'autorisation d'utiliser des informations statistiques
    génériques, telles que la fraction de valeurs nulles ou le nombre de
-   valeurs distinctes dans une colonne, quelque soit les droits d'accès.
+   valeurs distinctes dans une colonne, quels que soient les droits d'accès.
   </para>
 
   <para>

--- a/postgresql/planstats.xml
+++ b/postgresql/planstats.xml
@@ -425,7 +425,7 @@ rows = (outer_cardinality * inner_cardinality) * selectivity
   </para>
 
   <para>
-   Notez que nous afrfichons <literal>inner_cardinality</literal> à 10000,
+   Notez que nous affichons <literal>inner_cardinality</literal> à 10000,
    c'est-à-dire la taille non modifiée de <structname>tenk2</structname>. Il
    pourrait apparaître en inspectant l'affichage <command>EXPLAIN</command>
    que l'estimation des lignes jointes vient de 50 * 1, c'est-à-dire le


### PR DESCRIPTION
Typos, quelques fautes de frappe, espaces doubles, espaces insécables.
Tentatives d'allègement de formulation
Un ou deux faux sens corrigés.