### PR TITLE
Relecture psql-ref.xml

### DIFF
--- a/postgresql/plpython.xml
+++ b/postgresql/plpython.xml
@@ -181,7 +181,7 @@
    basé sur Python 3 dans la même session car les symbôles dans les modules
    dynamiques entreraient en conflit, ce qui pourrait résulter en des arrêts
    brutaux du processus serveur PostgreSQL. Une vérification est ajoutée pour
-   empêcher ce mélange de versions majeures Python dans une même sessio. Cette
+   empêcher ce mélange de versions majeures Python dans une même session. Cette
    vérification aura pour effet d'annuler la session si une différence est
    détectée. Néanmoins, il est possible d'utiliser les deux variantes de
    PL/Python dans une même base de données à condition que ce soit dans des

--- a/postgresql/ref/psql-ref.xml
+++ b/postgresql/ref/psql-ref.xml
@@ -113,8 +113,8 @@
        fait, vous ne pouvez pas mixer les commandes <acronym>SQL</acronym> et les
        métacommandes <application>psql</application> dans une option
        <option>-c</option>. Pour ce faire, vous pouvez utiliser plusieurs
-       options <option>-c</option> ou envoyer la chaîne par un
-       <foreignphrase>pipe</foreignphrase> dans
+       options <option>-c</option> ou envoyer la chaîne par un tube
+       (<foreignphrase>pipe</foreignphrase>) dans
        <application>psql</application>, par exemple&nbsp;:
 <programlisting>
 psql -c '\x' -c 'SELECT * FROM foo;'
@@ -230,8 +230,8 @@ EOF
       Si <replaceable>nomfichier</replaceable> est un <literal>-</literal>
       (tiret), alors l'entrée standard est lue jusqu'à la détection d'une fin
       de fichier ou de la métacommande <command>\q</command>. Ceci peut être
-      utilisé pour intercaler une saisie interactive entre l'entrée depuis
-      plusieurs fichiers. Néanmoins,
+      utilisé pour intercaler une saisie interactive entre des entrées depuis
+      des fichiers. Néanmoins,
       notez que Readline n'est pas utilisé dans ce cas (un peu comme si
       <option>-n</option> a été précisé).
      </para>
@@ -1239,7 +1239,7 @@ basetest=&gt;
         dont les noms commencent par le motif sont affichés.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
        </para>
       </listitem>
      </varlistentry>
@@ -1285,7 +1285,7 @@ basetest=&gt;
         conversions dont le nom correspond au motif sont listées.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
         Si <literal>+</literal> est ajouté au nom de la commande, chaque objet
         est listé avec sa description associée.
        </para>
@@ -1316,7 +1316,7 @@ basetest=&gt;
         Affiche les descriptions des objets du type <literal>contrainte</literal>,
         <literal>classe d'opérateur</literal>, <literal>famille d'opérateur</literal>,
         <literal>règle</literal> et <literal>trigger</literal>. Tous les autres
-        commentaires peuvent être visualisés avec les commandes antislashs
+        commentaires peuvent être visualisés avec les commandes antislash
         respectives pour ces types d'objets.
        </para>
 
@@ -1327,11 +1327,11 @@ basetest=&gt;
         une description sont listés.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
        </para>
 
        <para>
-        Les descriptions des objets peuvent être ajoutées avec la commande
+        Les descriptions des objets peuvent être créées avec la commande
         <acronym>SQL</acronym> <xref linkend="sql-comment"/>.
        </para>
       </listitem>
@@ -1347,7 +1347,7 @@ basetest=&gt;
         domaines dont le nom correspond au motif sont affichés.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
         Si <literal>+</literal> est ajouté au nom de la commande, chaque objet
         est listé avec sa description associée.
        </para>
@@ -1369,8 +1369,8 @@ basetest=&gt;
 
        <para>
         La commande <xref linkend="sql-alterdefaultprivileges"/> sert à positionner
-        les privilèges d'accès par défaut. Le sens de l'affichage
-        des privilèges est expliqué à la page de
+        les privilèges d'accès par défaut. La signification de l'affichage
+        des privilèges est expliquée à la page de
         <xref linkend="sql-grant"/>.
        </para>
       </listitem>
@@ -1402,24 +1402,10 @@ basetest=&gt;
         seuls les objets dont les noms correspondent au motif sont listés.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
        </para>
       </listitem>
      </varlistentry>
