### PR TITLE
Corrections mineures sur libpq

### DIFF
--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -224,7 +224,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
        il est pris pour une chaîne <parameter>conninfo</parameter> exactement
        de la même façon que si elle était passée à
        <function>PQconnectdb</function>, et le reste des paramètres est
-       ensuite appliqué as specified for <function>PQconnectdbParams</function>.
+       ensuite appliqué comme spécifié dans <function>PQconnectdbParams</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -301,7 +301,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
          <listitem>
           <para>
            Les paramètres <literal>hostaddr</literal> et <literal>host</literal> sont utilisés de
-           façon appropriée pour vous assurer que la requête de nom et la requête
+           façon appropriée pour vous assurer que la résolution de nom et la résolution
            inverse ne soient pas lancées. Voir la documentation de ces paramètres avec
            <function>PQconnectdbParams</function> ci-dessus pour les détails.
           </para>
@@ -454,9 +454,11 @@ PGconn *PQconnectdbParams(const char * const *keywords,
 
        <para>
         Notez que, bien que ces constantes resteront (pour maintenir une
-        compatibilité), une application ne devrait jamais se baser sur un ordre
-        pour celles-ci ou sur tout ou sur le fait que le statut fait partie de ces
-        valeurs documentés. Une application pourrait faire quelque chose comme
+        compatibilité), une application ne devrait jamais se baser sur
+        l'apparition de ces états dans un ordre particulier, ou leur survenance
+        tout court, ou sur le fait que le statut fait partie de ces valeurs
+        documentées.
+        Une application pourrait faire quelque chose comme
         ça&nbsp;:
         <programlisting>switch(PQstatus(conn))
 {


### PR DESCRIPTION
- "as specified" => "comme spécifié"

- "requête de nom" => "résolution de nom"

- légère reformulation dans la remarque sur les états intermédiaires
  lors de l'établissement de connexion.