-
-
-     <varlistentry>
-      <term><literal>\det[+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">motif</replaceable></link> ]</literal></term>
-      <listitem>
-       <para>
-        Liste les tables distantes (mnémotechnique&nbsp;: <quote>tables externes</quote>).
-        Si un <replaceable class="parameter">motif</replaceable> est fourni, seules les entrées
-        concernant les tables ou les schémas en correspondance seront listées. Si vous utilisez la
-        forme <literal>\det+</literal>, les options génériques et la description de la table distante seront également affichées.
-       </para>
-      </listitem>
-     </varlistentry>
-
 
      <varlistentry>
       <term><literal>\des[+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">motif</replaceable></link> ]</literal></term>
@@ -1430,12 +1416,24 @@ basetest=&gt;
         Si <replaceable class="parameter">motif</replaceable> est
         spécifié, seuls les serveurs dont le nom correspond au motif sont
         affichés. Si la forme <literal>\des+</literal> est utilisée, une description
-        complète de chaque serveur est affichée, incluant la liste de contrôle
+        complète de chaque serveur est affichée, incluant liste de contrôle
         d'accès du serveur (ACL), type, version, options et description.
        </para>
       </listitem>
      </varlistentry>
 
+
+    <varlistentry>
+       <term><literal>\det[+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">motif</replaceable></link> ]</literal></term>
+       <listitem>
+        <para>
+         Liste les tables distantes (mnémotechnique&nbsp;: <quote>tables externes</quote>).
+         Si un <replaceable class="parameter">motif</replaceable> est fourni, seules les entrées
+         concernant les tables ou les schémas en correspondance seront listées. Si vous utilisez la
+         forme <literal>\det+</literal>, les options génériques et la description de la table distante seront également affichées.
+        </para>
+       </listitem>
+    </varlistentry>
 
      <varlistentry>
       <term><literal>\deu[+] [ <link linkend="app-psql-patterns"><replaceable class="parameter">motif</replaceable></link> ]</literal></term>
@@ -1482,7 +1480,7 @@ basetest=&gt;
       <listitem>
        <para>
         Liste les fonctions, ainsi que leurs types de données pour le résultat, leurs
-        types de données pour les arguments et leurs
+        types de données pour les arguments et les
         types de fonctions, qui sont classés comme <quote>agg</quote> (agrégat),
         <quote>normal</quote>, <quote>trigger</quote>, or <quote>window</quote>.
         Afin de n'afficher que les fonctions d'un type spécifié,
@@ -1493,7 +1491,7 @@ basetest=&gt;
         affichées.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
         Si la forme <literal>\df+</literal> est utilisée, des informations
         supplémentaires sur chaque fonction sont affichées, incluant la
         volatibilité, le parallélisme, le propriétaire, la classification en
@@ -1552,8 +1550,8 @@ basetest=&gt;
         seuls les analyseurs dont le nom correspond au motif seront
         affichés. Si la forme <literal>\dFp+</literal> est utilisée, une
         description complète de chaque analyseur est affichée,
-        ceci incluant les fonctions sous-jacentes et les types de jeton
-        reconnu.
+        ceci incluant les fonctions sous-jacentes et la liste des types de jeton
+        reconnus.
        </para>
       </listitem>
      </varlistentry>
@@ -1579,12 +1577,12 @@ basetest=&gt;
       <listitem>
        <para>
         Liste les rôles des bases de données.
-        (Comme les concepts des <quote>utilisateurs</quote> et <quote>groupes</quote>
+        (Comme les concepts d'<quote>utilisateurs</quote> et <quote>groupes</quote>
         ont été unifiés dans les <quote>rôles</quote>, cette commande est
         maintenant équivalente à <literal>\du</literal>.)
-        Par défaut, seuls les rôles créés par des utilisateurs sont affichés.
-        Ajoutez le modificateur <literal>S</literal> pour inclure les rôles
-        systèmes. Si <replaceable
+        Par défaut, seuls les rôles créés par des utilisateurs sont affichés&nbsp;;
+        ajoutez le modificateur <literal>S</literal> pour inclure les rôles
+        système. Si <replaceable
         class="parameter">motif</replaceable> est spécifié, seuls les rôles
         dont le nom correspond au motif sont listés.
         Si la forme <literal>\dg+</literal> est utilisée, des informations
@@ -1600,7 +1598,7 @@ basetest=&gt;
       <listitem>
        <para>
         Ceci est un alias pour <command>\lo_list</command>, qui affiche une
-        liste des objets larges.
+        liste des Large Objects.
        </para>
       </listitem>
      </varlistentry>
@@ -1614,7 +1612,7 @@ basetest=&gt;
         Si un <replaceable class="parameter">motif</replaceable> est spécifié,
         seuls les langages dont les noms correspondent au motif sont listés.
         Par défaut, seuls les langages créés par les utilisateurs sont affichés&nbsp;; il faut
-        spécifier l'option <literal>S</literal> pour inclure les objets systèmes.
+        spécifier l'option <literal>S</literal> pour inclure les objets système.
         Si <literal>+</literal> est ajouté à la fin de la commande, chaque
         langage sera affiché avec ses gestionnaire d'appels, validateur, droits
         d'accès, et ce même s'il s'agit d'un objet système.
@@ -1628,13 +1626,13 @@ basetest=&gt;
 
       <listitem>
        <para>
-        Liste les schémas. Si <replaceable
+        Liste les schémas (espaces de noms). Si <replaceable
         class="parameter">motif</replaceable> est
         spécifié, seuls les schémas dont le nom correspond au motif sont
         listés.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
         Si <literal>+</literal> est ajouté à la fin de la commande, chaque
         objet sera affiché avec ses droits et son éventuelle description.
        </para>
@@ -1647,13 +1645,13 @@ basetest=&gt;
         ]</literal></term>
       <listitem>
        <para>
-        Liste les opérateurs avec leur opérande et type en
-        retour. Si <replaceable class="parameter">motif</replaceable> est
+        Liste les opérateurs avec les types de leur opérande et résultat.
+        Si <replaceable class="parameter">motif</replaceable> est
         spécifié, seuls les opérateurs dont le nom correspond au motif sont
         listés.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
         Si <literal>+</literal> est ajouté au nom de la commande, des
         informations supplémentaire sur chaque opérateur est affiché,
         actuellement uniquement le nom de la fonction sous-jacente.
@@ -1670,8 +1668,8 @@ basetest=&gt;
         Si <replaceable class="parameter">motif</replaceable> est
         spécifié, seuls les collationnements dont le nom correspond au
         motif sont listés. Par défaut, seuls les objets créés par les utilisateurs
-        sont affichés, fournissez un motif ou le modificateur <literal>S</literal>
-        pour afficher les objets systèmes. Si <literal>+</literal> est ajouté à la fin
+        sont affichés&nbsp;; fournissez un motif ou le modificateur <literal>S</literal>
+        pour afficher les objets système. Si <literal>+</literal> est ajouté à la fin
         de la commande, chacun des collationnements sera affiché avec son éventuelle
         description.
         Notez que seuls les collationnements compatibles avec l'encodage de la base de
@@ -1712,9 +1710,10 @@ basetest=&gt;
         être spécifiques à un rôle, spécifiques à une base, ou les deux.
         <replaceable>role-pattern</replaceable> et
         <replaceable>database-pattern</replaceable> servent à choisir sur quels rôles
-        spécifiques ou quelles bases de données - respectivement - les paramètres sont listés. Si ces options sont
+        spécifiques ou quelles bases de données les paramètres sont listés. Si ces options sont
         omises, ou si on spécifie <literal>*</literal>, tous les paramètres sont listés, y
-        compris ceux qui ne sont pas spécifiques à un rôle ou à une base, respectivement.
+        compris ceux qui ne sont pas spécifiques, respectivement, à un rôle ou
+        une base.
        </para>
 
        <para>
@@ -1760,11 +1759,12 @@ basetest=&gt;
         Si <replaceable class="parameter">motif</replaceable> est
         spécifié, seuls les types dont le nom correspond au motif sont
         affichés. Si <literal>+</literal> est ajouté à la fin de la commande,
-        chaque type est listé avec son nom interne et sa taille, ainsi que ses
-        valeurs autorisées si c'est un type <type>enum</type>.
+        chaque type est listé avec son nom interne et sa taille, ses
+        valeurs autorisées si c'est un type <type>enum</type>, et ses permissions
+        associées.
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
        </para>
       </listitem>
      </varlistentry>
@@ -1780,7 +1780,7 @@ basetest=&gt;
         <literal>\dg</literal>.)
         Par défaut, seuls les rôles créés par des utilisateurs sont affichés.
         Ajoutez le modificateur <literal>S</literal> pour inclure les rôles
-        systèmes.
+        système.
         Si <replaceable class="parameter">motif</replaceable> est indiqué,
         seuls les rôles dont le nom correspond au motif sont listés. Si la
         forme <literal>\du+</literal> est utilisée, des informations
@@ -1826,15 +1826,15 @@ basetest=&gt;
         spécifié, le fichier est édité&nbsp;; en quittant l'éditeur, le contenu
         du fichier est recopié dans le tampon de requête. Si aucun paramètre <replaceable class="parameter">nomfichier</replaceable>
         n'est fourni, le tampon de requête courant est copié dans un fichier
-        temporaire et édité à l'identique.  Sinon, si le tampon actuel de
+        temporaire qui édité de la même manière. Ou bien, si le tampon actuel de
         requête est vide, la dernière requête exécutée est copiée vers un
-        fichier temporaire et éditée de manière similaire.
+        fichier temporaire et éditée de la même manière.
        </para>
 
        <para>
         Le nouveau tampon de requête est ensuite ré-analysé suivant les règles
         habituelles de <application>psql</application>, où le tampon complet est
-        traité comme une seule ligne. Chaque requête complète est exécutée
+        traité comme une seule ligne. Toute requête complète est exécutée
         immédiatemment&nbsp;; c'est-à-dire que si le tampon de requête contient ou se
         termine par un point-virgule, tout ce qui précède est exécuté. Tout ce
         qui reste attendra dans le tampon de requête&nbsp;; en tapant point-virgule
@@ -1842,7 +1842,7 @@ basetest=&gt;
         <literal>\r</literal> annulera en effaçant le tampon de requête.
         Traiter le buffer comme une ligne unique affecte principalement les
         métacommandes&nbsp;: tout ce qui se trouve dans le tampon après une
-        métacommande sera pris en tant qu'argument de la métacommande, même
+        métacommande sera pris en tant qu'argument(s) de la métacommande, même
         si cela s'étend	sur plusieurs lignes (du coup, vous ne pouvez pas faire
         de scripts de cette façon. Utilisez <command>\i</command> pour cela).
        </para>
@@ -1855,18 +1855,10 @@ basetest=&gt;
         considère qu'il s'agit d'un numéro de ligne, et non pas un nom de fichier.
        </para>
 
-       <para>
-        Contrairement à la majorité des autres métacommandes, l'intégralité du
-        reste de la ligne est toujours pris en compte en tant qu'arguments
-        de <command>\ef</command>, et ni l'interpolation des variables ni la
-        substitution par guillemets inverses ne seront effectuées sur les
-        arguments.
-       </para>
-
        <tip>
         <para>
          Voir dans <xref linkend="app-psql-environment"
-         endterm="app-psql-environment-title"/> la façon de configurer
+         endterm="app-psql-environment-title"/> comment configurer
          et personnaliser votre éditeur.
         </para>
        </tip>
@@ -1879,8 +1871,8 @@ basetest=&gt;
         class="parameter">texte</replaceable> [ ... ]</literal></term>
       <listitem>
        <para>
-        Affiche les arguments sur la sortie standard séparés par un espace et
-        suivi par une nouvelle ligne. Ceci peut être utile pour intégrer des
+        Affiche les arguments sur la sortie standard, séparés par un espace et
+        suivis par une nouvelle ligne. Ceci peut être utile pour intégrer des
         informations sur la sortie des scripts. Par exemple&nbsp;:
         <programlisting>=&gt; <userinput>\echo `date`</userinput>
 Tue Oct 26 21:40:57 CEST 1999
@@ -1892,7 +1884,7 @@ Tue Oct 26 21:40:57 CEST 1999
        <tip>
         <para>
          Si vous utilisez la commande <command>\o</command> pour rediriger la
-         sortie de la requête, vous pourriez souhaiter utiliser
+         sortie de la requête, vous pouvez aussi utiliser
          <command>\qecho</command> au lieu de cette commande.
         </para>
        </tip>
@@ -1906,10 +1898,10 @@ Tue Oct 26 21:40:57 CEST 1999
       <listitem>
        <para>
         Cette commande récupère et édite la définition de la fonction
-        désignée au moyen d'une commande <command>CREATE OR REPLACE
+        désignée sous la forme d'une commande <command>CREATE OR REPLACE
          FUNCTION</command>.
         L'édition est faite de la même façon que pour <literal>\edit</literal>.
-        Après que l'éditeur se soit fermé, la commande mise à jour attend
+        Une fois l'éditeur fermé, la commande mise à jour attend
         dans le tampon de requête&nbsp;; tapez <literal>;</literal> ou
         <literal>\g</literal> pour l'envoyer, ou <literal>\r</literal> pour
         l'annuler.
@@ -1931,8 +1923,16 @@ Tue Oct 26 21:40:57 CEST 1999
         Si vous indiquez un numéro de ligne,
         <application>psql</application> positionnera le curseur sur
         cette ligne dans le corps de la fonction. (Notez que le corps
-        de la fonction ne commence pas sur la première ligne du
+        de la fonction, typiquement, ne commence pas sur la première ligne du
         fichier.)
+       </para>
+
+       <para>
+        Contrairement à la plupart des autres métacommandes, l'intégralité du
+        reste de la ligne est toujours pris en compte en tant qu'argument(s)
+        de <command>\ef</command>, et ni l'interpolation des variables ni la
+        substitution par guillemets inverses ne seront effectuées sur les
+        arguments.
        </para>
 
        <tip>
@@ -1977,7 +1977,7 @@ Tue Oct 26 21:40:57 CEST 1999
 
       <listitem>
        <para>
-        Cette commande récupère et édite la définition de la vue nommée, sous
+        Cette commande récupère et édite la définition de la vue désignée, sous
         la forme d'une commande <command>CREATE OR REPLACE VIEW</command>.
         L'édition se termine de la même façon que pour
         <literal>\edit</literal>. Après avoir quitté l'éditeur, la commande
@@ -2031,26 +2031,27 @@ Tue Oct 26 21:40:57 CEST 1999
 	Envoie le tampon de requête en entrée vers le serveur et stocke en
 	option la sortie de la requête dans
 	<replaceable class="parameter">nomfichier</replaceable>
-	ou envoie dans un tube la sortie vers un autre shell exécutant
+	ou envoie dans un tube (<foreignphrase>pipe</foreignphrase>)
+    la sortie vers un autre shell exécutant
 	<replaceable class="parameter">commande</replaceable> au lieu de
 	l'exécuter comme habituellement. Le fichier ou la commande
-	est écrite seulement si la requête renvoit zéro ou plus
-	d'enregistrements, mais pas si la requête échoue ou s'il s'agit d'une
+	n'est écrit que si la requête renvoit zéro ou plus
+	enregistrements, mais pas si la requête échoue ou s'il s'agit d'une
 	commande SQL ne renvoyant pas de données.
        </para>
        <para>
 	Si le tampon de la requête est vide, la dernière requête envoyée est
 	ré-exécutée à la place. En dehors de cette exception, <literal>\g</literal>
-	sans arguments est essentiellement équivalent à un point-virgule.
-        Un <literal>\g</literal> avec argument est une alternative en <quote>un
-         coup</quote> à la commande <command>\o</command>.
+	sans argument est essentiellement équivalent à un point-virgule.
+        Un <literal>\g</literal> avec argument est une alternative ponctuelle
+        à la commande <command>\o</command>.
        </para>
         <para>
 	Si l'argument débute par <literal>|</literal>, alors l'intégralité du
 	reste de la ligne est pris en tant que
 	<replaceable class="parameter">commande</replaceable> à exécuter
 	et ni l'interpolation des variables ni la substitution par guillemets
-	inverses ne seront effectuées. Le reste de la ligne est simplement
+	inverses n'y sont effectuées. Le reste de la ligne est simplement
 	passé littéralement au shell.
         </para>
         </listitem>
@@ -2063,7 +2064,8 @@ Tue Oct 26 21:40:57 CEST 1999
       <listitem>
        <para>
         Envoie le tampon de requête actuel au serveur, puis traite chaque
-        colonne de chaque ligne du résultat de la requête comme une requête à
+        colonne de chaque ligne du résultat de la requête (s'il y en a)
+        comme une requête à
         exécuter. Par exemple, pour créer un index sur chaque colonne de
         <structname>ma_table</structname>&nbsp;:
 <programlisting>
@@ -2080,14 +2082,14 @@ CREATE INDEX
        </para>
 
        <para>
-        Les requêtes générées sont exécutées dans l'ordre des lignes qui sont
-        renvoyés, et de gauche à droite sur chaque ligne s'il y a plus d'une
+        Les requêtes générées sont exécutées dans l'ordre dans lequel lignes sont
+        renvoyées, et de gauche à droite sur chaque ligne s'il y a plus d'une
         colonne. Les champs NULL sont ignorés. Les requêtes générées sont
         envoyées litéralement au serveur pour traitement, donc elles ne
         peuvent pas être des métacommandes <application>psql</application> ni
         contenir des références de variables <application>psql</application>.
         Si une requête individuelle échoue, l'exécution des requêtes suivantes
-        continue sauf si <varname>ON_ERROR_STOP</varname> est configuré.
+        continue, sauf si <varname>ON_ERROR_STOP</varname> est configuré.
         L'exécution de chaque requête est sujette au traitement de
         <varname>ECHO</varname>. (Configurer <varname>ECHO</varname> à
         <literal>all</literal> ou à <literal>queries</literal> est souvent
@@ -2165,7 +2167,7 @@ bonjour 10
         <replaceable class="parameter">commande</replaceable> ]</literal></term>
       <listitem>
        <para>
-        Donne la syntaxe sur la commande <acronym>SQL</acronym> spécifiée. Si
+        Fournit la syntaxe sur la commande <acronym>SQL</acronym> spécifiée. Si
         <replaceable class="parameter">commande</replaceable> n'est pas
         spécifiée, alors <application>psql</application> liste toutes les
         commandes pour lesquelles une aide en ligne est disponible. Si
@@ -2175,8 +2177,8 @@ bonjour 10
        </para>
 
         <para>
-	 Contrairement à la majorité des autres métacommandes, l'intégralité du
-	 reste de la ligne est toujours pris en compte en tant qu'arguments
+	 Contrairement à la plupart des autres métacommandes, l'intégralité du
+	 reste de la ligne est toujours pris en compte en tant qu'argument(s)
 	 de <command>\help</command>, et ni l'interpolation des variables ni la
 	 substitution par guillemets inverses ne seront effectuées sur les
 	 arguments.
@@ -2199,9 +2201,9 @@ bonjour 10
        <para>
         Active le format d'affichage <acronym>HTML</acronym> des requêtes. Si
         le format <acronym>HTML</acronym> est déjà activé, il est basculé au
-        format d'affichage défaut (texte aligné). Cette commande est pour la compatibilité
-        mais voir <command>\pset</command> pour configurer les autres options
-        d'affichage.
+        format d'affichage défaut (texte aligné). Cette commande existe pour
+        la compatibilité et la praticité, mais voyez <command>\pset</command>
+        pour configurer les autres options d'affichage.
        </para>
       </listitem>
      </varlistentry>
@@ -2218,9 +2220,9 @@ bonjour 10
        </para>
        <para>
         Si <replaceable>nomfichier</replaceable> est <literal>-</literal>
-        (tiret), l'entrée standard est lu jusqu'à arriver à la fin de fichier
-        ou à la métacommande <command>\q</command>. Ceci peut être utilisé
-        pour intégrer des entrées interactives avec des entrées de fichiers.
+        (tiret), l'entrée standard est lue jusqu'à une indication EOF
+        ou la métacommande <command>\q</command>. Ceci peut être utilisé
+        pour intercaler des entrées interactives entre des entrées de fichiers.
         Notez que le comportement de Readline ne sera activé que s'il est
         actif au niveau supérieur.
        </para>
@@ -2394,14 +2396,14 @@ SELECT
 
       <listitem>
        <para>
-        Stocke le fichier dans un objet large
+        Stocke le fichier dans un Large Object
         <productname>PostgreSQL</productname>. En option, il associe le
         commentaire donné avec l'objet. Exemple&nbsp;:
         <programlisting>foo=&gt; <userinput>\lo_import '/home/peter/pictures/photo.xcf' 'une
 photo de moi'</userinput>
 lo_import 152801
         </programlisting>
-        La réponse indique que l'objet large a reçu l'ID 152801, qui peut être
+        La réponse indique que le Large Object a reçu l'ID 152801, qui peut être
         utilisé pour accéder de nouveau à l'objet créé. Pour une meilleure
         lisibilité, il est recommandé de toujours associer un commentaire
         compréhensible par un humain avec chaque objet. Les OID et les
@@ -2421,7 +2423,7 @@ lo_import 152801
       <term><literal>\lo_list</literal></term>
       <listitem>
        <para>
-        Affiche une liste de tous les objets larges
+        Affiche une liste de tous les Large Objects
         <productname>PostgreSQL</productname> actuellement stockés dans la base
         de données, avec tous les commentaires fournis par eux.
        </para>
@@ -2433,7 +2435,7 @@ lo_import 152801
 
       <listitem>
        <para>
-        Supprime l'objet large d'<acronym>OID</acronym>
+        Supprime le Large Object d'<acronym>OID</acronym>
         <replaceable class="parameter">loid</replaceable> de la base
         de données.
        </para>
@@ -2441,7 +2443,7 @@ lo_import 152801
        <tip>
         <para>
          Utilisez <command>\lo_list</command> pour trouver
-         l'<acronym>OID</acronym> d'un objet large.
+         l'<acronym>OID</acronym> d'un Large Object.
         </para>
        </tip>
       </listitem>
@@ -2479,7 +2481,7 @@ lo_import 152801
 
        <tip>
         <para>
-         Pour intégrer du texte entre les résultats de requête, utilisez
+         Pour intercaler du texte entre des résultats de requête, utilisez
          <command>\qecho</command>.
         </para>
        </tip>
@@ -2507,7 +2509,7 @@ lo_import 152801
         le chiffre et l'envoie au serveur avec la commande <command>ALTER
          ROLE</command>. Ceci vous assure que le nouveau mot de passe n'apparaît
         pas en clair dans l'historique de la commande, les traces du serveur
-        ou encore ailleurs.
+        ou ailleurs.
        </para>
       </listitem>
      </varlistentry>
@@ -2537,8 +2539,8 @@ lo_import 152801
 
       <listitem>
        <para>
-        Cette commande initialise les options affectant l'affichage des tables
-        résultat de la requête. <replaceable
+        Cette commande initialise les options affectant l'affichage des tableaux
+        de résultat de requête. <replaceable
         class="parameter">option</replaceable> décrit l'option à initialiser.
         La sémantique de <replaceable class="parameter">valeur</replaceable> varie en fonction de
         l'option sélectionnée. Pour certaines options, omettre <replaceable
@@ -2562,8 +2564,8 @@ lo_import 152801
            <para>
             Le <replaceable class="parameter">valeur</replaceable> doit être
             un nombre. En général, plus grand est ce nombre, plus les tables
-            ont de bordure et de ligne mais ceci dépend du format. Dans le
-            format <acronym>HTML</acronym>, cela se traduire directement en un
+            ont de bordures et de lignes mais ceci dépend du format. Dans le
+            format <acronym>HTML</acronym>, cela se traduira directement en un
             attribut <literal>border=...</literal>. Dans la plupart des autres
             formats, seules les valeurs 0 (sans bordure), 1 (lignes interne de
             séparation) et 2 (cadre du tableau) ont un sens, et les valeurs
@@ -2587,9 +2589,10 @@ lo_import 152801
             Si l'option est positionnée à zéro (la valeur par défaut), la largeur de la colonne est contrôlée
             soit par la variable d'environnement <envar>COLUMNS</envar>, soit par la largeur d'écran détectée si
             <envar>COLUMNS</envar> n'est pas positionnée.
-            De plus, si <literal>columns</literal> vaut zero, alors le format
+            De plus, si <literal>columns</literal> vaut zéro, alors le format
             <literal>wrapped</literal> affecte seulement la sortie écran.
-            Si <literal>columns</literal> ne vaut pas zéro, alors les sorties fichier et tubes (pipe) font
+            Si <literal>columns</literal> ne vaut pas zéro, alors les sorties
+            fichier et tubes (<foreignphrase>pipes</foreignphrase>) font
             l'objet de retours à la ligne
             à cette largeur également.
            </para>
@@ -2651,7 +2654,7 @@ lo_import 152801
            <para>
             Si le paramètre <replaceable class="parameter">valeur</replaceable> est précisé, il doit valoir soit
             <literal>on</literal>, soit <literal>off</literal>, ce qui a pour effet d'activer
-            ou de désactiver l'affichage du pied de table (le compte&nbsp;: <literal>(<replaceable>n</replaceable> rows)</literal>).
+            ou de désactiver l'affichage du pied de tableau (le compte&nbsp;: <literal>(<replaceable>n</replaceable> rows)</literal>).
             Si le paramètre <replaceable class="parameter">valeur</replaceable> est omis, la commande bascule entre
             l'affichage du pied de table ou sa désactivation.
            </para>
@@ -2667,8 +2670,7 @@ lo_import 152801
             <literal>asciidoc</literal>, <literal>latex</literal> (utilise <literal>tabular</literal>),
             <literal>latex-longtable</literal> ou
             <literal>troff-ms</literal>.
-            Les
-            abréviations uniques sont autorisées. (ce qui signifie qu'une lettre
+            Les abréviations uniques sont autorisées. (Cela signifie qu'une lettre
             est suffisante.)
            </para>
 
@@ -2686,7 +2688,7 @@ lo_import 152801
            <para>
             Le format <literal>wrapped</literal> est comme <literal>aligned</literal>, sauf qu'il retourne à
             la ligne dans les données de grande taille afin que la sortie tienne dans la largeur
-            de colonne cible. La largeur cible est déterminée comme cela est décrit à l'option
+            de colonne cible. La largeur cible est déterminée comme décrit à l'option
             <literal>columns</literal>. Notez que <application>psql</application> n'essaie pas de revenir à la ligne dans
             les titres de colonnes. Par conséquent, si la largeur totale nécessaire pour le titre
             de colonne est plus grande que la largeur cible, le format
@@ -2696,8 +2698,8 @@ lo_import 152801
            <para>
             Les formats <literal>html</literal>, <literal>asciidoc</literal>, <literal>latex</literal>,
             <literal>latex-longtable</literal> et <literal>troff-ms</literal>
-            produisent des tables destinées à être inclues dans des documents
-            utilisant le langage de marques respectif. Ce ne sont pas des
+            produisent des tableaux destinées à être inclus dans des documents
+            utilisant les langages de balisage respectifs. Ce ne sont pas des
             documents complets&nbsp;! Ce n'est pas forcément nécessaire en
             <acronym>HTML</acronym> mais en <application>LaTeX</application>,
             vous devez avoir une structure de document complet.
@@ -2716,7 +2718,8 @@ lo_import 152801
             Positionne le style des lignes de bordure sur
             <literal>ascii</literal>, <literal>old-ascii</literal>
             <literal>unicode</literal>.
-            Les abréviations uniques sont autorisées.  (Cela signifie qu'une lettre suffit.)
+            Les abréviations uniques sont autorisées. (Cela signifie qu'une
+            lettre suffit.)
             La valeur par défaut est <literal>ascii</literal>.
             Cette option affecte seulement les formats de sortie
             <literal>aligned</literal> et
@@ -2724,14 +2727,14 @@ lo_import 152801
            </para>
 
            <para>
-            Le style <literal>ascii</literal> utilise les caractères basiques <acronym>ASCII</acronym>
-            .  Les retours à la ligne dans les données sont représentés par un
-            symbole <literal>+</literal> dans la marge de droite.
-            Si le format <literal>wrapped</literal> est sélectionné, un retour chariot est ajouté
-            à l'affichage pour les valeurs dont la taille à l'affichage est trop
-            importante pour tenir dans une cellule de la colonne associée. Un point
-            (<literal>.</literal>) est affiché dans la marge droite de la ligne avant le retour
-            chariot et un autre point est affiché dans la marge gauche de la ligne
+            Le style <literal>ascii</literal> utilise les caractères basiques
+            <acronym>ASCII</acronym>. Les retours à la ligne dans les données
+            sont représentés par un symbole <literal>+</literal> dans la marge
+            de droite.
+            Quand le format <literal>wrapped</literal> déroule les données
+            d'une ligne à l'autre sans caractère retour à la ligne, un point
+            (<literal>.</literal>) est affiché dans la marge droite de la
+            première ligne et à nouveau dans la marge gauche de la ligne
             suivante.
            </para>
 
@@ -2766,9 +2769,9 @@ lo_import 152801
           <listitem>
            <para>
             Positionne la chaîne de caractères à afficher à la place d'une valeur null.
-            Par défaut, rien n'est affiché, ce qui peut facilement être confondu avec une
-            chaîne de caractères vide. Par exemple, vous pouvez préférer afficher <literal>\pset null
-             '(null)'</literal>.
+            Par défaut rien n'est affiché, ce qui peut facilement être confondu avec une
+            chaîne de caractères vide. Par exemple, on peut préférer
+            <literal>\pset null '(null)'</literal>.
            </para>
           </listitem>
          </varlistentry>
@@ -2794,7 +2797,8 @@ lo_import 152801
             Contrôle l'utilisation d'un paginateur pour les requêtes et les
             affichages de l'aide de <application>psql</application>. Si la variable
             d'environnement <envar>PAGER</envar> est configurée, la sortie est
-            envoyée via un tube dans le programme spécifié. Sinon, une valeur par
+            envoyée via un tube (<foreignphrase>pipe</foreignphrase)dans
+            le programme spécifié. Sinon, une valeur par
             défaut dépendant de la plateforme (comme <filename>more</filename>)
             est utilisée.
            </para>
@@ -2802,23 +2806,15 @@ lo_import 152801
            <para>
             Quand l'option <literal>pager</literal> vaut <literal>off</literal>, le paginateur
             n'est pas utilisé. Quand l'option <literal>pager</literal> vaut
-            <literal>on</literal>, et que cela est approprié, c'est à dire quand la sortie est dirigée vers
-            un terminal, et ne tient pas dans l'écran, le paginateur est utilisé.
+            <literal>on</literal>, et que cela est approprié, c'est-à-dire
+            quand la sortie est dirigée vers un terminal et ne tient pas dans
+            l'écran, le paginateur est utilisé.
             L'option <literal>pager</literal> peut également être positionnée à <literal>always</literal>,
             ce qui a pour effet d'utiliser le paginateur pour toutes les sorties terminal,
-            que ces dernières tiennent ou non dans l'écran. <literal>\pset pager</literal>
-            sans préciser <replaceable class="parameter">valeur</replaceable> bascule entre les états "paginateur activé" et "paginateur désactivé".
-           </para>
-          </listitem>
-         </varlistentry>
-
-         <varlistentry>
-          <term><literal>recordsep</literal></term>
-          <listitem>
-           <para>
-            Indique le séparateur d'enregistrement (ligne) à utiliser dans le
-            mode d'affichage non aligné. La valeur par défaut est un caractère de
-            retour chariot.
+            que ces dernières tiennent ou non dans l'écran.
+            <literal>\pset pager</literal>,
+            sans préciser <replaceable class="parameter">valeur</replaceable>,
+            bascule entre les états "paginateur activé" et "paginateur désactivé".
            </para>
           </listitem>
          </varlistentry>
@@ -2829,11 +2825,23 @@ lo_import 152801
            <para>
             Si <literal>pager_min_lines</literal> est configuré à un numéro
             supérieur à la hauteur de page, le programme de pagination ne sera
-            pas appelé sauf s'il y a au moins ce nombre de lignes à afficher.
+            appelé que s'il y a au moins ce nombre de lignes à afficher.
             La configuration par défaut est 0.
            </para>
           </listitem>
          </varlistentry>
+
+          <varlistentry>
+           <term><literal>recordsep</literal></term>
+           <listitem>
+            <para>
+             Indique le séparateur d'enregistrement (ligne) à utiliser dans le
+             mode d'affichage non aligné. La valeur par défaut est un caractère de
+             retour chariot.
+            </para>
+           </listitem>
+          </varlistentry>
+
          <varlistentry>
           <term><literal>recordsep_zero</literal></term>
           <listitem>
@@ -2849,11 +2857,11 @@ lo_import 152801
           <listitem>
            <para>
             Dans le format <acronym>HTML</acronym>, ceci indique les attributs
-            à placer dans la balise <sgmltag>table</sgmltag> tag.  Cela
+            à placer dans la balise <sgmltag>table</sgmltag> tag. Ce
             pourrait être par exemple <literal>cellpadding</literal> ou
             <literal>bgcolor</literal>. Notez que vous ne voulez probablement pas
-            spécifier <literal>border</literal> car c'est pris en compte par
-            <literal>\pset border</literal>. Si <replaceable
+            spécifier <literal>border</literal> puisqu'il est déjà pris en compte
+            par  <literal>\pset border</literal>. Si <replaceable
             class="parameter">valeur</replaceable> n'est pas précisée, aucun
             attribut de table n'est positionné.
            </para>
@@ -2887,12 +2895,13 @@ lo_import 152801
            <para>
             Si <replaceable class="parameter">valeur</replaceable> est spécifiée, elle doit
             valoir soit <literal>on</literal>, soit <literal>off</literal>, ce qui va
-            activer ou désactiver le mode "tuples seulement".
+            activer ou désactiver le mode «&nbsp;tuples seulement&nbsp;».
             Si <replaceable class="parameter">valeur</replaceable> est omise,
-            la commande bascule entre la sortie normale et la sortie "tuples seulement".
+            la commande bascule entre la sortie normale et la sortie
+            «&nbsp;tuples seulement&nbsp;».
             La sortie normale comprend des informations supplémentaires telles que
             les entêtes de colonnes, les titres, et différents pieds. Dans le mode
-            "tuples seulement", seules les données de la table sont affichées.
+            «&nbsp;tuples seulement&nbsp;», seules les données de la table sont affichées.
            </para>
           </listitem>
          </varlistentry>
@@ -2902,8 +2911,8 @@ lo_import 152801
           <listitem>
            <para>
             Configure le style d'affichage de la bordure pour le style de
-            ligne <literal>unicode</literal> à soit <literal>single</literal>
-            soit <literal>double</literal>.
+            ligne <literal>unicode</literal> soit à <literal>single</literal>
+            soit à <literal>double</literal>.
            </para>
           </listitem>
          </varlistentry>
@@ -2913,8 +2922,8 @@ lo_import 152801
           <listitem>
            <para>
             Configure le style d'affichage de la colonne pour le style de
-            ligne <literal>unicode</literal> à soit <literal>single</literal>
-            soit <literal>double</literal>.
+            ligne <literal>unicode</literal> soit à <literal>single</literal>
+            soit à <literal>double</literal>.
            </para>
           </listitem>
          </varlistentry>
@@ -2924,8 +2933,8 @@ lo_import 152801
           <listitem>
            <para>
             Configure le style d'affichage de l'en-tête pour le style de
-            ligne <literal>unicode</literal> à soit <literal>single</literal>
-            soit <literal>double</literal>.
+            ligne <literal>unicode</literal> soit à <literal>single</literal>
+            soit à <literal>double</literal>.
            </para>
           </listitem>
          </varlistentry>

--- a/postgresql/ref/psql-ref.xml
+++ b/postgresql/ref/psql-ref.xml
@@ -3214,7 +3214,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
 	reste de la ligne est pris en tant que
 	<replaceable class="parameter">commande</replaceable> à exécuter
 	et ni l'interpolation des variables ni la substitution par guillemets
-	inverses n'y son effectuées. Le reste de la ligne est simplement
+	inverses n'y sont effectuées. Le reste de la ligne est simplement
 	passé littéralement au shell.
        </para>
       </listitem>
@@ -4496,7 +4496,7 @@ PSQL_EDITOR_LINENUMBER_ARG='--line '
      des serveurs plus récents que <application>psql</application> lui-même.
      Les fonctionnalités générales d'exécution de commandes SQL et d'affichage
      des résultats des requêtes devraient aussi fonctionner avec les serveurs
-     d'une version majeure plus récente mais ce n'est peut être garanti dans
+     d'une version majeure plus récente mais ce ne peut être garanti dans
      tous les cas.
     </para>
     <para>

--- a/postgresql/ref/psql-ref.xml
+++ b/postgresql/ref/psql-ref.xml
@@ -41,9 +41,9 @@
    <productname>PostgreSQL</productname> et de voir les résultats de ces
    requêtes. Alternativement, les entrées peuvent êtres lues à partir d'un fichier
    ou à partir des arguments de la ligne de commande.
-   De plus, il fournit un certain nombre de méta-commandes et plusieurs
+   De plus, il fournit un certain nombre de métacommandes et plusieurs
    fonctionnalités style shell pour faciliter l'écriture des scripts et
-   automatiser un nombre varié de tâches.
+   automatiser une grande variété de tâches.
   </para>
  </refsect1>
 
@@ -81,7 +81,7 @@
     <term><option>--echo-errors</option></term>
     <listitem>
      <para>
-      Affiche les commandes SQL échouées sur la sortie standard des erreurs.
+      Affiche les commandes SQL qui ont échoué sur la sortie standard des erreurs.
       C'est équivalent à configurer la variable <varname>ECHO</varname> à
       <literal>errors</literal>.
      </para>
@@ -109,11 +109,12 @@
        <replaceable class="parameter">commande</replaceable> doit être soit
        une chaîne de commande complètement analysable par le serveur
        (autrement dit, elle ne contient pas de fonctionnalités spécifiques à
-       <application>psql</application>), soit une simple méta-commande. De ce
-       fait, vous pouvez mixer les commandes <acronym>SQL</acronym> et les
-       méta-commandes <application>psql</application> dans une option
-       <option>-c</option>. Pour se faire, vous pouvez utiliser plusieurs
-       options <option>-c</option> ou d'envoyer la chaîne dans
+       <application>psql</application>), soit une simple métacommande. De ce
+       fait, vous ne pouvez pas mixer les commandes <acronym>SQL</acronym> et les
+       métacommandes <application>psql</application> dans une option
+       <option>-c</option>. Pour ce faire, vous pouvez utiliser plusieurs
+       options <option>-c</option> ou envoyer la chaîne par un
+       <foreignphrase>pipe</foreignphrase> dans
        <application>psql</application>, par exemple&nbsp;:
 <programlisting>
 psql -c '\x' -c 'SELECT * FROM foo;'
@@ -122,20 +123,20 @@ psql -c '\x' -c 'SELECT * FROM foo;'
 <programlisting>
 echo '\x \\ SELECT * FROM foo;' | psql
 </programlisting>
-       (<literal>\\</literal> est le séparateur de méta-commandes.)
+       (<literal>\\</literal> est le séparateur de métacommandes.)
      </para>
      <para>
-       Chaque chaîne de commande <acronym>SQL</acronym> passé à
-       <option>-c</option> est envoyée au serveur comme une simple requête. De
+       Chaque chaîne de commande <acronym>SQL</acronym> passée à
+       <option>-c</option> est envoyée au serveur comme une requête unique. De
        ce fait, le serveur l'exécute comme une seule transaction, même si la
        chaîne contient plusieurs commandes <acronym>SQL</acronym>, sauf si des
        commandes <command>BEGIN</command>/<command>COMMIT</command> explicites
-       sont inclus dans la chaîne pour la diviser en plusieurs transactions.
-       De plus, <application>psql</application> affiche seulement le résultat
+       sont incluses dans la chaîne pour la diviser en plusieurs transactions.
+       De plus, <application>psql</application> n'affiche que le résultat
        de la dernière commande <acronym>SQL</acronym> dans la chaîne. Ce
-       comportement est différent quand la même chaîne est lue à partir d'un
-       fichier ou envoyée ou <application>psql</application> via l'entrée
-       standard parce que <application>psql</application> envoie chaque
+       comportement est différent de celui où la même chaîne est lue à partir
+       d'un fichier ou envoyée à <application>psql</application> via l'entrée
+       standard, parce qu'alors <application>psql</application> envoie chaque
        commande <acronym>SQL</acronym> séparément.
      </para>
      <para>
@@ -185,7 +186,7 @@ EOF
     <term><option>--echo-queries</option></term>
     <listitem>
      <para>
-      Copie toutes les commandes qui sont envoyées au serveur sur la sortie
+      Copie toutes les commandes SQL envoyées au serveur aussi sur la sortie
       standard. Ceci est équivalent à initialiser la variable
       <varname>ECHO</varname> à <literal>queries</literal>.
      </para>
@@ -221,15 +222,15 @@ EOF
        lit pas les commandes à partir de l'entrée standard&nbsp;; à la place,
        il termine après avoir traité toutes les options <option>-c</option> et
        <option>-f</option> dans la séquence indiquée. En dehors de ça, cette
-       option est fortement équivalente à la méta-commande
+       option est fortement équivalente à la métacommande
        <command>\i</command>.
      </para>
 
      <para>
       Si <replaceable>nomfichier</replaceable> est un <literal>-</literal>
       (tiret), alors l'entrée standard est lue jusqu'à la détection d'une fin
-      de fichier ou de la méta-commande <command>\q</command>. Ceci peut être
-      utilisé pour répandre une saisie interactive à partir de l'entrée de
+      de fichier ou de la métacommande <command>\q</command>. Ceci peut être
+      utilisé pour intercaler une saisie interactive entre l'entrée depuis
       plusieurs fichiers. Néanmoins,
       notez que Readline n'est pas utilisé dans ce cas (un peu comme si
       <option>-n</option> a été précisé).
@@ -238,10 +239,10 @@ EOF
      <para>
       Utiliser cette option est légèrement différent d'écrire <literal>psql
        &lt; <replaceable class="parameter">nomfichier</replaceable></literal>. En
-      général, les deux feront ce que vous souhaitez mais utiliser
+      général, les deux feront ce que vous souhaitez, mais utiliser
       <literal>-f</literal> active certaines fonctionnalités intéressantes
       comme les messages d'erreur avec les numéros de ligne. Il y a aussi une
-      légère chance qu'utiliser cette option réduira la surcharge du lancement.
+      petite chance qu'utiliser cette option réduira la charge au démarrage.
       D'un autre côté, la variante utilisant la redirection de l'entrée du shell
       doit (en théorie) pour ramener exactement le même affichage que
       celui que vous auriez eu en saisissant tout manuellement.
@@ -272,7 +273,6 @@ EOF
      <para>
       Indique le nom d'hôte de la machine sur lequel le serveur est en cours
       d'exécution. Si la valeur commence avec un slash, elle est utilisée comme
-
       répertoire du socket de domaine Unix.
      </para>
     </listitem>
@@ -296,8 +296,8 @@ EOF
     <listitem>
      <para>
       Liste toutes les bases de données disponibles puis quitte. Les autres
-      option non relatives à la connexion sont ignorées. Ceci est similaire à la
-      méta-commande <command>\list</command>.
+      options non relatives à la connexion sont ignorées. Ceci est similaire
+      à la métacommande <command>\list</command>.
      </para>
 
      <para>
@@ -328,9 +328,9 @@ EOF
     <term><option>--no-readline</option></term>
     <listitem>
      <para>
-      N'utilise pas <application>Readline</application> pour l'édition de ligne et n'utilise pas
-      l'historique de commandes. Ceci est utile quand on veut désactiver la gestion de la
-      tabulation pour l'action copie/colle.
+      N'utilise pas <application>Readline</application> pour l'édition de ligne
+      et n'utilise pas l'historique des commandes. Ceci est utile quand on
+      veut désactiver la gestion de la tabulation quand on copie/colle.
      </para>
     </listitem>
    </varlistentry>
@@ -373,7 +373,8 @@ EOF
       Vous permet de spécifier les options d'affichage dans le style de
       <command>\pset</command> sur la ligne de commande. Notez que, ici, vous
       devez séparer nom et valeur avec un signe égal au lieu d'un espace. Du
-      coup, pour initialiser le format d'affichage en <application>LaTeX</application>, vous devez écrire
+      coup, pour initialiser le format d'affichage en
+      <application>LaTeX</application>, vous devez écrire
       <literal>-P format=latex</literal>.
      </para>
     </listitem>
@@ -385,8 +386,8 @@ EOF
     <listitem>
      <para>
       Indique que <application>psql</application> doit travailler
-      silencieusement. Par défaut, il affiche des messages de bienvenue et des
-      informations diverses. Si cette option est utilisée, rien de ceci
+      silencieusement. Par défaut, il affiche des messages de bienvenue et
+      diverses informations. Si cette option est utilisée, rien de ceci
       n'est affiché. C'est utile avec l'option <option>-c</option>. Ceci est
       équivalent à configurer la variable <varname>QUIET</varname> à
       <literal>on</literal>.
@@ -426,16 +427,17 @@ EOF
     <term><option>--single-line</option></term>
     <listitem>
      <para>
-      S'exécute en mode simple ligne où un retour à la ligne termine une
+      S'exécute en mode simple ligne, où un retour à la ligne termine une
       commande SQL, de la même façon qu'un point-virgule.
      </para>
 
      <note>
       <para>
-       Ce mode est fourni pour ceux qui insistent pour l'avoir, mais vous n'êtes pas
-       nécessairement encouragé à l'utiliser. En particulier, si vous mixez
-       <acronym>SQL</acronym> et méta-commandes sur une ligne, l'ordre
-       d'exécution n'est pas toujours clair pour l'utilisateur non expérimenté.
+       Ce mode est fourni pour ceux qui insistent pour l'avoir, mais vous
+       n'êtes pas nécessairement encouragé à l'utiliser. En particulier,
+       si vous mixez <acronym>SQL</acronym> et métacommandes sur une ligne,
+       l'ordre d'exécution peut ne pas être toujours clair pour
+       un utilisateur inexpérimenté.
       </para>
      </note>
     </listitem>
@@ -446,9 +448,9 @@ EOF
     <term><option>--tuples-only</option></term>
     <listitem>
      <para>
-      Désactive l'affichage des noms de colonnes et le pied de page
+      Désactive l'affichage des noms de colonnes, le pied de page
       contenant le nombre de résultats, etc. Ceci est équivalent à la
-      méta-commande <command>\t</command> ou à
+      métacommande <command>\t</command> ou à
       <command>\pset tuples_only</command>.
      </para>
     </listitem>
@@ -461,7 +463,7 @@ EOF
       class="parameter">options_table</replaceable></option></term>
     <listitem>
      <para>
-      Permet d'indiquer les options à placer à l'intérieur d'une balise
+      Indique les options à placer à l'intérieur d'une balise
       <sgmltag>table</sgmltag> en <acronym>HTML</acronym>. Voir
       <command>\pset tableattr</command> pour plus de détails.
      </para>
@@ -491,13 +493,14 @@ EOF
       class="parameter">affectation</replaceable></option></term>
     <listitem>
      <para>
-      Réalise une affectation de variable comme la méta-commande
-      <command>\set</command>. Notez que vous devez séparer nom et valeur par
+      Réalise une affectation de variable, comme la métacommande
+      <command>\set</command>. Notez que vous devez séparer le nom et la valeur,
+      s'il y en a une, par
       un signe égal sur la ligne de commande. Pour désinitialiser une variable,
-      enlevez le signe d'égalité. Pour simplement initialiser une variable sans
-      valeur, utilisez le signe égal sans passer de valeur. Ces affectations
+      enlevez le signe d'égalité. Pour initialiser une variable avec une valeur
+      vide, utilisez le signe égal sans passer de valeur. Ces affectations
       sont réalisées lors du traitement de la ligne de commande, du coup les
-      variables réservées à des buts internes peuvent être écrasées plus
+      variables reflétant l'état de la connection seront écrasées plus
       tard.
      </para>
     </listitem>
@@ -527,7 +530,7 @@ EOF
 
      <para>
       Notez que cette option restera positionnée pour l'ensemble de la session,
-      et qu'elle affecte aussi l'utilisation de la méta-commande
+      et qu'elle affecte aussi l'utilisation de la métacommande
       <command>\connect</command> en plus de la tentative de connexion
       initiale.
      </para>
@@ -555,7 +558,7 @@ EOF
 
      <para>
       Notez que cette option sera conservée pour la session entière,
-      et que du coup elle affecte l'utilisation de la méta-commande
+      et que du coup elle affecte l'utilisation de la métacommande
       <command>\connect</command> ainsi que la tentative de connexion
       initiale.
      </para>
@@ -579,8 +582,8 @@ EOF
     <listitem>
      <para>
       Ne lit pas le fichier de démarrage (ni le fichier système
-      <filename>psqlrc</filename> ni celui de l'utilisateur
-      <filename>~/.psqlrc</filename>).
+      <filename>psqlrc</filename> ni le <filename>~/.psqlrc</filename>
+      de l'utilisateur).
      </para>
     </listitem>
    </varlistentry>
@@ -598,7 +601,7 @@ EOF
 
    <varlistentry>
     <term><option>-0</option></term>
-    <term><option>--record-separator-zero</option></term>
+    <term><option>--record-separator-zero</option>root</term>
     <listitem>
      <para>
       Configure le séparateur d'enregistrement pour une sortie non alignée avec
@@ -619,15 +622,14 @@ EOF
       force <application>psql</application> à exécuter une commande
       <command>BEGIN</command> avant la première option de ce type et une
       commande <command>COMMIT</command> après la dernière, englobant la
-      totalité des commandes dans une seule transaction. Ceci assure que soit
-      toutes les commandes réussissent, soit toutes échouent (dans ce cas,
-      aucun des changements n'est appliqué).
+      totalité des commandes dans une seule transaction. Ceci garantit que soit
+      toutes les commandes réussissent, soit aucun changement n'est appliqué.
      </para>
 
      <para>
-      Si les commandes elles-mêmes contenant <command>BEGIN</command>,
+      Si les commandes elles-mêmes contiennent <command>BEGIN</command>,
       <command>COMMIT</command> ou <command>ROLLBACK</command>, cette option
-      n'aura pas les effets désirés. De plus, si une commande individuelle ne
+      n'aura pas les effets désirés. De plus, si une commande en particulier ne
       peut pas être exécutée à l'intérieur d'un bloc de transaction, indiquer
       cette option causera l'échec de toute la transaction.
      </para>
@@ -643,7 +645,7 @@ EOF
       paramètre optionnel <replaceable class="parameter">theme</replaceable>
       (par défaut à <literal>options</literal>) sélectionne les parties de
       <application>psql</application> à expliquer&nbsp;:
-      <literal>commands</literal> décrit les méta-commandes de
+      <literal>commands</literal> décrit les métacommandes de
       <application>psql</application>&nbsp;; <literal>options</literal> décrit
       les options en ligne de commande de
       <application>psql</application>&nbsp;; et <literal>variables</literal>
@@ -660,11 +662,12 @@ EOF
   <title>Code de sortie</title>
 
   <para>
-   <application>psql</application> renvoie 0 au shell s'il se termine
-   normalement, 1 s'il y a eu une erreur fatale de son fait (pas assez de
-   mémoire, fichier introuvable), 2 si la connexion au serveur s'est interrompue
-   ou a été annulée, 3 si une erreur est survenue dans un script et si la variable
-   <varname>ON_ERROR_STOP</varname> a été initialisée.
+   <application>psql</application> renvoie 0 au shell s'il s'est terminé
+   normalement, 1 s'il y a eu une erreur fatale de son fait (par exemple&nbsp;:
+   pas assez de mémoire, fichier introuvable), 2 si la connexion au serveur
+   s'est interrompue et que la session n'était pas interactive,
+   3 si une erreur est survenue dans un script et si la variable
+   <varname>ON_ERROR_STOP</varname> était positionnée.
   </para>
  </refsect1>
 
@@ -680,22 +683,24 @@ EOF
     <productname>PostgreSQL</productname> standard. Pour se connecter à une
     base de données, vous devez connaître le nom de votre base de
     données cible, le nom de l'hôte et le numéro de port du serveur ainsi que le
-    nom de l'utilisateur que vous souhaitez connecter.
-    <application>psql</application> peut connaître ces paramètres à partir
+    nom de l'utilisateur sous lequel vous voulez vous connecter.
+    On peut indiquer ces paramètres à <application>psql</application> à partir
     d'options en ligne de commande, respectivement
     <option>-d</option>, <option>-h</option>, <option>-p</option> et
-    <option>-U</option>. Si un argument autre qu'une option est rencontré,
-    il est interprété comme le nom de la base de données (ou le nom de
-    l'utilisateur si le nom de la base de données est déjà donné). Toutes les
-    options ne sont pas requises, des valeurs par défaut sont applicables. Si
-    vous omettez le nom de l'hôte, <application>psql</application> se connecte via un
-    socket de domaine Unix à un serveur sur l'hôte local ou via TCP/IP sur
-    <literal>localhost</literal> pour les machines qui n'ont pas sockets de domaine
-    Unix. Le numéro de port par
+    <option>-U</option>. Si un argument est rencontré qui ne correspond à
+    aucune option, il sera interprété comme le nom de la base de données
+    (ou le nom de l'utilisateur si le nom de la base de données est déjà donné).
+    Toutes ces options ne sont pas requises, il y a des valeurs par défaut
+    convenables. Si vous omettez le nom de l'hôte,
+    <application>psql</application> se connectera via un
+    socket de domaine Unix à un serveur sur l'hôte local, ou par TCP/IP sur
+    <literal>localhost</literal> pour les machines qui n'ont pas de sockets
+    de domaine Unix. Le numéro de port par
     défaut est déterminé au moment de la compilation. Comme le serveur de bases
     de données utilise la même valeur par défaut, vous n'aurez pas besoin de
     spécifier le port dans la plupart des cas. Le nom de l'utilisateur par
-    défaut est votre nom d'utilisateur du système d'exploitation, de même pour le nom de la base de
+    défaut est votre nom d'utilisateur pour le système d'exploitation,
+    de même pour le nom de la base de
     données par défaut. Notez que vous ne pouvez pas simplement vous connecter à
     n'importe quelle base de données avec n'importe quel nom d'utilisateur. Votre
     administrateur de bases de données doit vous avoir informé de vos droits
@@ -703,13 +708,13 @@ EOF
    </para>
 
    <para>
-    Quand les valeurs par défaut ne sont pas correctes, vous pouvez vous simplifier
-    la vie en configurant les variables d'environnement
+    Quand les valeurs par défaut ne sont pas idéales, vous pouvez vous
+    épargner de la frappe en configurant les variables d'environnement
     <envar>PGDATABASE</envar>, <envar>PGHOST</envar>, <envar>PGPORT</envar>
     et/ou <envar>PGUSER</envar> avec les valeurs appropriées (pour les variables
     d'environnement supplémentaires, voir <xref linkend="libpq-envars"/>). Il
-    est aussi intéressant d'avoir un fichier <filename>~/.pgpass</filename> pour éviter
-    d'avoir régulièrement à saisir des mots de passe. Voir <xref
+    est aussi pratique d'avoir un fichier <filename>~/.pgpass</filename> pour
+    éviter d'avoir régulièrement à saisir les mots de passe. Voir <xref
     linkend="libpq-pgpass"/> pour plus d'informations.
    </para>
 
@@ -723,16 +728,16 @@ EOF
 $ <userinput>psql "service=monservice sslmode=require"</userinput>
 $ <userinput>psql postgresql://dbmaster:5433/mydb?sslmode=require</userinput>
     </programlisting>
-    De cette façon, vous pouvez aussi utiliser <acronym>LDAP</acronym> pour la recherche de
-    paramètres de connexion, comme décrit dans <xref linkend="libpq-ldap"/>.
-    Voir <xref linkend="libpq-paramkeywords"/> pour plus d'informations sur toutes
-    les options de connexion disponibles.
+    De cette façon, vous pouvez aussi utiliser <acronym>LDAP</acronym> pour
+    la recherche de paramètres de connexion, comme décrit dans
+    <xref linkend="libpq-ldap"/>. Voir <xref linkend="libpq-paramkeywords"/>
+    pour plus d'informations sur toutes les options de connexion disponibles.
    </para>
 
    <para>
-    Si la connexion ne peut pas se faire, quelle qu'en soit la raison (c'est-à-dire
-    droits non suffisants, serveur arrêté sur l'hôte cible, etc.),
-    <application>psql</application> renvoie une erreur et s'arrête.
+    Si la connexion ne peut pas se faire, quelle qu'en soit la raison
+    (c'est-à-dire droits non suffisants, serveur arrêté sur l'hôte cible, etc.),
+    <application>psql</application> renverra une erreur et s'arrêtera.
    </para>
 
    <para>
@@ -742,8 +747,9 @@ $ <userinput>psql postgresql://dbmaster:5433/mydb?sslmode=require</userinput>
     détecter l'encodage approprié d'après les paramètres régionaux (définis
     par la variable système <envar>LC_CTYPE</envar> pour les systèmes
     Unix).
-    Si cette méthode échoue, il est possible de forcer l'encodage du client
-    en renseignant la variable d'environnement <envar>PGCLIENTENCODING</envar>.
+    Si cela ne fonctionne pas comme attendu, il est possible de forcer
+    l'encodage du client en renseignant la variable d'environnement
+    <envar>PGCLIENTENCODING</envar>.
    </para>
   </refsect2>
 
@@ -767,8 +773,22 @@ basetest=&gt;
     Ordinairement, les lignes en entrée sont envoyées vers le serveur quand un
     point-virgule de fin de commande est saisi. Une fin de ligne ne termine pas
     une commande. Du coup, les commandes peuvent être saisies sur plusieurs
-    lignes pour plus de clarté. Si la commande est envoyée et exécutée sans
-    erreur, les résultats de la commande sont affichés sur l'écran.
+    lignes pour plus de clarté. Si la commande a été envoyée et exécutée sans
+    erreur, ses résultats sont affichés sur l'écran.
+   </para>
+
+   <para>
+   Si des utilisateurs en qui vous n'avez pas confiance ont accès à une base
+   qui n'a pas adopté la
+   <link linkend="ddl-schemas-patterns">méthode sécurisée d'utilisation
+   des schémas</link>, démarrez votre session en supprimant de votre
+   <varname>search_path</varname> les schémas ouverts en écriture au public.
+   On peut ajouter <literal>options=-csearch_path=</literal> à la chaîne de
+   connection ou exécuter
+   <literal>SELECT pg_catalog.set_config('search_path', '', false)</literal>
+   avant toute autre commande SQL. Cette considération n'est pas propre à
+   <application>psql</application>&nbsp;; elle s'applique à chaque interface qui
+   exécute des commandes SQL quelconques.
    </para>
 
    <para>
@@ -779,22 +799,22 @@ basetest=&gt;
    </para>
 
    <para>
-    Tant que des blocs de commentaire de tpe C sont passés au serveur pour
-    traitement et suppression, les commentaires du standard SQL sont supprimés
+    Alors que les blocs de commentaire de type C sont transmis au serveur pour
+    traitement et suppression, les commentaires au standard SQL sont supprimés
     par <application>psql</application>.
    </para>
   </refsect2>
 
   <refsect2 id="app-psql-meta-commands">
-   <title>Meta-commandes</title>
+   <title>Métacommandes</title>
 
    <para>
     Tout ce que vous saisissez dans <application>psql</application> qui
-    commence par un antislash non échappé est une méta-commande
-    <application>psql</application> qui est traitée par
+    commence par un antislash non échappé est une métacommande
+    <application>psql</application>, traitée par
     <application>psql</application> lui-même. Ces commandes aident à rendre
     <application>psql</application> plus utile pour l'administration ou pour
-    l'écriture de scripts. Les méta-commandes sont plus souvent appelées les
+    l'écriture de scripts. Les métacommandes sont plus souvent appelées les
     commandes slash ou antislash.
    </para>
 
@@ -812,12 +832,12 @@ basetest=&gt;
     entre guillemets simples. Tout ce qui est contenu dans des guillemets
     simples est sujet aux substitutions du style langage C&nbsp;:
     <literal>\n</literal> (nouvelle ligne), <literal>\t</literal> (tabulation),
-    <literal>\b</literal> (retour arrière), <literal>\r</literal> (retour à la
-    ligne), <literal>\f</literal> (form feed),
+    <literal>\b</literal> (retour arrière), <literal>\r</literal> (retour
+    chariot), <literal>\f</literal> (saut de page),
     <literal>\</literal><replaceable>chiffres</replaceable> (octal), and
     <literal>\x</literal><replaceable>chiffres</replaceable> (hexadécimal).
     Un antislash précédant tout autre caractère dans une chaîne entre guillemets
-    simples est ignoré.
+    reproduit ce caractère, quel qu'il soit.
    </para>
 
    <para>
@@ -831,20 +851,21 @@ basetest=&gt;
     </para>
 
     <para>
-    Dans un argument, le texte qui est à l'intérieur de guillemets inverses
-    (<literal>`</literal>) est pris sur une ligne de commande qui est passée au
-    shell. La sortie de la commande (dont tous les retours à la ligne sont
+    Dans un argument, le texte entre des guillemets inverses
+    (<literal>`</literal>) est pris comme une ligne de commande, qui est passée
+    au shell. La sortie de la commande (dont tous les retours à la ligne sont
     supprimés) remplace le texte entre guillemets inverses.
-    Dans le texte à l'intérieur des guillemets inverses, il n'y aura pas
-    d'échappement ou d'autre traitement, à l'exception de
+    Dans le texte à l'intérieur des guillemets inverses, ne se déroule
+    ni échappement ni autre traitement, à l'exception de
 	<literal>:<replaceable>variable_name</replaceable></literal> où
 	<replaceable>variable_name</replaceable> est une
-    variable <application>psql</application> qui sera remplacée par sa valeur.
-    De plus, les occurences de <replaceable>variable_name</replaceable> sont
+    variable <application>psql</application>, qui sera remplacée par sa valeur.
+    De plus, les occurences de
+    <literal>:'<replaceable>variable_name</replaceable>'</literal>  sont
     remplacées par la valeur de la variable correctement échappée pour devenir
-    un unique argument de commande shell (cette dernière forme est quasiment
+    un unique argument de commande shell (cette dernière forme est presque
     toujours préférable, sauf à &ecirc;tre absolument s&ucirc;r du contenu de la
-    variable). Comme les retours chariots et les caractères sauts de ligne ne
+    variable). Comme les caractères retour chariot et saut de ligne ne
     peuvent &ecirc;tre échappés correctement sur toutes les plateformes, la
     forme <literal>:'<replaceable>variable_name</replaceable>'</literal> renvoie
     un message d'erreur et ne remplace pas la valeur de la variable quand ces
@@ -865,33 +886,34 @@ basetest=&gt;
    </para>
 
    <para>
-    L'analyse des arguments se termine quand d'autres antislash non entre
-    guillemets surviennent. Ceci est pris pour le début d'une nouvelle
-    méta-commande. La séquence spéciale <literal>\\</literal> (deux antislashes)
+    L'analyse des arguments se termine à la fin de la ligne ou quand un autre
+    antislash non entre guillemets est rencontré. Un antislash non entre
+    guillemets est pris pour le début d'une nouvelle
+    métacommande. La séquence spéciale <literal>\\</literal> (deux antislashes)
     marque la fin des arguments et continue l'analyse des commandes
     <acronym>SQL</acronym>, si elles existent. De cette façon, les commandes
     <acronym>SQL</acronym> et <application>psql</application> peuvent être
     mixées librement sur une ligne. Mais dans tous les cas, les arguments d'une
-    méta-commande ne peuvent pas continuer après la fin de la ligne.
+    métacommande ne peuvent pas continuer après la fin de la ligne.
    </para>
 
    <para>
-    De nombreuses méta-commandes utilisent le <firstterm>buffer de la requ&ecirc;te actuelle</firstterm>.   
+    De nombreuses métacommandes utilisent le <firstterm>buffer de la requ&ecirc;te actuelle</firstterm>.
     Ce buffer contient simplement le texte de la commande SQL qui a été écrite
     mais pas encore envoyée au serveur pour exécution. Cela comprendra les
     lignes saisies précédentes ainsi que tout texte présent avant la
-    méta-commande de la m&ecirc;me ligne.
+    métacommande de la m&ecirc;me ligne.
     </para>
 
     <para>
-    Les méta-commandes suivantes sont définies&nbsp;:
+    Les métacommandes suivantes sont définies&nbsp;:
 
     <variablelist>
      <varlistentry>
       <term><literal>\a</literal></term>
       <listitem>
        <para>
-        Si le format actuel d'affichage d'une table est non aligné, il est
+        Si le format d'affichage de table actuel est non aligné, il est
         basculé à aligné. S'il n'est pas non aligné, il devient non aligné.
         Cette commande est conservée pour des raisons de compatibilité. Voir
         <command>\pset</command> pour une solution plus générale.
@@ -904,7 +926,7 @@ basetest=&gt;
 
       <listitem>
        <para>
-        Établie une nouvelle connexion à un serveur
+        Établit une nouvelle connexion à un serveur
         <productname>PostgreSQL</productname>. Les paramètres de connexion
         utilisés peuvent être spécifiés en utilisant soit la syntaxe par
         position soit les chaînes de connexion <replaceable>conninfo</replaceable>
@@ -912,7 +934,7 @@ basetest=&gt;
        </para>
 
        <para>
-        Quand la méta-commande n'indique pas le nom de la base,
+        Quand la métacommande n'indique pas le nom de la base,
         l'utilisateur, l'hôte ou le port, la nouvelle connexion peut ré-
         utiliser les valeurs provenant de la connexion précédente. Par
         défaut, les valeurs de la connexion précédente sont ré-utilisées sauf
@@ -937,10 +959,10 @@ basetest=&gt;
         accès refusé, etc.), la connexion précédente est conservée si
         <application>psql</application> est en mode interactif. Lors de
         l'exécution d'un script non interactif, le traitement s'arrêtera
-        immédiatement avec une erreur. Cette distinction a été choisie pour deux
-        raisons&nbsp;: aider l'utilisateur face aux fautes de frappe et en tant
-        que mesure de précaution pour qu'un script n'agisse pas par erreur sur
-        la mauvaise base.
+        immédiatement avec une erreur. Cette distinction a été choisie d'une
+        part comme facilité pour l'utilisateur confronté aux fautes de frappe,
+        d'autre part en tant que sécurité pour que des scripts n'agissent pas
+        par erreur sur la mauvaise base de données.
        </para>
 
        <para>
@@ -975,7 +997,7 @@ basetest=&gt;
       <term><literal>\cd [ <replaceable>répertoire</replaceable> ]</literal></term>
       <listitem>
        <para>
-        Modifie le répertoire courant par
+        Change le répertoire courant en
         <replaceable>répertoire</replaceable>. Sans argument, le
         répertoire personnel de l'utilisateur devient le répertoire courant.
        </para>
@@ -993,7 +1015,7 @@ basetest=&gt;
       <term><literal>\conninfo</literal></term>
       <listitem>
        <para>
-        Affiche des informations sur la connexion actuelle à la base de données.
+        Affiche des informations sur la connexion en cours à la base de données.
        </para>
       </listitem>
      </varlistentry>
@@ -1006,7 +1028,7 @@ basetest=&gt;
 
       <listitem>
        <para>
-        Réalise une opération de copy côté client. C'est une opération qui
+        Réalise une opération de copie côté client. C'est une opération qui
         exécute une commande <acronym>SQL</acronym>, <xref linkend="sql-copy"/>,
         mais au lieu que le serveur lise ou écrive le
         fichier spécifié, <application>psql</application> lit ou écrit le
@@ -1022,16 +1044,16 @@ basetest=&gt;
         <application>psql</application> et les données provenant ou fournies à
         <replaceable class="parameter">commande</replaceable> sont routées entre
         le serveur et le client. Encore une fois, les droits d'exécution sont
-        ceux de l'utilisateur local, et non pas du serveur, et que les droits
-        super-utilisateur ne sont pas nécessaires.
+        ceux de l'utilisateur local, et non du serveur, et les droits
+        superutilisateur ne sont pas nécessaires.
        </para>
 
        <para>
         Pour <literal>\copy ... from stdin</literal>, les lignes de données
         sont lues depuis la même source qui a exécuté la commande, continuant
         jusqu'à ce que <literal>\.</literal> soit lu ou que le flux atteigne
-        <acronym>EOF</acronym>. Cette option est utile pour populer des tables
-        en ligne dans des scripts SQL.
+        <acronym>EOF</acronym>. Cette option est utile pour remplir des tables
+        depuis les scripts SQL même.
         Pour <literal>\copy ... to stdout</literal>, la sortie est envoyée au
         même endroit que la sortie des commandes<application>psql</application>,
         et le statut de la commande <literal>COPY <replaceable>count
@@ -1046,11 +1068,11 @@ basetest=&gt;
        <para>
         La syntaxe de cette commande est similaire à celle de la commande
         <acronym>SQL</acronym> <xref linkend="sql-copy"/>.
-        Toutes les options autre que la source et destination sont comme il
-        est spécifié pour <xref linkend="sql-copy"/>.
-        A cause de cela, des règles spéciales d'analyse sont appliquées à la
-	    méta-commande <command>\copy</command>. Contrairement à la majorité des
-	    autres méta-commandes, l'intégralité du reste de la ligne est toujours
+        Toutes les options autres que les source/destination des données sont
+        comme spécifié pour <xref linkend="sql-copy"/>.
+        À cause de cela, des règles spéciales d'analyse sont appliquées à la
+	    métacommande <command>\copy</command>. Contrairement à la majorité des
+	    autres métacommandes, l'intégralité du reste de la ligne est toujours
 	    pris en compte en tant qu'arguments de <command>\copy</command>,
 	    et ni l'interpolation des variables ni la substitution par guillemets
 	    inverses ne seront effectuées sur les arguments.
@@ -1090,13 +1112,13 @@ basetest=&gt;
         <listitem>
         <para>
         Exécute le tampon de requête actuel (tout comme <literal>\g</literal>)
-        et affiche le résultat dans une grille croisée. La requête doit
+        et affiche le résultat dans un tableau croisé. La requête doit
         renvoyer au moins trois colonnes. La colonne en sortie identifiée par
         <replaceable class="parameter">colV</replaceable> devient l'en-tête
         vertical et la colonne en sortie identifiée par <replaceable
         class="parameter">colH</replaceable> devient l'en-tête horizontal.
         <replaceable class="parameter">colD</replaceable> identifie la colonne
-        en sortie à afficher dans la grille. <replaceable
+        en sortie à afficher à l'intérieur de la grille. <replaceable
         class="parameter">sortcolH</replaceable> identifie une colonne
         optionnelle de tri pour l'en-tête horizontal.
         </para>
@@ -1104,8 +1126,8 @@ basetest=&gt;
         <para>
         Chaque spécification de colonne peut être un numéro de colonne (en
         commençant à 1) ou un nom de colonne. Les règles SQL habituelles de
-        casse et de guillemet s'appliquent aux noms de colonne. Si omis, la
-        colonne 1 est utilisée pour <replaceable
+        casse et de guillemet s'appliquent aux noms de colonne. En cas
+        d'omission, la colonne 1 est utilisée pour <replaceable
         class="parameter">colV</replaceable> et la colonne 2 est utilisée pour
         <replaceable class="parameter">colH</replaceable>. <replaceable
         class="parameter">colH</replaceable> doit différer de <replaceable
@@ -1136,7 +1158,7 @@ basetest=&gt;
         </para>
 
         <para>
-        À l'intérieur de la grille croisée, pour chaque valeur
+        À l'intérieur du tableau croisé, pour chaque valeur
         <literal>x</literal> distincte de <replaceable
         class="parameter">colH</replaceable> et pour chaque valeur
         <literal>y</literal> distincte de <replaceable
@@ -1161,17 +1183,18 @@ basetest=&gt;
         Pour chaque relation (table, vue, vue matérialisée, index, séquence ou
         table distante) ou type composite correspondant au
         <replaceable class="parameter">motif</replaceable>, affiche toutes les
-        colonnes, leur types, le tablespace (s'il ne s'agit pas du tablespace
+        colonnes, leurs types, le tablespace (s'il ne s'agit pas du tablespace
         par défaut) et tout attribut spécial tel que <literal>NOT
          NULL</literal> ou les valeurs par défaut. Les index, contraintes, règles
-        et déclencheurs associés sont aussi affichés, ainsi que la définition de
-        la vue si la relation est une vue. Pour les tables distantes, le serveur
-        distant associé est aussi affiché. (Ce qui <quote>Correspond au motif</quote> est
-        défini ci-dessous.)
+        et déclencheurs associés sont aussi affichés. Pour les tables distantes,
+        le serveur distant associé est aussi affiché. (Ce qui
+        <quote>correspond au motif</quote> est défini dans
+        <xref linkend="APP-PSQL-patterns" endterm="APP-PSQL-patterns-title">
+        ci-dessous.)
        </para>
 
        <para>
-        Pour chaque type de relation, <literal>\d</literal> affiche des informations
+        Pour certains type de relation, <literal>\d</literal> affiche des informations
         supplémentaires pour chaque colonne&nbsp;; colonne valeur pour les séquences,
         expression indexée pour les index, options du wrapper de données distantes
         pour les tables distantes.
@@ -1181,7 +1204,7 @@ basetest=&gt;
         Le forme de la commande <literal>\d+</literal> est identique, sauf que
         des informations plus complètes sont affichées&nbsp;: tout commentaire associé avec
         les colonnes de la table est affiché, ainsi que la présence d'OID dans
-        la table, la définition de la vue (si la relation ciblée est une vue),un
+        la table, la définition de la vue (si la relation ciblée est une vue), un
         réglage de <link linkend="sql-createtable-replica-identity">replica
          identity</link> autre que celui par défaut.
        </para>
@@ -1189,15 +1212,16 @@ basetest=&gt;
        <para>
         Par défaut, seuls les objets créés par les utilisateurs sont affichés&nbsp;;
         fournissez un motif ou le modificateur <literal>S</literal> pour afficher
-        les objets systèmes.
+        les objets système.
        </para>
 
        <note>
         <para>
          Si <command>\d</command> est utilisé sans argument
-         <replaceable class="parameter">motif</replaceable>, c'est équivalent,
+         <replaceable class="parameter">motif</replaceable>, il est équivalent,
          en plus commode, à <command>\dtvmsE</command> qui affiche une liste de
-         toutes les tables, vues, vues matérialisées, séquences et tables distantes.
+         toutes les tables, vues, vues matérialisées, séquences et tables
+         distantes. Ce n'est qu'un outil pratique.
         </para>
        </note>
       </listitem>
@@ -1209,7 +1233,7 @@ basetest=&gt;
 
       <listitem>
        <para>
-        Liste toutes les fonctions d'agrégat disponibles, avec lee type de retour
+        Liste toutes les fonctions d'agrégat disponibles, avec le type en retour
         et les types de données sur lesquels elles opèrent. Si <replaceable
         class="parameter">motif</replaceable> est spécifié, seuls les agrégats
         dont les noms commencent par le motif sont affichés.
@@ -1230,7 +1254,7 @@ basetest=&gt;
         class="parameter">motif</replaceable> est précisé, seules sont
         affichées les méthodes d'accès dont le nom correspond au motif. Si
         <literal>+</literal> est ajouté au nom de la commande, chaque méthode
-        d'accès est listé avec sa fonction gestionnaire et sa description
+        d'accès est listée avec sa fonction gestionnaire et sa description
         associées.
         </para>
         </listitem>
@@ -1308,8 +1332,7 @@ basetest=&gt;
 
        <para>
         Les descriptions des objets peuvent être ajoutées avec la commande
-        <acronym>SQL</acronym> <xref
-        linkend="sql-comment"/>.
+        <acronym>SQL</acronym> <xref linkend="sql-comment"/>.
        </para>
       </listitem>
      </varlistentry>
@@ -1818,8 +1841,8 @@ basetest=&gt;
         ou <literal>\g</literal>, le contenu sera envoyé, tandis que
         <literal>\r</literal> annulera en effaçant le tampon de requête.
         Traiter le buffer comme une ligne unique affecte principalement les
-        méta-commandes&nbsp;: tout ce qui se trouve dans le tampon après une
-        méta-commande sera pris en tant qu'argument de la méta-commande, même
+        métacommandes&nbsp;: tout ce qui se trouve dans le tampon après une
+        métacommande sera pris en tant qu'argument de la métacommande, même
         si cela s'étend	sur plusieurs lignes (du coup, vous ne pouvez pas faire
         de scripts de cette façon. Utilisez <command>\i</command> pour cela).
        </para>
@@ -1833,7 +1856,7 @@ basetest=&gt;
        </para>
 
        <para>
-        Contrairement à la majorité des autres méta-commandes, l'intégralité du
+        Contrairement à la majorité des autres métacommandes, l'intégralité du
         reste de la ligne est toujours pris en compte en tant qu'arguments
         de <command>\ef</command>, et ni l'interpolation des variables ni la
         substitution par guillemets inverses ne seront effectuées sur les
@@ -1975,7 +1998,7 @@ Tue Oct 26 21:40:57 CEST 1999
        </para>
 
        <para>
-        Contrairement à la majorité des autres méta-commandes, l'intégralité du
+        Contrairement à la majorité des autres métacommandes, l'intégralité du
         reste de la ligne est toujours pris en compte en tant qu'arguments
         de <command>\ev</command>, et ni l'interpolation des variables ni la
         substitution par guillemets inverses ne seront effectuées sur les
@@ -2061,7 +2084,7 @@ CREATE INDEX
         renvoyés, et de gauche à droite sur chaque ligne s'il y a plus d'une
         colonne. Les champs NULL sont ignorés. Les requêtes générées sont
         envoyées litéralement au serveur pour traitement, donc elles ne
-        peuvent pas être des méta-commandes <application>psql</application> ni
+        peuvent pas être des métacommandes <application>psql</application> ni
         contenir des références de variables <application>psql</application>.
         Si une requête individuelle échoue, l'exécution des requêtes suivantes
         continue sauf si <varname>ON_ERROR_STOP</varname> est configuré.
@@ -2152,7 +2175,7 @@ bonjour 10
        </para>
 
         <para>
-	 Contrairement à la majorité des autres méta-commandes, l'intégralité du
+	 Contrairement à la majorité des autres métacommandes, l'intégralité du
 	 reste de la ligne est toujours pris en compte en tant qu'arguments
 	 de <command>\help</command>, et ni l'interpolation des variables ni la
 	 substitution par guillemets inverses ne seront effectuées sur les
@@ -2196,7 +2219,7 @@ bonjour 10
        <para>
         Si <replaceable>nomfichier</replaceable> est <literal>-</literal>
         (tiret), l'entrée standard est lu jusqu'à arriver à la fin de fichier
-        ou à la méta-commande <command>\q</command>. Ceci peut être utilisé
+        ou à la métacommande <command>\q</command>. Ceci peut être utilisé
         pour intégrer des entrées interactives avec des entrées de fichiers.
         Notez que le comportement de Readline ne sera activé que s'il est
         actif au niveau supérieur.
@@ -3067,7 +3090,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
        </para>
 
         <para>
-	Contrairement à la majorité des autres méta-commandes, l'intégralité du
+	Contrairement à la majorité des autres métacommandes, l'intégralité du
 	reste de la ligne est toujours pris en tant qu'argument(s) de
 	<command>\sf</command> et ni l'interpolation des variables ni la
 	substitution par guillemets inverses ne seront effectuées.
@@ -3093,7 +3116,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
          </para>
 
         <para>
-	Contrairement à la majorité des autres méta-commandes, l'intégralité du
+	Contrairement à la majorité des autres métacommandes, l'intégralité du
 	reste de la ligne est toujours pris en tant qu'argument(s) de
 	<command>\sv</command> et ni l'interpolation des variables ni la
 	substitution par guillemets inverses ne seront effectuées.
@@ -3201,7 +3224,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
         activé), l'heure du début de la requête, et l'intervalle.
        </para>
         <para>
-	Si le tampon de requête actuel est vide, la dernière requête envoyée 
+	Si le tampon de requête actuel est vide, la dernière requête envoyée
 	est exécutée à nouveau.
         </para>
       </listitem>
@@ -3249,7 +3272,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
         </para>
 
         <para>
-	 Contrairement à la majorité des autres méta-commandes, l'intégralité du
+	 Contrairement à la majorité des autres métacommandes, l'intégralité du
 	 reste de la ligne est toujours pris en compte en tant qu'arguments
 	 de <command>\!</command>, et ni l'interpolation des variables ni la
 	 substitution par guillemets inverses ne seront effectuées sur les
@@ -3268,7 +3291,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
         class="parameter">theme</replaceable> (par défaut à
         <literal>commands</literal>) sélectionne les parties de
         <application>psql</application> à expliquer&nbsp;:
-        <literal>commands</literal> décrit les méta-commandes de
+        <literal>commands</literal> décrit les métacommandes de
         <application>psql</application>&nbsp;; <literal>options</literal>
         décrit les options en ligne de commande de
         <application>psql</application>&nbsp;; et <literal>variables</literal>
@@ -3403,7 +3426,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
 
     <para>
      Pour configurer une variable, utilisez la
-     méta-commande <application>psql</application> <command>\set</command>.
+     métacommande <application>psql</application> <command>\set</command>.
      Par exemple&nbsp;:
      <programlisting>basetest=&gt; <userinput>\set foo bar</userinput>
      </programlisting>
@@ -3413,7 +3436,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
      <programlisting>basetest=&gt; <userinput>\echo :foo</userinput>
 bar
      </programlisting>
-     Ceci fonctionne avec les commandes SQL et les méta-commandes standards. Il
+     Ceci fonctionne avec les commandes SQL et les métacommandes standards. Il
      y a plus de détails dans <xref linkend="app-psql-interpolation"
      endterm="app-psql-interpolation-title"/>, ci-dessous.
     </para>
@@ -3925,7 +3948,7 @@ bar
      Une fonctionnalité clé des variables <application>psql</application> est
      que vous pouvez les substituer (<quote>interpolation</quote>) dans des
      requêtes <acronym>SQL</acronym> standards, ainsi qu'en arguments de
-     méta-commandes. De plus, <application>psql</application> fournit des
+     métacommandes. De plus, <application>psql</application> fournit des
      fonctionnalités vous assurant que les valeurs des variables utilisées
      comme constantes et identifiants SQL sont correctement mises entre
      guillemets. La syntaxe pour l'interpolation d'une valeur sans guillemets
@@ -4449,7 +4472,7 @@ PSQL_EDITOR_LINENUMBER_ARG='--line '
      </para>
      <para>
       L'emplacement du fichier historique peut aussi être configuré explicitement
-      avec la variable <application>psql</application> <varname>HISTFILE</varname> 
+      avec la variable <application>psql</application> <varname>HISTFILE</varname>
       ou avec la variable d'environnement <envar>PSQL_HISTORY</envar>.
      </para>
     </listitem>

--- a/postgresql/ref/psql-ref.xml
+++ b/postgresql/ref/psql-ref.xml
@@ -638,11 +638,11 @@ EOF
 
    <varlistentry>
     <term><option>-?</option></term>
-    <term><option>--help[=<replaceable class="parameter">theme</replaceable>]</option></term>
+    <term><option>--help[=<replaceable class="parameter">thème</replaceable>]</option></term>
     <listitem>
      <para>
       Affiche de l'aide sur <application>psql</application> puis quitte. Le
-      paramètre optionnel <replaceable class="parameter">theme</replaceable>
+      paramètre optionnel <replaceable class="parameter">thème</replaceable>
       (par défaut à <literal>options</literal>) sélectionne les parties de
       <application>psql</application> à expliquer&nbsp;:
       <literal>commands</literal> décrit les métacommandes de
@@ -2399,7 +2399,7 @@ SELECT
         Stocke le fichier dans un Large Object
         <productname>PostgreSQL</productname>. En option, il associe le
         commentaire donné avec l'objet. Exemple&nbsp;:
-        <programlisting>foo=&gt; <userinput>\lo_import '/home/peter/pictures/photo.xcf' 'une
+        <programlisting>foo=&gt; <userinput>\lo_import '/home/pierre/pictures/photo.xcf' 'une
 photo de moi'</userinput>
 lo_import 152801
         </programlisting>
@@ -2900,7 +2900,7 @@ lo_import 152801
             la commande bascule entre la sortie normale et la sortie
             «&nbsp;tuples seulement&nbsp;».
             La sortie normale comprend des informations supplémentaires telles que
-            les entêtes de colonnes, les titres, et différents pieds. Dans le mode
+            les en-têtes de colonnes, les titres, et différents pieds. Dans le mode
             «&nbsp;tuples seulement&nbsp;», seules les données de la table sont affichées.
            </para>
           </listitem>
@@ -3023,7 +3023,7 @@ lo_import 152801
         Initialise la variable <replaceable
         class="parameter">nom</replaceable> de <application>psql</application> à <replaceable
         class="parameter">valeur</replaceable> ou, si plus d'une valeur est
-        donnée, à la concaténation de toutes les valeurs. Si seulement un argument est
+        donnée, à la concaténation de toutes les valeurs. Si un seul argument est
         donné, la variable est configurée avec une valeur vide.
         Pour désinitialiser une variable, utilisez la commande
         <command>\unset</command>.
@@ -3036,7 +3036,7 @@ lo_import 152801
 
        <para>
         Les noms de variables valides peuvent contenir des lettres, chiffres
-        et tirets bas. Voir la section <xref linkend="app-psql-variables"
+        et tirets bas (_). Voir la section <xref linkend="app-psql-variables"
         endterm="app-psql-variables-title"/> ci-dessous pour les détails. Les noms
         des variables sont sensibles à la casse.
        </para>
@@ -3116,7 +3116,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
           Cette commande récupère et affiche la définition de la vue nommée,
           dans la forme d'une commande <command>CREATE OR REPLACE
           VIEW</command>. La définition est affichée au travers du canal de
-          sortie actuelle, comme configuré par <command>\o</command>.
+          sortie actuel, comme configuré par <command>\o</command>.
          </para>
 
          <para>
@@ -3128,7 +3128,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
 	Contrairement à la majorité des autres métacommandes, l'intégralité du
 	reste de la ligne est toujours pris en tant qu'argument(s) de
 	<command>\sv</command> et ni l'interpolation des variables ni la
-	substitution par guillemets inverses ne seront effectuées.
+	substitution par guillemets inverses ne sont effectuées dans les arguments.
         </para>
         </listitem>
       </varlistentry>
@@ -3214,7 +3214,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
 	reste de la ligne est pris en tant que
 	<replaceable class="parameter">commande</replaceable> à exécuter
 	et ni l'interpolation des variables ni la substitution par guillemets
-	inverses ne seront effectuées. Le reste de la ligne est simplement
+	inverses n'y son effectuées. Le reste de la ligne est simplement
 	passé littéralement au shell.
        </para>
       </listitem>
@@ -3229,7 +3229,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
         <literal>\g</literal>) jusqu'à être interrompu explicitement ou que la
         requête échoue. Attend le nombre spécifié de secondes (2 par défaut)
         entre les exécutions. Chaque résultat de requête est affiché avec un
-        entête qui inclut la chaîne <literal>\pset title</literal> (si c'est
+        en-tête qui inclut la chaîne <literal>\pset title</literal> (si c'est
         activé), l'heure du début de la requête, et l'intervalle.
        </para>
         <para>
@@ -3257,7 +3257,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
       <listitem>
        <para>
         Liste les tables, vues et séquences
-        avec leur droit d'accès associé. Si un <replaceable
+        avec leur droits d'accès associés. Si un <replaceable
         class="parameter">motif</replaceable> est spécifié, seules les tables,
         vues et séquences dont le nom correspond au motif sont listées.
        </para>
@@ -3293,11 +3293,11 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
 
 
      <varlistentry>
-      <term><literal>\? [ <replaceable class="parameter">theme</replaceable> ]</literal></term>
+      <term><literal>\? [ <replaceable class="parameter">thème</replaceable> ]</literal></term>
       <listitem>
        <para>
         Affiche l'aide. Le paramètre optionnel <replaceable
-        class="parameter">theme</replaceable> (par défaut à
+        class="parameter">thème</replaceable> (par défaut à
         <literal>commands</literal>) sélectionne les parties de
         <application>psql</application> à expliquer&nbsp;:
         <literal>commands</literal> décrit les métacommandes de
@@ -3320,20 +3320,6 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
      <primary>motifs</primary>
      <secondary>dans psql et pg_dump</secondary>
     </indexterm>
-
-    <para>
-    Si des utilisateurs non dignes de confiance ont accès à une base de
-    données qui n'a pas adopté une <link
-    linkend="ddl-schemas-patterns">méthode sécurisée d'utilisation des
-    schémas</link>, commencez votre session en supprimant les schémas
-    modifiables par tout le monde de votre <varname>search_path</varname>. Il
-    est possible d'ajouter <literal>options=-csearch_path=</literal> à la
-    chaîne de connexion ou de lancez <literal>SELECT
-    pg_catalog.set_config('search_path', '', false)</literal> avant toute
-    autre commande SQL. Cette considération n'est pas spécifique à
-    <application>psql</application>&nbsp;; elle s'applique à toute interface
-    permettant d'exécuter des commandes SQL arbitraires.
-    </para>
 
     <para>
      Les différentes commandes <literal>\d</literal> acceptent un paramètre
@@ -3361,7 +3347,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
      <literal>*</literal>.
      (Un objet est dit <firstterm>visible</firstterm> si le schéma qui le contient
      est dans le chemin de recherche et qu'aucun objet de même type et même nom n'apparaît
-     en priorité dans le chemin de recherche. Cela est équivalent à dire que
+     avant dans le chemin de recherche. Cela est équivalent à dire que
      l'objet peut être référencé par son nom sans préciser explicitement
      le schéma.)
      Pour voir tous les objets de la base quelle que soit leur visibilité,
@@ -3384,7 +3370,7 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
      <literal>\dt foo*.*bar*</literal> affiche toutes les tables dont le nom
      inclut <literal>bar</literal> et qui sont dans des schémas dont le
      nom commence avec <literal>foo</literal>. Sans point, le motif correspond
-     seulement avec les objets qui sont visibles dans le chemin de recherche
+     seulement aux objets qui sont visibles dans le chemin de recherche
      actuel des schémas. De nouveau, un point dans des guillemets doubles
      perd sa signification spéciale et est traité directement.
     </para>
@@ -3428,9 +3414,9 @@ testdb=&gt; <userinput>\setenv LESS -imx4F</userinput>
     <para>
      <application>psql</application> fournit des fonctionnalités de substitution
      de variable similaire aux shells de commandes Unix. Les variables sont
-     simplement des paires nom/valeur où la valeur peut être toute chaîne, quel
-     que soit sa longueur. Le nom doit consister en des lettres (includant des
-     lettres non latines), des chiffres et des tirets bas.
+     simplement des paires nom/valeur où la valeur peut être toute chaîne, quelle
+     que soit sa longueur. Le nom doit consister en lettres (incluant les
+     lettres non latines), chiffres et tirets bas.
     </para>
 
     <para>
@@ -3452,7 +3438,8 @@ bar
 
     <para>
      Si vous appelez <command>\set</command> sans second argument, la variable
-     est initialisée avec une chaîne vide. Pour désinitialiser (ou supprimer) une
+     est initialisée avec une chaîne vide. Pour désinitialiser (c'est-a-dire
+     supprimer) une
      variable, utilisez la commande <command>\unset</command>.
      Pour afficher les valeurs de toutes les variables, appelez
      <command>\set</command> sans argument.
@@ -3464,7 +3451,7 @@ bar
       substitution que les autres commandes. Du coup, vous pouvez construire des
       références intéressantes comme <literal>\set :foo 'quelquechose'</literal>
       et obtenir des <quote>liens doux</quote> ou des <quote>variables de
-       variables</quote> comme, respectivement, <productname>Perl</productname> ou
+       variables</quote> comme, respectivement, en <productname>Perl</productname> ou
       <productname><acronym>PHP</acronym></productname>. Malheureusement (ou
       heureusement&nbsp;?), on ne peut rien faire
       d'utile avec ces constructions. D'un autre côté, <literal>\set bar
@@ -3479,10 +3466,10 @@ bar
      la valeur de la variable ou, dans certains cas, représentent un état
      modifiable de <application>psql</application>. La convention veut que
      tous les noms de variables traités
-     spécialement utilisent des lettres ASCII en majuscule (avec en option
+     spécialement utilisent des lettres ASCII en majuscule (et éventuellement
      des chiffres et des tirets bas). Pour s'assurer une compatibilité maximum
-     dans le futur, éviter d'utiliser de tels noms de variables pour votre
-     propre besoin.
+     dans le futur, éviter d'utiliser de tels noms de variables pour vos
+     propres besoins.
    </para>
 
    <para>
@@ -3553,8 +3540,8 @@ bar
       <term><varname>COMP_KEYWORD_CASE</varname></term>
       <listitem>
        <para>
-        Détermine la casse à utiliser lors de la compléttion d'un mot clé SQL.
-        Si c'est configuré à <literal>lower</literal> ou <literal>upper</literal>,
+        Détermine la casse à utiliser lors de la complétion d'un mot clé SQL.
+        S'il est configuré à <literal>lower</literal> ou <literal>upper</literal>,
         le mot complété sera, respectivement, en minuscule ou en majuscule.
         Si la variable est configurée à <literal>preserve-lower</literal> ou
         <literal>preserve-upper</literal> (valeur par défaut), le mot complété
@@ -3635,8 +3622,8 @@ bar
       <term><varname>FETCH_COUNT</varname></term>
       <listitem>
        <para>
-        Si cette variable est un entier positif, les résultats de la requête
-        <command>SELECT</command> sont récupérés et affichés en groupe de
+        Si cette variable est un entier plus grand que zéro, les résultats des
+        requêtes <command>SELECT</command> sont récupérés et affichés en groupe de
         ce nombre de lignes, plutôt que par le comportement par défaut
         (récupération de l'ensemble complet des résultats avant l'affichage).
         Du coup, seule une petite quantité de mémoire est utilisée, quelle que
@@ -3674,7 +3661,7 @@ bar
        </para>
        <note>
         <para>
-         Cette fonctionnalité a été plagiée sur
+         Cette fonctionnalité a été plagiée sans vergogne sur
          <application>Bash</application>.
         </para>
        </note>
@@ -3694,7 +3681,7 @@ bar
        </para>
        <note>
         <para>
-         Cette fonctionnalité a été plagiée sans honte à partir de
+         Cette fonctionnalité a été plagiée sans vergogne sur
          <application>Bash</application>.
         </para>
        </note>
@@ -3711,7 +3698,7 @@ bar
        </para>
        <note>
         <para>
-         Cette fonctionnalité a été plagiée sur
+         Cette fonctionnalité a été plagiée sans vergogne sur
          <application>Bash</application>.
         </para>
        </note>
@@ -3722,7 +3709,7 @@ bar
       <term><varname>HOST</varname></term>
       <listitem>
        <para>
-        L'hôte du serveur de la base de données où vous êtes actuellement
+        L'hôte du serveur de la base de données sur lequel vous êtes actuellement
         connecté. Ceci est configuré à chaque fois que vous vous connectez à une
         base de données (ainsi qu'au lancement du programme) mais peut être
         changé ou désinitialisé.
@@ -3745,7 +3732,7 @@ bar
        </para>
        <note>
         <para>
-         Cette fonctionnalité a été plagiée sur
+         Cette fonctionnalité a été plagiée sans vergogne sur
          <application>Bash</application>.
         </para>
        </note>
@@ -3781,9 +3768,9 @@ bar
         ne le sont pas lors de la lecture de scripts. Lorsqu'il est configuré
         à <literal>off</literal> (valeur par défaut), une instruction générant une
         erreur dans un bloc de transaction annule la transaction complète. Le
-        mode on_error_rollback-on fonctionne en exécutant un
+        mode avec <literal>on</literal> fonctionne en exécutant un
         <command>SAVEPOINT</command> implicite pour vous, juste avant chaque commande
-        se trouvant dans un bloc de transaction et annule jusqu'au dernier
+        se trouvant dans un bloc de transaction, et annule jusqu'au
         point de sauvegarde si la commande échoue.
        </para>
       </listitem>
@@ -3796,14 +3783,14 @@ bar
         Par défaut, le traitement des commandes continue après une
         erreur. Quand cette variable est positionnée à <literal>on</literal>, le traitement
         sera immédiatement arrêté dès la première erreur rencontrée.
-        Dans le mode interactif, <application>psql</application>
-        reviendra à l'invite de commande. Sinon
+        En mode interactif, <application>psql</application>
+        reviendra à l'invite de commande&nbsp;; sinon
         <application>psql</application> quittera en renvoyant le code
         d'erreur 3 pour distinguer ce cas des conditions d'erreurs
         fatales, qui utilisent le code 1. Dans tous les cas, tout script
-        en cours d'exécution (le script de haut niveau et tout autre
-        script qui pourrait avoir été appelé) sera terminé
-        immédiatement. Si la chaîne de commande de haut niveau contient
+        en cours d'exécution (le script de plus haut niveau, s'il y a, et
+        tout autre script qui pourrait avoir été appelé) sera terminé
+        immédiatement. Si la chaîne de commande de plus haut niveau contient
         plusieurs commandes SQL, le traitement s'arrêtera à la commande
         en cours.
        </para>
@@ -3906,7 +3893,7 @@ bar
       <term><varname>USER</varname></term>
       <listitem>
        <para>
-        L'utilisateur de la base de données où vous êtes actuellement
+        L'utilisateur de la base de données sur laquelle vous êtes actuellement
         connecté. Ceci est configuré à chaque fois que vous vous connectez à une
         base de données (ainsi qu'au lancement du programme) mais peut être
         changé ou désinitialisé.
@@ -3968,7 +3955,7 @@ basetest=&gt; <userinput>SELECT * FROM :foo;</userinput>
      </programlisting>
      envoie alors la requête pour la table <literal>ma_table</literal>. Notez que cela peut
      être dangereux&nbsp;; la valeur de la variable est copiée de façon litérale, elle peut
-     même contenir des guillemets non fermés, ou bien des commandes backslash. Vous devez
+     même contenir des guillemets non fermés, ou bien des commandes antislash. Vous devez
      vous assurer que cela a du sens à l'endroit où vous les utilisez.
     </para>
 
@@ -4007,22 +3994,22 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
     </para>
 
     <para>
-     Comme les caractères deux-points peuvent légitimement apparaître dans les
+     Comme des caractères deux-points peuvent légitimement apparaître dans les
      commandes SQL, une tentative apparente d'interpolation (comme <literal>:nom</literal>,
      <literal>:'nom'</literal>, ou <literal>:"nom"</literal>) n'est pas remplacée, sauf si
      la variable nommée est actuellement positionnée. Dans tous les cas, vous pouvez échapper un
-     caractère deux-points avec un backslash pour le protéger des substitutions.
+     caractère deux-points avec un antislash pour le protéger des substitutions.
     </para>
 
     <para>
      La syntaxe deux-points pour les variables est du <acronym>SQL</acronym> standard pour
      les langages de requête embarqués, comme <application>ECPG</application>.
      La syntaxe avec les deux-points pour les tranches de tableau et les conversions de types
-     sont des extensions <productname>PostgreSQL</productname> extensions, qui peut parfois
+     sont des extensions <productname>PostgreSQL</productname>, qui peut parfois
      provoquer un conflit avec l'utilisation standard.
      La syntaxe avec le caractère deux-points pour échapper la valeur d'une variable en tant
-     que chaîne SQL litérale ou identifiant est une extension <application>psql</application>
-     .
+     que chaîne SQL litérale ou identifiant est une extension
+     <application>psql</application>.
     </para>
 
    </refsect3>
@@ -4038,9 +4025,11 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
      l'invite. L'invite 1 est l'invite normale qui est lancée quand
      <application>psql</application> réclame une nouvelle commande. L'invite 2 est
      lancée lorsqu'une saisie supplémentaire est attendue lors de la saisie de la
-     commande parce que la commande n'a pas été terminée avec un point-virgule ou
-     parce qu'un guillemet n'a pas été fermé. L'invite 3 est lancée lorsque vous
-     exécutez une commande <acronym>SQL</acronym> <command>COPY FROM stdin</command> et que
+     commande, par exemple parce que la commande n'a pas été terminée avec un
+     point-virgule ou qu'un guillemet n'a pas été fermé.
+     L'invite 3 est lancée lorsque vous
+     exécutez une commande <acronym>SQL</acronym>
+     <command>COPY FROM stdin</command> et que
      vous devez saisir les valeurs des lignes sur le terminal.
     </para>
 
@@ -4131,17 +4120,19 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
         <para>
 	Dans le prompt 1 normalement <literal>=</literal>, mais
 	<literal>@</literal> si la session est dans une branche inactive d'un
-	bloc conditionnel, ou <literal>^</literal> si la session est
+	bloc conditionnel, ou <literal>^</literal> en mode simple ligne,
+    ou <literal>!</literal> si la session est
 	déconnectée de la base (ce qui peut arriver si <command>\connect</command>
 	échoue). Dans le prompt 2, <literal>%R</literal> est remplacé par un
-	caractère qui dépend de la raison pour laquelle psql attend des entrées
-	supplémentaires&nbsp;: <literal>-</literal> si la commande n'est pas encore
+	caractère qui dépend de la raison pour laquelle
+    <application>psql</application> attend des entrées
+	supplémentaires&nbsp;: <literal>-</literal> si la commande n'est juste pas
 	terminée, mais <literal>*</literal> s'il y a un commentaire
 	<literal>/* ... */</literal> non terminé,
-	un guillemet simple pour une chaîne de caractères échappée non
-	terminée,
-	un guillemet double pour un identifiant échappé non terminé,
-	un signe dollar pour une chaîne de caractères échappée avec un dollar,
+	un guillemet simple pour une chaîne de caractères entre guillemets simples
+    non terminée,
+    un guillemet double pour un identifiant échappé non terminé,
+	un signe dollar pour une chaîne de caractères entre dollars,
 	ou <literal>(</literal> s'il y a une parenthèse ouvrante sans correspondance.
         Dans le prompt 3, <literal>%R</literal> n'a aucun effet.
         </para>
@@ -4153,10 +4144,10 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
        <listitem>
         <para>
          État de la Transaction&nbsp;: une chaîne vide lorsque vous n'êtes pas
-         dans un bloc de transaction ou <literal>*</literal> si vous vous y trouvez, ou
-         <literal>!</literal> si vous êtes dans une transaction échouée, ou enfin
+         dans un bloc de transaction, ou <literal>*</literal> si vous y êtes, ou
+         <literal>!</literal> dans une transaction échouée, ou
          <literal>?</literal> lorsque l'état de la transaction est indéterminé (par
-         exemple à cause d'une rupture de la connexion).
+         exemple parce qu'il n'y a pas de connexion).
         </para>
        </listitem>
       </varlistentry>
@@ -4165,7 +4156,7 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
         <term><literal>%l</literal></term>
         <listitem>
          <para>
-          Le numéro de ligne dans la requête courante, en commençant à partir
+          Le numéro de ligne dans la requête courante, en partant
           de <literal>1</literal>.
          </para>
         </listitem>
@@ -4199,8 +4190,8 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
         class="parameter">commande</replaceable><literal>`</literal></term>
        <listitem>
         <para>
-         la sortie de la <replaceable
-         class="parameter">commande</replaceable>, similaire à la substitution
+         La sortie de la <replaceable class="parameter">commande</replaceable>,
+         similaire à la substitution
          par <quote>guillemets inverse</quote> classique.
         </para>
        </listitem>
@@ -4217,7 +4208,7 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
          <application>Readline</application> fonctionnent correctement, les
          caractères de contrôle non affichables doivent être indiqués comme
          invisibles en les entourant avec <literal>%[</literal> et
-         <literal>%]</literal>. Des pairs multiples de ceux-ci pourraient
+         <literal>%]</literal>. Des paires multiples de ceux-ci peuvent
          survenir à l'intérieur de l'invite. Par exemple&nbsp;:
          <programlisting>basetest=&gt; \set PROMPT1 '%[%033[1;33;40m%]%n@%/%R%[%033[0m%]%# '
          </programlisting>
@@ -4238,7 +4229,7 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
 
     <note>
      <para>
-      Cette fonctionnalité a été plagiée sur
+      Cette fonctionnalité a été plagiée sans vergogne sur
       <application>tcsh</application>.
      </para>
     </note>
@@ -4258,7 +4249,7 @@ basetest=&gt; <userinput>INSERT INTO ma_table VALUES (:'contenu');</userinput>
      complétion n'ait pas la prétention d'être un analyseur
      <acronym>SQL</acronym>. Les requêtes générées par complétion peuvent aussi
      interférer avec les autres commandes SQL, par exemple <literal>SET
-      TRANSACTION ISOLATION LEVEL</literal>. Si pour quelques raisons que ce soit,
+      TRANSACTION ISOLATION LEVEL</literal>. Si pour quelque raison que ce soit
      vous n'aimez pas la complétion par tabulation, vous pouvez la désactiver en
      plaçant ceci dans un fichier nommé <filename>.inputrc</filename> de votre
      répertoire personnel&nbsp;:
@@ -4378,7 +4369,7 @@ PSQL_EDITOR_LINENUMBER_ARG='--line '
     <listitem>
      <para>
       Emplacement alternatif pour le fichier d'historique des commandes.
-      L'expansion du symbôle <literal>~</literal> est réalisée.
+      L'expansion du symbole <literal>~</literal> est réalisée.
      </para>
     </listitem>
    </varlistentry>
@@ -4505,15 +4496,16 @@ PSQL_EDITOR_LINENUMBER_ARG='--line '
      des serveurs plus récents que <application>psql</application> lui-même.
      Les fonctionnalités générales d'exécution de commandes SQL et d'affichage
      des résultats des requêtes devraient aussi fonctionner avec les serveurs
-     d'une version majeure plus récente mais ce n'est pas garanti dans tous
-     les cas.
+     d'une version majeure plus récente mais ce n'est peut être garanti dans
+     tous les cas.
     </para>
     <para>
      Si vous voulez utiliser <application>psql</application> pour vous
      connecter à différentes versions majeures, il est recommandé d'utiliser
      la dernière version de <application>psql</application>. Autrement, vous
-     pouvez conserver une copie de psql pour chaque version majeure utilisée
-     et vous assurez que la version utilisée correspond au serveur respectif.
+     pouvez conserver une copie de <application>psql</application>
+     pour chaque version majeure utilisée
+     et vous assurer que la version utilisée correspond au serveur respectif.
      En pratique, cette complication supplémentaire n'est pas nécessaire.
     </para>
    </listitem>
@@ -4545,7 +4537,7 @@ PSQL_EDITOR_LINENUMBER_ARG='--line '
   <para>
    <application>psql</application> est construit comme une
    <quote>application de type console</quote>. Comme les fenêtres console de
-   windows utilisent un codage différent du reste du système, vous devez
+   Windows utilisent un codage différent du reste du système, vous devez
    avoir une attention particulière lors de l'utilisation de caractères sur
    8 bits à l'intérieur de <application>psql</application>. Si
    <application>psql</application> détecte une page de code problématique,
@@ -4582,9 +4574,9 @@ PSQL_EDITOR_LINENUMBER_ARG='--line '
    Le premier exemple montre comment envoyer une commande sur plusieurs lignes
    d'entrée. Notez le changement de l'invite&nbsp;:
    <programlisting>basetest=&gt; <userinput>CREATE TABLE ma_table (</userinput>
-basetest(> <userinput> premier integer not NULL default 0,</userinput>
-basetest(> <userinput> second text)</userinput>
-basetest-> <userinput>;</userinput>
+basetest(&gt; <userinput> premier integer not NULL default 0,</userinput>
+basetest(&gt; <userinput> second text)</userinput>
+basetest-&gt; <userinput>;</userinput>
 CREATE TABLE
    </programlisting>
    Maintenant, regardons la définition de la table&nbsp;:
@@ -4597,79 +4589,79 @@ CREATE TABLE
    </programlisting>
    Maintenant, changeons l'invite par quelque chose de plus intéressant&nbsp;:
    <programlisting>basetest=&gt; <userinput>\set PROMPT1 '%n@%m %~%R%# '</userinput>
-peter@localhost basetest=&gt;
+pierre@localhost basetest=&gt;
    </programlisting>
    Supposons que nous avons rempli la table de données et que nous voulons les
    regarder&nbsp;:
-   <programlisting>peter@localhost basetest=&gt; SELECT * FROM ma_table;
+   <programlisting>pierre@localhost basetest=&gt; SELECT * FROM ma_table;
  premier | second
 ---------+--------
-       1 | one
-       2 | two
-       3 | three
-       4 | four
+       1 | un
+       2 | deux
+       3 | trois
+       4 | quatre
 (4 rows)
 
    </programlisting>
    Vous pouvez afficher cette table de façon différente en utilisant la
    commande <command>\pset</command>&nbsp;:
-   <programlisting>peter@localhost basetest=&gt; <userinput>\pset border 2</userinput>
+   <programlisting>pierre@localhost basetest=&gt; <userinput>\pset border 2</userinput>
 Border style is 2.
-peter@localhost basetest=&gt; <userinput>SELECT * FROM ma_table;</userinput>
----------+--------+
+pierre@localhost basetest=&gt; <userinput>SELECT * FROM ma_table;</userinput>
++---------+--------+
 | premier | second |
----------+--------+
-|       1 | one    |
-|       2 | two    |
-|       3 | three  |
-|       4 | four   |
----------+--------+
++---------+--------+
+|       1 | un     |
+|       2 | deux   |
+|       3 | trois  |
+|       4 | quatre |
++---------+--------+
 (4 rows)
 
-peter@localhost basetest=&gt; <userinput>\pset border 0</userinput>
+pierre@localhost basetest=&gt; <userinput>\pset border 0</userinput>
 Border style is 0.
-peter@localhost basetest=&gt; <userinput>SELECT * FROM ma_table;</userinput>
+pierre@localhost basetest=&gt; <userinput>SELECT * FROM ma_table;</userinput>
 premier second
 ------- ------
-      1 one
-      2 two
-      3 three
-      4 four
+      1 un
+      2 deux
+      3 trois
+      4 quatre
 (4 rows)
 
-peter@localhost basetest=&gt; <userinput>\pset border 1</userinput>
+pierre@localhost basetest=&gt; <userinput>\pset border 1</userinput>
 Border style is 1.
-peter@localhost basetest=&gt; <userinput>\pset format unaligned</userinput>
+pierre@localhost basetest=&gt; <userinput>\pset format unaligned</userinput>
 Output format is unaligned.
-peter@localhost basetest=&gt; <userinput>\pset fieldsep ","</userinput>
+pierre@localhost basetest=&gt; <userinput>\pset fieldsep ","</userinput>
 Field separator is ",".
-peter@localhost basetest=&gt; <userinput>\pset tuples_only</userinput>
+pierre@localhost basetest=&gt; <userinput>\pset tuples_only</userinput>
 Showing only tuples.
-peter@localhost basetest=&gt; <userinput>SELECT second, first FROM
+pierre@localhost basetest=&gt; <userinput>SELECT second, premier FROM
 ma_table;</userinput>
-one,1
-two,2
-three,3
-four,4
+un,1
+deux,2
+trois,3
+quatre,4
    </programlisting>
    Vous pouvez aussi utiliser les commandes courtes&nbsp;:
-   <programlisting>peter@localhost basetest=&gt; <userinput>\a \t \x</userinput>
+   <programlisting>pierre@localhost basetest=&gt; <userinput>\a \t \x</userinput>
 Output format is aligned.
 Tuples only is off.
 Expanded display is on.
-peter@localhost basetest=&gt; <userinput>SELECT * FROM ma_table;</userinput>
--[ RECORD 1 ]-
-first  | 1
-second | one
--[ RECORD 2 ]-
-first  | 2
-second | two
--[ RECORD 3 ]-
-first  | 3
-second | three
--[ RECORD 4 ]-
-first  | 4
-second | four
+pierre@localhost basetest=&gt; <userinput>SELECT * FROM ma_table;</userinput>
+-[ RECORD 1 ]---
+premier  | 1
+second   | un
+-[ RECORD 2 ]---
+premier  | 2
+second   | deux
+-[ RECORD 3 ]---
+premier  | 3
+second   | trois
+-[ RECORD 4 ]---
+premier  | 4
+second   | quatre
    </programlisting>
   </para>
 
@@ -4678,21 +4670,21 @@ second | four
   représentation croisée avec la commande <command>\crosstabview</command>&nbsp;:
 <programlisting>
 testdb=&gt; <userinput>SELECT first, second, first &gt; 2 AS gt2 FROM my_table;</userinput>
- first | second | gt2
--------+--------+-----
-     1 | one    | f
-     2 | two    | f
-     3 | three  | t
-     4 | four   | t
+premier | second | gt2
+---------+--------+-----
+      1 | un     | f
+      2 | deux   | f
+      3 | trois  | t
+      4 | quatre | t
 (4 rows)
 
-testdb=&gt; <userinput>\crosstabview first second</userinput>
- first | one | two | three | four
--------+-----+-----+-------+------
-     1 | f   |     |       |
-     2 |     | f   |       |
-     3 |     |     | t     |
-     4 |     |     |       | t
+testdb=&gt; <userinput>\crosstabview premier second</userinput>
+premier | un | deux | trois | quatre
+---------+----+------+-------+--------
+      1 | f  |      |       |
+      2 |    | f    |       |
+      3 |    |      | t     |
+      4 |    |      |       | t
 (4 rows)
 </programlisting>
 
@@ -4700,9 +4692,9 @@ Ce deuxième exemple montre une table de multiplication avec les lignes triées
 en ordre numérique inverse et les colonnes dans un ordre numérique ascendant
 indépendant.
 <programlisting>
-testdb=&gt; <userinput>SELECT t1.first as "A", t2.first+100 AS "B", t1.first*(t2.first+100) as "AxB",</userinput>
-testdb(&gt; <userinput>row_number() over(order by t2.first) AS ord</userinput>
-testdb(&gt; <userinput>FROM my_table t1 CROSS JOIN my_table t2 ORDER BY 1 DESC</userinput>
+testdb=&gt; <userinput>SELECT t1.premier as "A", t2.premier+100 AS "B", t1.premier*(t2.premier+100) as "AxB",</userinput>
+testdb(&gt; <userinput>row_number() over(order by t2.premier) AS ord</userinput>
+testdb(&gt; <userinput>FROM ma_table t1 CROSS JOIN ma_table t2 ORDER BY 1 DESC</userinput>
 testdb(&gt; <userinput>\crosstabview "A" "B" "AxB" ord</userinput>
  A | 101 | 102 | 103 | 104
 ---+-----+-----+-----+-----


### PR DESCRIPTION
Relecture complète de psql-ref.xml en face de la VO en 10.4.

Diverses améliorations de style ou de correction d'écart avec le texte original
Quelques fautes de frappe ou d'accord, ou de temps pas identique à la source.
2-3 paragraphes mal placés ou absents
Métacommande n'a pas de tiret.
Harmonisation de "en-tête"/"entête sur l'orthographe ancienne.
"Tableau croisé" et non "grille croisée"
Laissé "Large Objects" comme apparemment dans le reste de la doc, au lieu du peu heureux "objets larges" (sinon :  grand objets ?)

J'ai revu l'exemple à la fin et terminé sa francisation.

En prime, deux typos dans plpython.xml vues par hasard.