### PR TITLE
Libpq.xml : traduction nouveautés v11ß3 et relecture

### DIFF
--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -2845,7 +2845,7 @@ void *PQgetssl(const PGconn *conn);
           <para>
            La structure <structname>PGresult</structname> contient une seule
            ligne de résultat provenant de la commande courante. Ce statut
-           n'intervient que lorsque le mode simple ligne a été sélectionné
+           n'intervient que lorsque le mode ligne-à-ligne a été sélectionné
            pour cette requête (voir <xref linkend="libpq-single-row-mode"/>).
           </para>
          </listitem>
@@ -4126,15 +4126,15 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
  <para>
   La fonction <function>PQexec</function> est adéquate pour soumettre des
-  commandes aux applications standards, synchrones. Néanmoins, il a quelques
-  déficiences pouvant être d'importance à certains utilisateurs&nbsp;:
+  commandes aux applications standards, synchrones. Néanmoins, elle a quelques
+  défauts pouvant être d'importance à certains utilisateurs&nbsp;:
 
   <itemizedlist>
    <listitem>
     <para>
      <function>PQexec</function> attend que la commande se termine. L'application
-     pourrait avoir d'autres travaux à réaliser (comme le rafraichissement de
-     l'interface utilisateur), auquel cas il ne voudra pas être bloqué en attente
+     pourrait avoir du travail ailleur (comme le rafraîchissement de
+     l'interface utilisateur), auquel cas elle ne voudra pas être bloquée en attente
      de la réponse.
     </para>
    </listitem>
@@ -4194,9 +4194,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
        Après un appel réussi à <function>PQsendQuery</function>, appelez
        <function>PQgetResult</function> une ou plusieurs fois pour obtenir
-       les résultats. <function>PQsendQuery</function>  ne peut pas être appelé
+       les résultats. <function>PQsendQuery</function> ne peut pas être appelé
        de nouveau (sur la même connexion) tant que
-       <function>PQgetResult</function> ne renvoie pas de pointeur nul,
+       <function>PQgetResult</function> ne renvoie pas de pointeur NULL,
        indiquant que la commande a terminé.
       </para>
      </listitem>
@@ -4219,11 +4219,11 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       </synopsis>
 
       Ceci est équivalent à <function>PQsendQuery</function> sauf que les
-      paramètres de requêtes peuvent être spécifiés à partir de la chaîne de
+      paramètres de requêtes peuvent être spécifiés séparément à partir de la chaîne de
       requête. Les paramètres de la fonction sont gérés de façon identique à
       <function>PQexecParams</function>. Comme
       <function>PQexecParams</function>, cela ne fonctionnera pas
-      pour les connexions utilisant le protocole 2.0 et cela ne permettra
+      pour les connexions utilisant le protocole 2.0 et cela ne permet
       qu'une seule commande dans la chaîne de requête.
      </para>
     </listitem>
@@ -4270,7 +4270,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
       Ceci est similaire à <function>PQsendQueryParams</function> mais la
       commande à exécuter est spécifiée en nommant une instruction
-      précédemment préparée au lieu de donner une chaîne contenant la
+      préparée précédente au lieu de donner une chaîne contenant la
       requête. Les paramètres de la fonction sont gérés de façon identique à
       <function>PQexecPrepared</function>. Comme
       <function>PQexecPrepared</function>, cela ne fonctionnera pas pour les
@@ -4327,29 +4327,29 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQgetResult</function><indexterm><primary>PQgetResult</primary></indexterm></term>
     <listitem>
      <para>
-      Attend le prochain résultat d'un appel précédant à
+      Attend le prochain résultat d'un appel précédent à
       <function>PQsendQuery</function>,
       <function>PQsendQueryParams</function>,
       <function>PQsendPrepare</function>,
       <function>PQsendQueryPrepared</function>,
       <function>PQsendDescribePrepared</function> ou
       <function>PQsendDescribePortal</function>, et le renvoie. Un pointeur
-      nul est renvoyé quand la commande est terminée et qu'il n'y aura plus
+      NULL est renvoyé quand la commande est terminée et qu'il n'y aura plus
       de résultats.
       <synopsis>PGresult *PQgetResult(PGconn *conn);
       </synopsis>
      </para>
 
      <para>
-      <function>PQgetResult</function> doit être appelé de façon répété
-      jusqu'à ce qu'il retourne un pointeur nul indiquant que la commande
-      s'est terminée (si appelé à un moment où aucune commande n'est
-      active, <function>PQgetResult</function> renverra seulement un
-      pointeur nul à la fois). Chaque résultat non nul provenant de
+      <function>PQgetResult</function> doit être appelé de façon répétée
+      jusqu'à ce qu'il retourne un pointeur NULL indiquant que la commande
+      s'est terminée. (Si appelée à un moment où aucune commande n'est
+      active, <function>PQgetResult</function> renverra juste immédiatement un
+      pointeur NULL). Chaque résultat non NULL provenant de
       <function>PQgetResult</function> devrait être traité en utilisant les
       mêmes fonctions d'accès à <structname>PGresult</structname> que celles
       précédemment décrites. N'oubliez pas de libérer chaque objet résultat
-      avec <function>PQclear</function> une fois que vous en avez terminé.
+      avec <function>PQclear</function> quand vous en avez terminé.
       Notez que <function>PQgetResult</function> bloquera seulement si la
       commande est active et que les données nécessaires en réponse n'ont
       pas encore été lues par <function>PQconsumeInput</function>.
@@ -4359,7 +4359,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <para>
        Même quand <function>PQresultStatus</function> indique une erreur
        fatale, <function>PQgetResult</function> doit être appelé
-       jusqu'à ce qu'il renvoie un pointeur nul pour permettre à
+       jusqu'à ce qu'il renvoie un pointeur NULL pour permettre à
        <application>libpq</application> de traiter l'information sur
        l'erreur correctement.
       </para>
@@ -4380,7 +4380,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  </para>
 
  <para>
-  Une autre fonctionnalité fréquemment demandée, pouvant être obtenu avec
+  Une autre fonctionnalité fréquemment demandée, pouvant être obtenue avec
   <function>PQsendQuery</function> et <function>PQgetResult</function> est
   la récupération d'un gros résultat une ligne à la fois. Ceci est discuté
   dans <xref linkend="libpq-single-row-mode"/>.
@@ -4397,7 +4397,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQconsumeInput</function><indexterm><primary>PQconsumeInput</primary></indexterm></term>
     <listitem>
      <para>
-      Si l'entrée est disponible à partir du serveur, consommez-la.
+      Si l'entrée est disponible à partir du serveur, la consomme.
       <synopsis>int PQconsumeInput(PGconn *conn);
       </synopsis>
      </para>
@@ -4412,13 +4412,13 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       si leur état a changé.
      </para>
      <para>
-      <function>PQconsumeInput</function> pourrait être appelé même si l'application
-      n'est pas encore préparé à gérer un résultat ou une notification. La fonction
+      <function>PQconsumeInput</function> peut être appelé même si l'application
+      n'est pas encore préparée à traiter un résultat ou une notification. La fonction
       lira les données disponibles et les sauvegardera dans un tampon indiquant
       ainsi qu'une lecture d'un <function>select()</function> est possible.
       L'application peut donc utiliser <function>PQconsumeInput</function> pour
-      effacer la condition <function>select()</function> immédiatement, puis pour
-      examiner les résultats autant que possible.
+      effacer la condition <function>select()</function> immédiatement, puis
+      examiner les résultats à loisir.
      </para>
     </listitem>
    </varlistentry>
@@ -4428,9 +4428,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <listitem>
      <para>
       Renvoie 1 si une commande est occupée, c'est-à-dire que
-      <function>PQgetResult</function> bloquerait en attendant une entrée. Un zéro
-      indiquerait que <function>PQgetResult</function> peut être appelé avec
-      l'assurance de ne pas être bloqué.
+      <function>PQgetResult</function> bloque en attendant une entrée. Un zéro
+      indique que <function>PQgetResult</function> peut être appelé avec
+      l'assurance de ne pas bloquer.
       <synopsis>int PQisBusy(PGconn *conn);
       </synopsis>
      </para>
@@ -4438,7 +4438,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       <function>PQisBusy</function> ne tentera pas lui-même de lire les données à
       partir du serveur&nbsp;; du coup, <function>PQconsumeInput</function> doit être
-      appelé d'abord ou l'état occupé ne s'arrêtera jamais.
+      appelé d'abord ou l'état occupé ne prendra jamais fin.
      </para>
     </listitem>
    </varlistentry>
@@ -4448,14 +4448,14 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  <para>
   Une application typique de l'utilisation de ces fonctions aura une boucle
   principale utilisant <function>select()</function> ou <function>poll()</function> pour
-  attendre toutes les conditions auxquelles il doit répondre. Une des conditions
+  attendre que toutes les conditions soient remplies. Une des conditions
   sera la disponibilité des données à partir du serveur, ce qui signifie des données
   lisibles pour <function>select()</function> sur le descripteur de
   fichier identifié par <function>PQsocket</function>. Lorsque la boucle
-  principale détecte la disponibilité de données, il devrait appeler
-  <function>PQconsumeInput</function> pour lire l'en-tête. Il peut ensuite appeler
+  principale détecte la disponibilité de données, elle devrait appeler
+  <function>PQconsumeInput</function> pour lire l'en-tête. Elle peut ensuite appeler
   <function>PQisBusy</function> suivi par <function>PQgetResult</function> si
-  <function>PQisBusy</function> renvoie false (0). Il peut aussi appeler
+  <function>PQisBusy</function> renvoie false (0). Elle peut aussi appeler
   <function>PQnotifies</function> pour détecter les messages <command>NOTIFY</command>
   (voir la <xref linkend="libpq-notify"/>).
  </para>
@@ -4464,7 +4464,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   Un client qui utilise
   <function>PQsendQuery</function>/<function>PQgetResult</function> peut aussi
   tenter d'annuler une commande en cours de traitement par le
-  serveur&nbsp;; voir la <xref linkend="libpq-cancel"/>. Mais quelque soit la valeur
+  serveur&nbsp;; voir la <xref linkend="libpq-cancel"/>. Mais quelle que soit la valeur
   renvoyée par <function>PQcancel</function>, l'application doit continuer avec
   la séquence normale de lecture du résultat en utilisant
   <function>PQgetResult</function>. Une annulation réussie causera simplement une
@@ -4476,10 +4476,10 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   blocage pendant l'attente de données du serveur. Néanmoins, il est toujours
   possible que l'application se bloque en attendant l'envoi vers le serveur.
   C'est relativement peu fréquent mais cela peut arriver si de très longues
-  commandes SQL ou données sont envoyées (c'est bien plus probable si
-  l'application envoie des données via <command>COPY IN</command>).  Pour
-  empêcher cette possibilité et réussir des opérations de bases de données
-  totalement non bloquantes, les fonctions supplémentaires suivantes pourraient
+  commandes SQL ou données sont envoyées (mais c'est bien plus probable si
+  l'application envoie des données via <command>COPY IN</command>). Pour
+  éviter cette possibilité et parvenir à des opérations de bases de données
+  totalement non bloquantes, les fonctions supplémentaires suivantes peuvent
   être utilisées.
 
   <variablelist>
@@ -4532,7 +4532,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <listitem>
      <para>
       Tente de vider les données des queues de sortie du serveur. Renvoie 0 en cas de
-      succès (ou si la queue d'envoi est vide), -1 en cas d'échec quelque soit la
+      succès (ou si la queue d'envoi est vide), -1 en cas d'échec quelle que soit la
       raison ou 1 s'il a été incapable d'envoyer encore toutes les données dans la
       queue d'envoi (ce cas arrive seulement si la connexion est non bloquante).
       <synopsis>int PQflush(PGconn *conn);
@@ -4556,7 +4556,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   d'envoyer des données, par exemple des messages NOTICE, et ne va pas lire nos
   données tant que nous n'avons pas lu les siennes.) Une fois que
   <function>PQflush</function> renvoie 0, attendez que la socket soit disponible
-  en lecture puis lisez la réponse comme décrit ci-dessus.
+  en lecture, puis lisez la réponse comme décrit ci-dessus.
  </para>
 
 </sect1>
@@ -4566,40 +4566,40 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
  <indexterm zone="libpq-single-row-mode">
   <primary>libpq</primary>
-  <secondary>mode simple ligne</secondary>
+  <secondary>mode ligne-à-ligne</secondary>
  </indexterm>
 
  <para>
   D'habitude, <application>libpq</application> récupère le résultat complet
   d'une commande SQL et la renvoie à l'application sous la forme d'une seule
-  structure <structname>PGresult</structname>. Ce comportement peut être un
-  problème pour les commandes qui renvoient un grand nombre de lignes. Dans
+  structure <structname>PGresult</structname>. Ce peut être imparaticable
+  pour les commandes renvoyant un grand nombre de lignes. Dans
   de tels cas, les applications peuvent utiliser
   <function>PQsendQuery</function> et <function>PQgetResult</function> dans
-  le <firstterm>mode simple ligne</firstterm>. Dans ce mode, les lignes du
+  le <firstterm>mode ligne-à-ligne</firstterm>. Dans ce mode, les lignes du
   résultat sont renvoyées à l'application une par une, au fur et à mesure
   qu'elles sont reçues du serveur.
  </para>
 
  <para>
-  Pour entrer dans le mode simple ligne, appelez
+  Pour entrer dans le mode ligne-à-ligne, appelez
   <function>PQsetSingleRowMode</function> immédiatement après un appel
   réussi à <function>PQsendQuery</function> (ou une fonction similaire).
   Cette sélection de mode ne fonctionne que pour la requête en cours
   d'exécution. Puis appelez <function>PQgetResult</function> de façon répétée,
-  jusqu'à ce qu'elle renvoit null, comme documenté dans <xref
-  linkend="libpq-async"/>. Si la requête renvoit des lignes, ils sont renvoyées
-  en tant qu'objet <structname>PGresult</structname> individuel, qui ressemble
+  jusqu'à ce qu'elle renvoit NULL, comme documenté dans <xref
+  linkend="libpq-async"/>. Si la requête renvoit des lignes, elles sont renvoyées
+  en tant qu'objets <structname>PGresult</structname> individuels, qui ressemblent
   à des résultats de requêtes standards en dehors du fait qu'elles ont le code
   de statut <literal>PGRES_SINGLE_TUPLE</literal> au lieu de
-  <literal>PGRES_TUPLES_OK</literal>. Après la dernière ligne ou immédiatement
-  si la requête ne renvoit aucune ligne, un objet de zéro ligne avec le statut
+  <literal>PGRES_TUPLES_OK</literal>. Après la dernière ligne, ou immédiatement
+  si la requête ne renvoit aucune ligne, un objet à zéro ligne avec le statut
   <literal>PGRES_TUPLES_OK</literal> est renvoyé&nbsp;; c'est le signal
   qu'aucune autre ligne ne va arriver. (Notez cependant qu'il est toujours
   nécessaire de continuer à appeler <function>PQgetResult</function> jusqu'à
-  ce qu'elle renvoit null.) Tous les objets <structname>PGresult</structname>
+  ce qu'elle renvoit NULL.) Tous les objets <structname>PGresult</structname>
   contiendront les mêmes données de description de lignes (noms de colonnes,
-  types, etc) qu'un objet <structname>PGresult</structname> standard aurait
+  types, etc.) qu'un objet <structname>PGresult</structname> standard aurait
   pour cette requête. Chaque objet doit être libéré avec la fonction
   <function>PQclear</function> comme d'ordinaire.
  </para>
@@ -4629,7 +4629,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       toute autre opération sur la connexion comme
       <function>PQconsumeInput</function> ou
       <function>PQgetResult</function>. Si elle est appelée au bon moment,
-      la fonction active le mode simple ligne pour la requête en cours et
+      la fonction active le mode ligne-à-ligne pour la requête en cours et
       renvoit 1. Sinon, le mode reste inchangé et la fonction renvoit 0. Dans
       tous les cas, le mode retourne à la normale après la fin de la requête
       en cours.
@@ -4641,13 +4641,13 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
  <caution>
   <para>
-   Lors du traitement d'une requête, le serveur pourrait renvoyer quelques
+   Lors du traitement d'une requête, le serveur peut renvoyer quelques
    lignes puis rencontrer une erreur, causant l'annulation de la requête.
    D'ordinaire, la bibliothèque partagée <application>libpq</application>
-   annule ces lignes et renvoit une erreur. Avec le mode simple ligne,
+   jette ces lignes et renvoit une erreur. Avec le mode ligne-à-ligne,
    des lignes ont déjà pu être envoyées à l'application. Du coup, l'application
    verra quelques objets <structname>PGresult</structname> de statut
-   <literal>PGRES_SINGLE_TUPLE</literal> suivi par un objet de statut
+   <literal>PGRES_SINGLE_TUPLE</literal> suivis par un objet de statut
    <literal>PGRES_FATAL_ERROR</literal>. Pour un bon comportement transactionnel,
    l'application doit être conçue pour invalider ou annuler tout ce qui a été
    fait avec les lignes précédemment traitées si la requête finit par échouer.
@@ -4681,9 +4681,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      <function>PQgetCancel</function> crée un objet fonction
-      <structname>PGcancel</structname><indexterm><primary>PGcancel</primary></indexterm> avec un
-      objet connexion <structname>PGconn</structname>. Il renverra
+      <function>PQgetCancel</function> crée un objet
+      <structname>PGcancel</structname><indexterm><primary>PGcancel</primary></indexterm>
+      à partir d'un objet connexion <structname>PGconn</structname>. Il renverra
       <symbol>NULL</symbol> si le paramètre <parameter>conn</parameter>
       donné est <symbol>NULL</symbol> ou est une connexion
       invalide. L'objet <structname>PGcancel</structname> est une structure opaque
@@ -4741,10 +4741,10 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      <function>PQcancel</function> peut être invoqué de façon sûr
+      <function>PQcancel</function> peut être invoqué de façon sûre
       par le gestionnaire de signaux si <parameter>errbuf</parameter> est une
       variable locale dans le gestionnaire de signaux. L'objet
-      <structname>PGcancel</structname> est en lecture seule pour ce qui
+      <structname>PGcancel</structname> est en lecture seule en ce qui
       concerne <function>PQcancel</function>, pour qu'il puisse aussi
       être appelé à partir d'un thread séparé de celui manipulant
       l'objet <structname>PGconn</structname>.
@@ -4771,8 +4771,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <structname>PGconn</structname> et, en cas d'échec, stocke le message d'erreur
       dans l'objet <structname>PGconn</structname> (d'où il peut être récupéré avec
       <function>PQerrorMessage</function>). Bien qu'il s'agisse de la même
-      fonctionnalité, cette approche est hasardeuse en cas de programmes
-      compatibles avec les threads ainsi que pour les gestionnaires de
+      fonctionnalité, cette approche est hasardeuse dans les programmes
+      multi-threads et les gestionnaires de
       signaux car il est possible que la surcharge du message d'erreur de
       <structname>PGconn</structname> gênera l'opération en cours sur la connexion.
      </para>
@@ -4784,15 +4784,16 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 </sect1>
 
 <sect1 id="libpq-fastpath">
- <title>Interface à chemin rapide</title>
+ <title>Interface rapide (Fast Path)</title>
 
  <indexterm zone="libpq-fastpath"><primary>fast path</primary></indexterm>
 
  <indexterm zone="libpq-fastpath"><primary>chemin rapide</primary></indexterm>
 
  <para>
-  <productname>PostgreSQL</productname> fournit une interface rapide pour
-  envoyer des appels de fonctions simples au serveur.
+  <productname>PostgreSQL</productname> fournit une interface rapide
+  (<foreignphrase>Fast Path</foreignphrase>) pour des appels de fonctions
+  simples au serveur.
  </para>
 
  <tip>
@@ -4836,9 +4837,10 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   d'arguments déclarés de la fonction. Quand le champ
   <parameter>isint</parameter> d'une structure est vrai, la valeur de
   <parameter>u.integer</parameter> est envoyée au serveur en tant qu'entier de
-  la longueur indiquée (qui doit être 2 ou 4 octets)&nbsp;; les bons échanges
-  d'octets se passent. Quand <parameter>isint</parameter> est faux, le nombre
-  d'octets indiqué sur <parameter>*u.ptr</parameter> est envoyé au
+  la longueur indiquée (qui doit être 2 ou 4 octets)&nbsp;; les permtutations
+  d'octets adéquates sont opérées.
+  Quand <parameter>isint</parameter> est faux, le nombre
+  d'octets indiqué sur <parameter>*u.ptr</parameter> est envoyé sans
   traitement&nbsp;; les données doivent être dans le format attendu par le
   serveur pour la transmission binaire du type de données de l'argument de la
   fonction. (La déclaration de <parameter>u.ptr</parameter> en tant que type
@@ -4846,15 +4848,15 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   comme un <type>void *</type>.) <parameter>result_buf</parameter> pointe vers
   le tampon dans lequel placer le code de retour de la fonction. L'appelant doit
   avoir alloué suffisamment d'espace pour stocker le code de retour (il n'y a
-  pas de vérification&nbsp;!). La longueur actuelle du résultat en octet sera
-  renvoyé dans l'entier pointé par <parameter>result_len</parameter>. Si un
+  pas de vérification&nbsp;!). La longueur effective du résultat en octet sera
+  renvoyée dans l'entier pointé par <parameter>result_len</parameter>. Si un
   résultat sur un entier de 2 ou 4 octets est attendu, initialisez
   <parameter>result_is_int</parameter> à 1, sinon initialisez-le à 0.
   Initialiser <parameter>result_is_int</parameter> à 1 fait que
-  <application>libpq</application> échange les octets de la valeur si nécessaire,
+  <application>libpq</application> permute les octets de la valeur si nécessaire,
   de façon à ce que la bonne valeur <type>int</type> soit délivrée pour la
   machine cliente&nbsp;; notez qu'un entier sur quatre octets est fourni dans
-  <parameter>*result_buf</parameter> pour la taille du résultat autorisé. Quand
+  <parameter>*result_buf</parameter> pour chaque taille de résultat autorisée. Quand
   <parameter>result_is_int</parameter> vaut 0, la chaîne d'octets au format
   binaire envoyée par le serveur est renvoyée non modifiée. (Dans ce cas, il est
   préférable de considérer <parameter>result_buf</parameter> comme étant du type
@@ -4865,13 +4867,13 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   <function>PQfn</function> renvoie toujours un pointeur
   <structname>PGresult</structname> valide. L'état du résultat devrait être
   vérifié avant que le résultat ne soit utilisé. Le demandeur est responsable de
-  la libération de la structure <structname>PGresult</structname>  avec
+  la libération de la structure <structname>PGresult</structname> avec
   <function>PQclear</function> lorsque celle-ci n'est plus nécessaire.
  </para>
 
  <para>
-  Notez qu'il n'est pas possible de gérer les arguments nuls, les résultats nuls
-  et les résultats d'ensembles nuls en utilisant cette interface.
+  Notez qu'il n'est pas possible de gérer les arguments NULL, les résultats NULL
+  et les résultats d'ensembles NULL en utilisant cette interface.
  </para>
 
 </sect1>
@@ -4885,14 +4887,14 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  </indexterm>
 
  <para>
-  <productname>PostgreSQL</productname> propose des notifications asynchrone via
+  <productname>PostgreSQL</productname> propose des notifications asynchrones via
   les commandes <command>LISTEN</command> et <command>NOTIFY</command>. Une
   session cliente enregistre son intérêt dans un canal particulier avec
   la commande <command>LISTEN</command> (et peut arrêter son écoute avec la
   commande <command>UNLISTEN</command>). Toutes les sessions écoutant un
   canal particulier seront notifiées de façon asynchrone lorsqu'une commande
   <command>NOTIFY</command> avec ce nom de canal sera exécutée par une
-  session. Une chaîne de <quote>charge</quote> peut être renseigné pour fournir
+  session. Une chaîne de <quote>charge</quote> peut être renseignée pour fournir
   des données supplémentaires aux processus en écoute.
  </para>
 
@@ -4908,7 +4910,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  <para>
   La fonction <function>PQnotifies</function> renvoie la prochaine notification à
   partir d'une liste de messages de notification non gérés reçus à partir du
-  serveur. Il renvoie un pointeur nul s'il n'existe pas de notifications en
+  serveur. Il renvoie un pointeur NULL s'il n'existe pas de notifications en
   attente. Une fois qu'une notification est renvoyée à partir de
   <function>PQnotifies</function>, elle est considérée comme étant gérée et sera supprimée
   de la liste des notifications.
@@ -4944,7 +4946,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   réception à temps des messages <command>NOTIFY</command> consistait à soumettre
   constamment des commandes de soumission, même vides, puis de vérifier
   <function>PQnotifies</function> après chaque <function>PQexec</function>. Bien
-  que ceci fonctionnait, cela a été abandonné à cause de la perte de puissance.
+  que ceci fonctionnait, cela a été abandonné car un gaspillage de ressources.
  </para>
 
  <para>
@@ -4953,22 +4955,22 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   <function>PQconsumeInput</function> puis de vérifier
   <function>PQnotifies</function>. Vous pouvez utiliser
   <function>select()</function> pour attendre l'arrivée des données à partir du
-  serveur, donc en utilisant aucune puissance du <acronym>CPU</acronym> sauf
+  serveur, donc sans utiliser de <acronym>CPU</acronym> sauf
   lorsqu'il y a quelque chose à faire (voir <function>PQsocket</function> pour
   obtenir le numéro du descripteur de fichiers à utiliser avec
-  <function>select()</function>). Notez que ceci fonctionnera bien que vous
-  soumettez les commandes avec
+  <function>select()</function>). Notez que ceci fonctionnera que
+  soumettiez les commandes avec
   <function>PQsendQuery</function>/<function>PQgetResult</function> ou que vous
-  utilisez simplement <function>PQexec</function>. Néanmoins, vous devriez vous
+  utilisiez simplement <function>PQexec</function>. Néanmoins, vous devriez vous
   rappeler de vérifier <function>PQnotifies</function> après chaque
   <function>PQgetResult</function> ou <function>PQexec</function> pour savoir si
-  des notifications sont arrivées lors du traitement de la commande.
+  des notifications sont arrivées pendant le traitement de la commande.
  </para>
 
 </sect1>
 
 <sect1 id="libpq-copy">
- <title>Fonctions associées avec la commande <command>COPY</command></title>
+ <title>Fonctions associées à la commande <command>COPY</command></title>
 
  <indexterm zone="libpq-copy">
   <primary>COPY</primary>
@@ -4986,7 +4988,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  <para>
   Le traitement complet est le suivant. L'application lance tout d'abord la
   commande SQL <command>COPY</command> via <function>PQexec</function> ou une
-  des fonctions équivalents. La réponse à ceci (s'il n'y a pas d'erreur dans la
+  des fonctions équivalentes. La réponse à ceci (s'il n'y a pas d'erreur dans la
   commande) sera un objet <structname>PGresult</structname> avec un code de retour
   <literal>PGRES_COPY_OUT</literal> ou <literal>PGRES_COPY_IN</literal> (suivant
   la direction spécifiée pour la copie). L'application devrait alors utiliser les
@@ -4995,7 +4997,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   <structname>PGresult</structname> est renvoyé pour indiquer le succès ou l'échec du
   transfert. Son statut sera <literal>PGRES_COMMAND_OK</literal> en cas de succès
   et <literal>PGRES_FATAL_ERROR</literal> si un problème a été rencontré. À ce
-  point, toute autre commande SQL pourrait être exécutée via
+  point, d'autres commandes SQL peuvent être exécutées via
   <function>PQexec</function> (il n'est pas possible d'exécuter d'autres
   commandes SQL en utilisant la même connexion tant que l'opération
   <command>COPY</command> est en cours).
@@ -5022,7 +5024,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  <para>
   Un objet <structname>PGresult</structname> gérant un de ces statuts comporte quelques
   données supplémentaires sur l'opération <command>COPY</command> qui commence.
-  La données supplémentaire est disponible en utilisant les fonctions qui sont
+  Les données supplémentaires sont disponibles en utilisant les fonctions qui sont
   aussi utilisées en relation avec les résultats de requêtes&nbsp;:
 
   <variablelist>
@@ -5056,11 +5058,11 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Renvoie le code de format (0 pour le texte, 1 pour le binaire)
       associé avec chaque colonne de l'opération de copie. Les codes de
       format par colonne seront toujours zéro si le format de copie complet
-      est textuel mais le format binaire supporte à la fois des colonnes
+      est textuel, mais le format binaire supporte à la fois des colonnes
       textuelles et des colonnes binaires (néanmoins, avec l'implémentation
       actuelle de <command>COPY</command>, seules les colonnes binaires
-      apparaissent dans une copie binaire&nbsp; donc les formats par
-      colonnes correspondent toujours au format complet actuellement).
+      apparaissent dans une copie binaire&nbsp; donc pour le moment
+      les formats par colonnes correspondent toujours au format complet).
      </para>
     </listitem>
    </varlistentry>
@@ -5099,17 +5101,17 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       Transmet les données de <command>COPY</command> dans le tampon spécifié
       (<parameter>buffer</parameter>), sur <parameter>nbytes</parameter> octets, au serveur. Le résultat
-      vaut 1 si les données ont été placées dans la queue, zéro si elles n'ont pas été placées dans la queue car
-      la tentative pourrait bloquer (ce cas n'est possible que lors d'une connexion
-      en mode non bloquant) ou -1 si une erreur s'est produite (utilisez
+      vaut 1 si les données ont été placées dans la queue, zéro si elles n'ont
+      pas été placées dans la queue à casue de tampons pleins (cela n'arrivera
+      qu'en mode non bloquant) ou -1 si une erreur s'est produite. (Utilisez
       <function>PQerrorMessage</function> pour récupérer des détails si la valeur de
-      retour vaut -1. Si la valeur vaut zéro, attendez qu'il soit prêt en écriture et
+      retour vaut -1. Si la valeur vaut zéro, attendez qu'il soit prêt à écrire et
       ré-essayez).
      </para>
 
      <para>
-      L'application pourrait diviser le flux de données de <command>COPY</command>
-      dans des chargements de tampon de taille adéquate. Les limites n'ont pas de
+      L'application peut diviser le flux de données de <command>COPY</command>
+      dans des tampons de taille adéquate. Les limites des tampons n'ont pas de
       signification sémantique lors de l'envoi. Le contenu du flux de données doit
       correspondre au format de données attendu par la commande
       <command>COPY</command>&nbsp;; voir <xref linkend="sql-copy"/>
@@ -5132,26 +5134,26 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       Termine l'opération <literal>COPY_IN</literal> avec succès si <parameter>errormsg</parameter>
       est <symbol>NULL</symbol>. Si <parameter>errormsg</parameter> n'est pas
-      <symbol>NULL</symbol> alors <command>COPY</command> échoue, la chaîne pointée par
-      <parameter>errormsg</parameter> étant utilisée comme message d'erreur (néanmoins, vous
-      ne devriez pas supposer que ce message d'erreur précis reviendra du
-      serveur car le serveur pourrait avoir déjà échouée sur la commande
+      <symbol>NULL</symbol> alors <command>COPY</command> est passé en échec,
+      avec la chaîne pointée par <parameter>errormsg</parameter>
+      comme message d'erreur. (Mais ne pas supposer que ce message d'erreur précis
+      proviendra du serveur car le serveur pourrait avoir déjà échoué sur la commande
       <command>COPY</command> pour des raisons qui lui sont propres). Notez aussi que
       l'option forçant l'échec ne fonctionnera pas lors de l'utilisation de
       connexions avec un protocole pre-3.0.
      </para>
 
      <para>
-      Le résultat est 1 si la donnée de fin a été envoyée, ou dans le
-      mode non bloquant, cela peut uniquement indiquer que la donnée de
-      fin a été correctement mise dans la file d'attente. (En mode non
+      Le résultat est 1 si le message de terminaison a été envoyé&nbsp;; ou en
+      mode non bloquant, cela peut seulement indiquer que le message de
+      terminaison a été correctement mis en file d'attente. (En mode non
       bloquant, pour être certain que les données ont été correctement
       envoyées, vous devriez ensuite attendre que le mode écriture soit
       disponible puis appeler <function>PQflush</function>, à répéter
       jusqu'à ce que 0 soit renvoyé). Zéro indique que la fonction n'a
-      pas pu mettre en file d'attente la donnée de fin à cause d'une
+      pas pu mettre en file d'attente le message de terminaison à cause d'une
       file pleine&nbsp;; ceci ne peut survenir qu'en mode non bloquant. (Dans ce
-      cas, attendez que le mode écriture soit disponible puis rappeler
+      cas, attendez que le mode écriture soit disponible puis rappelez
       à nouveau la fonction <function>PQputCopyEnd</function>). Si
       une erreur physique survient, -1 est renvoyé&nbsp;; vous pouvez alors
       appeler <function>PQerrorMessage</function> pour avoir plus de
@@ -5162,7 +5164,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Après un appel réussi à <function>PQputCopyEnd</function>, appelez
       <function>PQgetResult</function> pour obtenir le statut de résultat final de la commande
       <command>COPY</command>. Vous pouvez attendre que le résultat soit disponible de la
-      même façon. Puis, retournez aux opérations normales.
+      même façon. Puis, retournez aux fonctionnement normal.
      </para>
     </listitem>
    </varlistentry>
@@ -5180,7 +5182,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   </para>
 
   <variablelist>
-   <varlistentry id="libpq-pqgetcopydata">
+   <varlistentry id="libpq-">
     <term><function>PQgetCopyData</function><indexterm><primary>PQgetCopyData</primary></indexterm></term>
     <listitem>
      <para>
@@ -5204,8 +5206,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      Lorsqu'une ligne est renvoyée avec succès, le code de retour est le
-      nombre d'octets de la donnée dans la ligne (et sera donc supérieur
+      Lorsqu'une ligne est renvoyée avec succès, la valeur de retour est le
+      nombre d'octets de la donnée dans la ligne (et sera donc toujours supérieur
       à zéro). La chaîne renvoyée est toujours terminée par un octet nul bien que ce
       ne soit utile que pour les <command>COPY</command> textuels. Un résultat
       zéro indique que la commande <command>COPY</command> est toujours en cours mais
@@ -5219,17 +5221,17 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Lorsque <parameter>async</parameter> est vraie (différent de zéro),
       <function>PQgetCopyData</function> ne bloquera pas en attente d'entrée&nbsp;; il
       renverra zéro si <command>COPY</command> est toujours en cours mais qu'aucune
-      ligne n'est encore disponible (dans ce cas, attendez qu'il soit prêt en
-      lecture puis appelez <function>PQconsumeInput</function> avant d'appeler
+      ligne n'est encore disponible. (Dans ce cas, attendez qu'il soit prêt à
+      lire puis appelez <function>PQconsumeInput</function> avant d'appeler
       <function>PQgetCopyData</function> de nouveau). Quand <parameter>async</parameter> est faux (zéro),
       <function>PQgetCopyData</function> bloquera tant que les données ne seront pas
       disponibles ou tant que l'opération n'aura pas terminée.
      </para>
 
      <para>
-      Après que <function>PQgetCopyData</function> ait renvoyé -1, appelez
+      Après que <function>PQgetCopyData</function> a renvoyé -1, appelez
       <function>PQgetResult</function> pour obtenir le statut de résultat final de la commande
-      <command>COPY</command>. Vous pourriez attendre la disponibilité de ce résultat comme
+      <command>COPY</command>. On peut attendre la disponibilité de ce résultat comme
       d'habitude. Puis, retournez aux opérations habituelles.
      </para>
     </listitem>
@@ -5266,7 +5268,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Cette fonction copie jusqu'à <parameter>length</parameter>-1 caractères dans le tampon
       et convertit le retour chariot en un octet nul. <function>PQgetline</function>
       renvoie <symbol>EOF</symbol> à la fin de l'entrée, 0 si la ligne entière a été
-      lu et 1 si le tampon est complet mais que le retour chariot à la fin n'a pas
+      lue et 1 si le tampon est complet mais que le retour chariot à la fin n'a pas
       encore été lu.
      </para>
      <para>
@@ -5275,8 +5277,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       l'envoi des résultats de la commande <command>COPY</command>. Si l'application
       peut recevoir des lignes de plus de <parameter>length</parameter>-1 caractères, une
       attention toute particulière est nécessaire pour s'assurer qu'elle reconnaisse
-      la ligne <literal>\.</literal> correctement (et ne la confond pas, par exemple,
-      avec la fin d'une longue ligne de données).
+      la ligne <literal>\.</literal> correctement (et ne confond pas, par exemple,
+      la fin d'une longue ligne de données pour une ligne de terminaison).
      </para>
     </listitem>
    </varlistentry>
@@ -5301,7 +5303,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <literal>PGRES_COPY_OUT</literal>, l'application devrait appeler
       <function>PQconsumeInput</function> et
       <function>PQgetlineAsync</function> jusqu'à ce que le signal de fin des données
-      ne soit détecté.
+      soit détecté.
      </para>
      <para>
       Contrairement à <function>PQgetline</function>, cette fonction prend la
@@ -5318,7 +5320,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       traitements habituels.
      </para>
      <para>
-      Les données renvoyées ne seront pas étendues au delà de la limite de la ligne.
+      Les données renvoyées ne seront pas étendues au-delà de la limite de la ligne.
       Si possible, une ligne complète sera retournée en une fois. Mais si le tampon
       offert par l'appelant est trop petit pour contenir une ligne envoyée par le
       serveur, alors une ligne de données partielle sera renvoyée. Avec des données
@@ -5326,7 +5328,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <literal>\n</literal> ou non (dans un <command>COPY</command> binaire, l'analyse
       réelle du format de données <command>COPY</command> sera nécessaire pour faire la
       détermination équivalente). La chaîne renvoyée n'est pas terminée par un
-      octet nul (si vous voulez ajouter un octet nul de terminaison, assurez-vous de
+      octet nul. (Si vous voulez ajouter un octet nul de terminaison, assurez-vous de
       passer un <parameter>bufsize</parameter> inférieur de 1 par rapport à l'espace
       réellement disponible).
      </para>
@@ -5357,9 +5359,10 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <para>
        Avant le protocole 3.0 de <productname>PostgreSQL</productname>, il était
        nécessaire pour l'application d'envoyer explicitement les deux caractères
-       <literal>\.</literal> comme ligne finale pour indiquer qu'il a terminé l'envoi
-       des données du <command>COPY</command> data. Bien que ceci fonctionne toujours, cette
-       méthode est abandonnée et la signification spéciale de <literal>\.</literal>
+       <literal>\.</literal> comme ligne finale pour indiquer au serveur
+       qu'elle a terminé l'envoi des données du <command>COPY</command>.
+       Bien que ceci fonctionne toujours, cette
+       méthode est obsolète et la signification spéciale de <literal>\.</literal>
        pourrait être supprimée dans une prochaine version. Il est suffisant d'appeler
        <function>PQendcopy</function> après avoir envoyé les vraies données.
       </para>
@@ -5380,8 +5383,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      C'est exactement comme <function>PQputline</function> sauf que le tampon de
-      donnée n'a pas besoin d'être terminé avec un octet nul car le nombre d'octets
+      C'est exactement comme <function>PQputline</function>, sauf que le tampon de
+      données n'a pas besoin d'être terminé avec un octet nul car le nombre d'octets
       envoyés est spécifié directement. Utilisez cette procédure pour envoyer des
       données binaires.
      </para>
@@ -5395,12 +5398,12 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Se synchronise avec le serveur.
       <synopsis>int PQendcopy(PGconn *conn);
       </synopsis>
-      Cette fonction attend que le serveur ait terminé la copie. Il devrait soit
-      indiquer quand la dernière chaîne a été envoyée au serveur en utilisant
-      <function>PQputline</function> soit le moment où la dernière chaîne a été reçue
+      Cette fonction attend que le serveur ait terminé la copie. Elle devrait
+      indiquer soit le moment om la dernière chaîne a été envoyée au serveur en utilisant
+      <function>PQputline</function>, soit le moment où la dernière chaîne a été reçue
       du serveur en utilisant <function>PGgetline</function>. Si ce n'est pas fait,
       le serveur renverra un <quote>out of sync</quote> (perte de
-      synchronisation) au client. Suivant le retour de cette fonction, le serveur est
+      synchronisation) au client. Au retour de cette fonction, le serveur est
       prêt à recevoir la prochaine commande SQL. Le code de retour 0 indique un
       succès complet et est différent de zéro dans le cas contraire (utilisez
       <function>PQerrorMessage</function> pour récupérer des détails sur l'échec).
@@ -5412,7 +5415,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <function>PQgetline</function> de façon répétée, suivi par un
       <function>PQendcopy</function> une fois la ligne de terminaison aperçue.
       Il devrait ensuite retourner à la boucle <function>PQgetResult</function>
-      jusqu'à ce que <function>PQgetResult</function> renvoie un pointeur nul. De
+      jusqu'à ce que <function>PQgetResult</function> renvoie un pointeur NULL. De
       façon similaire, un résultat <literal>PGRES_COPY_IN</literal> est traité par une
       série d'appels à <function>PQputline</function> suivis par un
       <function>PQendcopy</function>, ensuite retour à la boucle
@@ -5422,8 +5425,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      Les anciennes applications soumettent un <command>COPY</command> via
-      <function>PQexec</function> et assument que la transaction est faite après un
+      Les anciennes applications sont susceptibles de soumettre un
+      <command>COPY</command> via <function>PQexec</function> et supposent que
+      la transaction est faite après un
       <function>PQendcopy</function>. Ceci fonctionnera correctement seulement si
       <command>COPY</command> est la seule commande <acronym>SQL</acronym> dans la
       chaîne de commandes.
@@ -5460,9 +5464,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       int PQclientEncoding(const PGconn *<replaceable>conn</replaceable>);
      </synopsis>
 
-     Notez qu'il renvoie l'identifiant d'encodage, pas une chaîne symbolique
-     telle que <literal>EUC_JP</literal>.  Renvoie -1 en cas d'échec.  Pour
-     convertir un identifiant d'encodage en nom, vous pouvez utiliser&nbsp;:
+     Notez qu'il renvoie l'ID de l'encodage, pas une chaîne symbolique
+     telle que <literal>EUC_JP</literal>. Renvoie -1 en cas d'échec. Pour
+     convertir un ID d'encodage en nom, vous pouvez utiliser&nbsp;:
 
      <synopsis>
        char *pg_encoding_to_char(int <replaceable>encoding_id</replaceable>);
@@ -5489,7 +5493,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <replaceable>conn</replaceable> est la connexion au serveur, et
      <replaceable>encoding</replaceable> est l'encodage que vous voulez
      utiliser. Si la fonction initialise l'encodage avec succès, elle
-     renvoie 0, sinon -1. L'encodage actuel de cette connexion peut être
+     renvoie 0, sinon -1. L'encodage en cours pour cette connexion peut être
      déterminé en utilisant <function>PQclientEncoding</function>.
     </para>
    </listitem>
@@ -5511,16 +5515,17 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        PGVerbosity PQsetErrorVerbosity(PGconn *conn, PGVerbosity verbosity);
      </synopsis>
      <function>PQsetErrorVerbosity</function> initialise le mode de verbosité, renvoyant le
-     paramétrage précédant de cette connexion. Dans le mode <firstterm>terse</firstterm>, les
+     paramétrage précédant de cette connexion. Dans le mode
+     <firstterm>TERSE</firstterm>, les
      messages renvoyés incluent seulement la sévérité, le texte principal et la
      position&nbsp;; ceci tiendra normalement sur une seule ligne. Le mode par
-     défaut produit des messages qui inclut ces champs ainsi que les champs détail,
+     défaut produit des messages qui incluent ces champs ainsi que les champs détail,
      astuce ou contexte (ils pourraient être sur plusieurs lignes). Le mode
      <firstterm>VERBOSE</firstterm> inclut tous les champs disponibles. Modifier la verbosité
      n'affecte pas les messages disponibles à partir d'objets
-     <structname>PGresult</structname> déjà existants, seulement ceux créés après
-     (mais voir <function>PQresultVerboseErrorMessage</function> si vous voulez
-     imprimer une erreur précédente avec une verbosité différente).
+     <structname>PGresult</structname> déjà existants, seulement ceux créés après.
+     (Mais voyez <function>PQresultVerboseErrorMessage</function> si vous voulez
+     afficher une erreur précédente avec une verbosité différente).
      </para>
     </listitem>
    </varlistentry>
@@ -5555,15 +5560,15 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
       inclus dans les messages (sauf si la verbosité est configurée à
       <firstterm>TERSE</firstterm>, auquel cas <literal>CONTEXT</literal> n'est
       jamais affiché). Le mode <firstterm>NEVER</firstterm> n'inclut jamais
-      <literal>CONTEXT</literal> alors que <firstterm>ALWAYS</firstterm> l'inclut
+      <literal>CONTEXT</literal>, alors que <firstterm>ALWAYS</firstterm> l'inclut
       en permanence s'il est disponible. Dans le mode par défaut,
       <firstterm>ERRORS</firstterm>, les champs <literal>CONTEXT</literal> sont
       inclus seulement pour les messages d'erreur, et non pas pour les messages
       d'informations et d'avertissements. La modification de ce mode n'affecte
       pas les messages disponibles à partir des objets
-      <structname>PGresult</structname> déjà existant, seulement ceux créés
-      après. (Cependant, voir <function>PQresultVerboseErrorMessage</function>
-      si vous voulez imprimer l'erreur précédent avec un mode d'affichage
+      <structname>PGresult</structname> déjà existants, seulement ceux créés
+      après. (Cependant, voyez <function>PQresultVerboseErrorMessage</function>
+      si vous voulez afficher une erreur précédente avec un mode d'affichage
       différent.)
     </para>
    </listitem>
@@ -5573,16 +5578,16 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
    <term><function>PQtrace</function><indexterm><primary>PQtrace</primary></indexterm></term>
    <listitem>
     <para>
-     Active les traces de communication entre client et serveur dans un
-     flux fichier de débogage.
+     Active la trace de la communication entre client et serveur vers un
+     fichier de débogage.
      <synopsis>void PQtrace(PGconn *conn, FILE *stream);
      </synopsis>
     </para>
     <note>
      <para>
       Sur Windows, si la bibliothèque <application>libpq</application> et une application sont
-      compilées avec des options différentes, cet appel de fonction arrêtera
-      brutalement l'application car la représentation interne des pointeurs
+      compilées avec des options différentes, cet appel de fonction fera
+      planter l'application car la représentation interne des pointeurs
       <literal>FILE</literal> diffère. Spécifiquement, les options multi-threaded/single-threaded
       release/debug et static/dynamic devraient être identiques pour la bibliothèque et les
       applications qui l'utilisent.
@@ -5609,7 +5614,7 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
  <title>Fonctions diverses</title>
 
  <para>
-  Comme toujours, certains fonctions ne sont pas catégorisables.
+  Comme toujours, certaines fonctions ne sont pas catégorisables.
  </para>
 
  <variablelist>
@@ -5635,8 +5640,8 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
      <function>PQescapeBytea</function>, <function>PQunescapeBytea</function>,
      et <function>PQnotifies</function>. Il est particulièrement important
      que cette fonction, plutôt que <function>free()</function>, soit utilisée
-     sur Microsoft Windows. Ceci est dû à  l'allocation de la mémoire dans une
-     DLL et la relâcher dans l'application fonctionne seulement si les drapeaux
+     sur Microsoft Windows. Ceci est dû au fait qu'allouer de la mémoire dans une
+     DLL et la relâcher dans l'application ne marche que si les drapeaux
      multi-thread/mon-thread, release/debug et static/dynamic sont les mêmes
      pour la DLL et l'application. Sur les plateformes autres que Microsoft
      Windows, cette fonction est identique à la fonction
@@ -5665,7 +5670,7 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
 
     <para>
      Un simple appel à <function>PQfreemem</function> ne suffira pas car le
-     tableau contient des références à des chaînes supplémentaires.
+     tableau contient des références à des chaînes complémentaires.
     </para>
    </listitem>
   </varlistentry>
@@ -5678,38 +5683,32 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
      <synopsis>
       char *PQencryptPasswordConn(PGconn *conn, const char *passwd, const char *user, const char *algorithm);
      </synopsis>
-     Cette fonction est utilisée par les applications clientes qui souhaitent envoyées
+     Cette fonction est utilisée par les applications clientes qui souhaitent envoyer
      des commandes comme <literal>ALTER USER joe PASSWORD 'passe'</literal>.
      Une bonne pratique est de ne pas envoyer le mot de passe en clair dans une
      telle commande car le mot de passe serait exposé dans les journaux, les affichages
-     d'activité, et ainsi de suite. À la place, utilisez cette fonction pour convertir
-     le mot de passe en clair en une forme chiffrée avant de l'envoyer. Les arguments
-     sont le mot de passe en clair et le nom SQL de l'utilisateur. La valeur renvoyée
-     est une chaîne allouée par <function>malloc</function> ou NULL s'il ne reste plus
-     de mémoire.
-     L'appelant assume que la chaîne ne contient aucun caractère spécial qui
-     nécessiterait un échappement. Utilisez <function>PQfreemem</function> pour libérer
-     le résultat une fois terminé.
-     </para>
+     d'activité et ainsi de suite. À la place, utilisez cette fonction pour convertir
+     le mot de passe sous forme chiffrée avant de l'envoyer.
+    </para>
 
-     <para>
+    <para>
       Les arguments <parameter>passwd</parameter> et
-      <parameter>user</parameter> sont des mots de passe en clair, et le nom
-      SQL de l'utilisateur à qui ils correspondent.
+      <parameter>user</parameter> sont le mot de passe en clair et le nom
+      SQL de l'utilisateur correspondant.
       <parameter>algorithm</parameter> spécifie l'algorithme de chiffrement à
-      utiliser pour chiffrer le mot de passe.  Pour le moment, les algorithmes
+      utiliser pour chiffrer le mot de passe. Pour le moment, les algorithmes
       supportés sont <literal>md5</literal> et <literal>scram-sha-256</literal>
       (<literal>on</literal> et <literal>off</literal> sont également acceptés
       comme des alias pour <literal>md5</literal>, pour compatibilité avec les
-      anciennes versions de serveur).  Veuillez noter que le support de
+      versions des anciens serveurs). Veuillez noter que le support de
       <literal>scram-sha-256</literal> a été introduit dans la version 10 de
       <productname>PostgreSQL</productname>, et ne fonctionnera pas
-      corrrectement avec des versions de serveur plus ancienne.  Si
+      corrrectement avec des versions de serveur plus ancienne. Si
       <parameter>algorithm</parameter> est <symbol>NULL</symbol>, cette
-      fonction demandera au serveur pour la valeur actuelle du réglage <xref
-          linkend="guc-password-encryption"/>.  Cela peut être bloquant, et
-      échouera si la transaction courante est annulée, ou si la connexion est
-      occupée à effectuer une autre requête.  Si vous souhaitez utiliser
+      fonction demandera au serveur la valeur actuelle du réglage
+      <xref linkend="guc-password-encryption"/>. Cela peut être bloquant, et
+      échouera si la transaction courante est annulée ou si la connexion est
+      occupée à effectuer une autre requête. Si vous souhaitez utiliser
       l'algorithme par défaut du serveur mais que vous voulez éviter un
       blocage, vérifiez vous-même <varname>password_encryption</varname> avant
       d'appeler <function>PQencryptPasswordConn</function>, et fournissez cette
@@ -5718,10 +5717,10 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
 
      <para>
       La valeur retournée est une chaîne allouée par
-      <function>malloc</function>.  L'appelant peut partir du principe que la
+      <function>malloc</function>. L'appelant peut partir du principe que la
       chaîne ne contient pas de caractères spéciaux qui nécessiteraient un
-      échappement.  Utilisez <function>PQfreemem</function> pour libérer le
-      résultat quand vous avez fini de l'utiliser.  En cas d'erreur,
+      échappement. Utilisez <function>PQfreemem</function> pour libérer le
+      résultat quand vous avez fini de l'utiliser. En cas d'erreur,
       <symbol>NULL</symbol> est retourné, et un message d'erreur adéquat est
       stocké dans l'objet de connexion.
      </para>
@@ -5745,10 +5744,10 @@ PGContextVisibility PQsetErrorContextVisibility(PGconn *conn, PGContextVisibilit
 char *PQencryptPassword(const char *passwd, const char *user);
  </synopsis>
       <function>PQencryptPassword</function> est une version ancienne et
-      dépréciée et <function>PQencryptPasswodConn</function>.  La différence
+      obsolète de <function>PQencryptPasswodConn</function>. La différence
       est que <function>PQencryptPassword</function> ne nécessite pas d'objet
-      de connexion, et que <literal>md5</literal> est toujours utilisé comme
-      algorithme de chiffrement.
+      de connexion, et que l'algorithme de chiffrement utilisé est toujours
+      <literal>md5</literal>.
     </para>
    </listitem>
   </varlistentry>
@@ -5763,7 +5762,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
 
    <listitem>
     <para>
-     Construit un objet <structname>PGresult</structname> vide avec la statut
+     Construit un objet <structname>PGresult</structname> vide avec le statut
      indiqué.
      <synopsis>
        PGresult *PQmakeEmptyPGresult(PGconn *conn, ExecStatusType status);
@@ -5775,10 +5774,10 @@ char *PQencryptPassword(const char *passwd, const char *user);
      allouer et initialiser un objet <structname>PGresult</structname> vide.
      Cette fonction renvoit NULL si la mémoire n'a pas pu être allouée. Elle
      est exportée car certaines applications trouveront utiles de générer
-     eux-mêmes des objets de résultat (tout particulièrement ceux avec des
+     elles-mêmes des objets de résultat (tout particulièrement ceux avec des
      statuts d'erreur). Si <parameter>conn</parameter> n'est pas <symbol>NULL</symbol> et que
      <parameter>status</parameter> indique une erreur, le message d'erreur
-     actuel de la connexion indiquée est copié dans
+     courant de la connexion indiquée est copié dans
      <structname>PGresult</structname>. De plus, si
      <parameter>conn</parameter> n'est pas NULL, toute procédure d'événement
      enregistrée dans la connexion est copiée dans le

--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -318,7 +318,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
          <listitem>
           <para>
            Les paramètres <literal>hostaddr</literal> et <literal>host</literal> sont utilisés de
-           façon appropriée pour vous assurer que la résolution de nom et la résolution
+           façon appropriée pour garantir que la résolution de nom et la résolution
            inverse ne soient pas lancées. Voir la documentation de ces paramètres avec
            <function>PQconnectdbParams</function> ci-dessus pour les détails.
           </para>
@@ -382,15 +382,15 @@ PGconn *PQconnectdbParams(const char * const *keywords,
        </para>
 
        <para>
-        À tout moment pendant la connexion, le statut de cette connexion pourrait
+        À tout moment pendant la connexion, le statut de cette connexion peut
         être vérifié en appelant <function>PQstatus</function>. Si le résultat est
         <symbol>CONNECTION_BAD</symbol>, alors la procédure de connexion a échoué&nbsp;;
         si, au contraire, elle renvoie <function>CONNECTION_OK</function>, alors la
         connexion est prête. Ces deux états sont détectables à partir de la valeur
         de retour de <function>PQconnectPoll</function>, décrite ci-dessus. D'autres états
-        pourraient survenir lors (et seulement dans ce cas) d'une procédure de
+        pourraient survenir lors (et seulement lors) d'une procédure de
         connexion asynchrone. Ils indiquent l'état actuel de la procédure de
-        connexion et pourraient être utile pour fournir un retour à l'utilisateur.
+        connexion et pourraient être utiles pour fournir un retour à l'utilisateur.
         Ces statuts sont&nbsp;:
        </para>
 
@@ -444,7 +444,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
          <term><symbol>CONNECTION_SETENV</symbol></term>
          <listitem>
           <para>
-           Négociation des paramétrages de l'environnement.
+           Négociation des paramétres de l'environnement.
           </para>
          </listitem>
         </varlistentry>
@@ -463,7 +463,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
          <term><symbol>CONNECTION_CONSUME</symbol></term>
          <listitem>
           <para>
-           Consuming any remaining response messages on connection.
+           En train de traiter les messages de réponse restants sur la connexion.
           </para>
          </listitem>
         </varlistentry>
@@ -1006,11 +1006,11 @@ typedef struct
       <listitem>
        <para>
         Nom de l'hôte où se connecter.<indexterm><primary>host
-        name</primary></indexterm> Si un host name commence avec un slash, il
+        name</primary></indexterm> Si un nom d'ĥôte commence avec un slash, il
         spécifie une communication par domaine Unix plutôt qu'une communication
         TCP/IP&nbsp;; la valeur est le nom du répertoire où le fichier socket
         est stocké. Si plusieurs nom d'hôte sont spécifiés, chacun sera essayé
-        à son tour dans l'ordre donné.  Par défaut, quand
+        à son tour dans l'ordre donné. Par défaut, quand
         <literal>host</literal> n'est pas spécifié ou est vide, il s'agit d'une
         communication par socket de domaine Unix<indexterm><primary>socket de
         domaine Unix</primary></indexterm> dans <filename>/tmp</filename> (ou
@@ -1020,10 +1020,11 @@ typedef struct
         <literal>localhost</literal>.
        </para>
        <para>
-        Une liste séparée de virgules de noms d'hôtes est aussi acceptée,
-        auquel cas chaque nom d'hôte est placé dans un ordre précis; an empty item in the
-        list selects the default behavior as explained above. Voir
-        <xref linkend="libpq-multiple-hosts"/> pour plus de détails.
+        Une liste de noms d'hôtes séparés par des virgules est aussi acceptée,
+        auquel cas chaque nom d'hôte est testé dans cet ordre&nbsp;;
+        un élément vide dans la liste implique le comportement par
+        défaut comme décrit plus haut. Voir
+        <xref linkend="libpq-multiple-hosts"/> pour les détails.
        </para>
       </listitem>
      </varlistentry>
@@ -1033,16 +1034,16 @@ typedef struct
       <listitem>
        <para>
         Adresse IP numérique de l'hôte de connexion. Elle devrait être au format
-        d'adresse standard IPv4, c'est-à-dire <literal>172.28.40.9</literal>. Si votre
+        d'adresse standard IPv4, par exemple <literal>172.28.40.9</literal>. Si votre
         machine supporte IPv6, vous pouvez aussi utiliser ces adresses. La
         communication TCP/IP est toujours utilisée lorsqu'une chaîne non vide est
         spécifiée pour ce paramètre.
        </para>
        <para>
         Utiliser <literal>hostaddr</literal> au lieu de <literal>host</literal>
-        permet à l'application d'éviter une recherche de nom d'hôte, qui
-        pourrait être importante pour les applications ayant des
-        contraintes de temps. Un nom d'hôte est requis pour les méthodes
+        permet à l'application d'éviter une résolution de nom, ce qui
+        pourrait être important dans les applications avec des
+        contraintes de temps. Cependant, un nom d'hôte est requis pour les méthodes
         d'authentification GSSAPI ou SSPI, ainsi que pour la
         vérification de certificat SSL en <literal>verify-full</literal>.
         Les règles suivantes sont observées&nbsp;:
@@ -1050,7 +1051,7 @@ typedef struct
          <listitem>
           <para>
            Si <literal>host</literal> est indiqué sans
-           <literal>hostaddr</literal>, une recherche du nom de l'hôte
+           <literal>hostaddr</literal>, une résolution du nom de l'hôte
            est lancée.
           </para>
          </listitem>
@@ -1058,7 +1059,7 @@ typedef struct
           <para>
            Si <literal>hostaddr</literal> est indiqué sans
            <literal>host</literal>, la valeur de
-           <literal>hostaddr</literal> donne l'adresse réseau de
+           <literal>hostaddr</literal> fournit l'adresse réseau de
            l'hôte. La tentative de connexion échouera si la méthode
            d'authentification nécessite un nom d'hôte.
           </para>
@@ -1066,7 +1067,7 @@ typedef struct
          <listitem>
           <para>
            Si <literal>host</literal> et <literal>hostaddr</literal>
-           sont indiqués, la valeur de <literal>hostaddr</literal>
+           sont spécifiés, la valeur de <literal>hostaddr</literal>
            donne l'adresse réseau de l'hôte. La valeur de
            <literal>host</literal> est ignorée sauf si la méthode
            d'authentification la réclame, auquel cas elle sera
@@ -1075,19 +1076,19 @@ typedef struct
          </listitem>
         </itemizedlist>
         Notez que l'authentification a de grandes chances d'échouer si
-        <literal>host</literal> n'est pas identique au nom du serveur
-        pour l'adresse réseau <literal>hostaddr</literal>. De même, quand
-        <literal>host</literal> et que <literal>hostaddr</literal> sont
+        <literal>host</literal> n'est pas le nom du serveur
+        à l'adresse réseau <literal>hostaddr</literal>. Et quand
+        <literal>host</literal> et <literal>hostaddr</literal> sont tous deux
         spécifiés, seul  <literal>host</literal> est utilisé pour identifier
         la connexion dans un fichier de mots de passe (voir la <xref
         linkend="libpq-pgpass"/>).
        </para>
        <para>
-        Une liste séparée de virgules de noms d'hôtes est aussi acceptée,
-        auquel cas chaque nom d'hôte est placé dans un ordre précis. An empty
-        item in the list causes the corresponding host name to be used, or the
-        default host name if that is empty as well. Voir <xref
-        linkend="libpq-multiple-hosts"/> pour plus de détails.
+        Une liste d'adresses <literal>hostaddr</literal>, séparées par des
+        virgules est aussi acceptée, auquel cas chaque hôte est essayé dans cet
+        ordre. Un élément vide dans la liste mène à l'utilisation du nom d'hôte
+        correspondant, ou, s'il est vide aussi, de la valeur par défaut.
+        Voir <xref linkend="libpq-multiple-hosts"/> pour plus de détails.
        </para>
        <para>
         Sans un nom ou une adresse d'hôte, <application>libpq</application> se
@@ -1104,14 +1105,15 @@ typedef struct
        <para>
         Numéro de port pour la connexion au serveur ou extension du nom de
         fichier pour des connexions de domaine Unix.
-        <indexterm><primary>port</primary></indexterm> 
-        If multiple hosts were given in the <literal>host</literal> or
-        <literal>hostaddr</literal> parameters, this parameter may specify a
-        comma-separated list of ports of the same length as the host list, or
-        it may specify a single port number to be used for all hosts.
-        An empty string, or an empty item in a comma-separated list,
-        specifies the default port number established
-        when <productname>PostgreSQL</productname> was built.
+        <indexterm><primary>port</primary></indexterm>
+        Si plusieurs hôtes sont indiquées dans les paramètres
+        <literal>host</literal> ou <literal>hostaddr</literal>,
+        ce paramètre spécifie une liste de ports, séparés par des virgules,
+        liste de même taille que la liste
+        des hôtes, ou bien il peut préciser un seul port à tester pour tous les hôtes.
+        Une chaîne vide, ou un élément vide de la liste, indique le numéro de
+        port par défaut établi à la compilation de
+        <productname>PostgreSQL</productname>.
        </para>
       </listitem>
      </varlistentry>
@@ -1122,7 +1124,7 @@ typedef struct
        <para>
         Nom de la base de données. Par défaut, la même que le nom utilisateur.
         Dans certains contextes, la valeur est vérifiée pour les formats
-        étendues&nbsp;; voir <xref linkend="libpq-connstring"/> pour plus
+        étendus&nbsp;; voir <xref linkend="libpq-connstring"/> pour plus
         d'informations.
        </para>
       </listitem>
@@ -1134,7 +1136,7 @@ typedef struct
        <para>
         Nom de l'utilisateur <productname>PostgreSQL</productname> qui se
         connecte.
-        Par défaut, il s'agit du nom de l'utilisateur ayant lancé l'application.
+        Par défaut, il s'agit du nom d'utilisateur système ayant lancé l'application.
        </para>
       </listitem>
      </varlistentry>
@@ -1174,8 +1176,8 @@ typedef struct
         connexion.
         Par exemple, si vous indiquez deux hôtes et que le paramètre
         <literal>connect_timeout</literal> vaut 5, chaque hôte sera en timeout
-        si aucune connexion n'est réalisée en cinq secondes, donc le temps
-        total passé à attendre une connexion ira jusqu'à dix secondes.
+        si aucune connexion n'est réalisée en 5 secondes, donc le temps
+        total passé à attendre une connexion peut monter jusqu'à 10 secondes.
        </para>
       </listitem>
      </varlistentry>
@@ -1186,7 +1188,7 @@ typedef struct
        <para>
         Ceci configure le paramètre <varname>client_encoding</varname>
         pour cette connexion. En plus des valeurs acceptées par
-        l'option serveur correspondante, vous pouvez utiliser
+        l'option correspondante du serveur, vous pouvez utiliser
         <literal>auto</literal> pour déterminer le bon encodage à
         partir de la locale courante du client (variable
         d'environnement <envar>LC_CTYPE</envar> sur les systèmes Unix).
@@ -1230,10 +1232,11 @@ typedef struct
         Indique une valeur de secours pour le paramètre de configuration
         <xref linkend="guc-application-name"/>. Cette valeur sera utilisée
         si aucune valeur n'est donnée à <literal>application_name</literal>
-        via un paramètre de connexion ou la variable d'environnement.
+        via un paramètre de connexion ou la variable d'environnement
+        <literal>PGAPPNAME</literal>.
         L'indication d'un nom de secours est utile pour les programmes
         outils génériques qui souhaitent configurer un nom d'application
-        par défaut mais permettrait sa surcharge par l'utilisateur.
+        par défaut mais permettent sa surcharge par l'utilisateur.
        </para>
       </listitem>
      </varlistentry>
@@ -1287,7 +1290,7 @@ typedef struct
       <term><literal>keepalives_count</literal></term>
       <listitem>
        <para>
-        Contrôle le nombre de messages TCP keepalives pouvant être perdus
+        Contrôle le nombre de messages TCP keepalive pouvant être perdus
         avant que la connexion du client au serveur ne soit considérée
         comme perdue. Une valeur de zéro utilise la valeur par défaut du
         système. Ce paramètre est uniquement supporté sur les systèmes où
@@ -1303,7 +1306,7 @@ typedef struct
       <term><literal>tty</literal></term>
       <listitem>
        <para>
-        Ignoré (auparavant, ceci indiquait où envoyer les traces de débogage du
+        Ignoré (autrefois, ceci indiquait où envoyer les traces de débogage du
         serveur).
        </para>
       </listitem>
@@ -1313,16 +1316,17 @@ typedef struct
       <term><literal>replication</literal></term>
       <listitem>
       <para>
-       This option determines whether the connection should use the
-       replication protocol instead of the normal protocol.  This is what
-       PostgreSQL replication connections as well as tools such as
-       <application>pg_basebackup</application> use internally, but it can
-       also be used by third-party applications.  For a description of the
-       replication protocol, consult <xref linkend="protocol-replication"/>.
+       Cette option détermine si la connexion doit utiliser le protocole de
+       réplication au lieu du protocole normal.
+       C'est ce qu'utilisent les connexions de réplication de PostgreSQL, ainsi
+       que des outils comme <application>pg_basebackup</application>, mais il
+       peut aussi être utilisé par des applications tierces. Pour une description
+       du protocole de réplication, consulter
+       <xref linkend="protocol-replication"/>
       </para>
 
       <para>
-       The following values, which are case-insensitive, are supported:
+       Les valeurs suivantes, non sensibles à la casse, sont supportées&nbsp;:
        <variablelist>
         <varlistentry>
          <term>
@@ -1331,7 +1335,7 @@ typedef struct
          </term>
          <listitem>
           <para>
-           The connection goes into physical replication mode.
+           La connexion passe en mode réplication physique.
           </para>
          </listitem>
         </varlistentry>
@@ -1340,8 +1344,8 @@ typedef struct
          <term><literal>database</literal></term>
          <listitem>
           <para>
-           The connection goes into logical replication mode, connecting to
-           the database specified in the <literal>dbname</literal> parameter.
+           La connexion passe en mode réplication logique, se connectant à la
+           base donnée spécifiée par le paramètre <literal>dbname</literal>.
           </para>
          </listitem>
         </varlistentry>
@@ -1353,7 +1357,8 @@ typedef struct
          </term>
          <listitem>
           <para>
-           The connection is a regular one, which is the default behavior.
+           On utilise la connexion habituelle, ce qui est le comportement par
+           défaut.
           </para>
          </listitem>
         </varlistentry>
@@ -1361,8 +1366,8 @@ typedef struct
       </para>
 
       <para>
-       In physical or logical replication mode, only the simple query protocol
-       can be used.
+       En mode réplication physique ou logique, seul le protocole simple de
+       requête peut être utilisé.
       </para>
       </listitem>
      </varlistentry>
@@ -1410,9 +1415,9 @@ typedef struct
           <term><literal>require</literal></term>
           <listitem>
            <para>
-            essaie seulement une connexion <acronym>SSL</acronym>.
-            Si un certificat racine d'autorité est présent, vérifie
-            le certificat de la même façon que si
+            essaie seulement une connexion <acronym>SSL</acronym>
+            Si un certificat racine d'autorité (<acronym>CA</acronym>)
+            est présent, vérifie le certificat de la même façon que si
             <literal>verify-ca</literal> était spécifié
            </para>
           </listitem>
@@ -1444,8 +1449,8 @@ typedef struct
        </para>
 
        <para>
-        Voir <xref linkend="libpq-ssl"/> pour une description détaillée de
-        comment ces options fonctionnent.
+        Voir <xref linkend="libpq-ssl"/> pour une description détaillée du
+        fonctionnement de ces options.
        </para>
 
        <para>
@@ -1455,9 +1460,9 @@ typedef struct
         de SSL, l'utilisation des options <literal>require</literal>,
         <literal>verify-ca</literal> et
         <literal>verify-full</literal> causera
-        une erreur alors que les options <literal>allow</literal> et
-        <literal>prefer</literal> seront acceptées mais
-        <application>libpq</application> ne sera pas capable de négocier une
+        une erreur, alors que les options <literal>allow</literal> et
+        <literal>prefer</literal> seront acceptées, bien qu'en fait
+        <application>libpq</application> n'essaiera pas de négocier une
         connexion <acronym>SSL</acronym>.
         <indexterm>
          <primary>SSL</primary>
@@ -1491,28 +1496,28 @@ typedef struct
       <term><literal>sslcompression</literal></term>
       <listitem>
        <para>
-        If set to 1, data sent over SSL connections will be compressed.  If
-        set to 0, compression will be disabled.  The default is 0.  This
-        parameter is ignored if a connection without SSL is made.
+        Si ce paramètre vaut 1, les données envoyées sur des connexions SSL
+        seront compressées. S'il vaut 0, la compression sera désactivée. Le
+        défaut est 0. Ce paramètre est ignoré pour une connexion sans SSL.
        </para>
 
        <para>
-        SSL compression is nowadays considered insecure and its use is no
-        longer recommended.  <productname>OpenSSL</productname> 1.1.0 disables
-        compression by default, and many operating system distributions
-        disable it in prior versions as well, so setting this parameter to on
-        will not have any effect if the server does not accept compression.
-        On the other hand, <productname>OpenSSL</productname> before 1.0.0
-        does not support disabling compression, so this parameter is ignored
-        with those versions, and whether compression is used depends on the
-        server.
+        De nos jours, la compression SSL est considérée non sûre et son
+        usage n'est plus recommandé. <productname>OpenSSL</productname> 1.1.0
+        désactive la compression par défaut, et de nombreux systèmes
+        d'exploitation la désactive aussi dans des versions précédentes,
+        donc activer ce paramètre n'aura aucun effet si le serveur n'accepte
+        pas la compression. D'un autre côté, <productname>OpenSSL</productname>
+        avant la version 1.1.0 ne supporte pas la désactivation de la compression,
+        donc ce paramètre est ignoré sur ces versions, et l'utilisation de la
+        compression dépend du serveur.
        </para>
 
        <para>
-        If security is not a primary concern, compression can improve
-        throughput if the network is the bottleneck.  Disabling compression
-        can improve response time and throughput if CPU performance is the
-        limiting factor.
+        Si la sécurité n'est pas un souci majeur, la compression peut améliorer
+        le débit si le réseau est le goulot d'étranglement. Désactiver la
+        compression peut améliorer le temps de réponse et le débit si le
+        processeur est le facteur limitant.
        </para>
       </listitem>
      </varlistentry>
@@ -1537,7 +1542,8 @@ typedef struct
         le certificat client. Il peut soit indiquer un nom de fichier qui
         sera utilisé à la place du fichier
         <filename>~/.postgresql/postgresql.key</filename> par défaut, soit
-        indiquer un clé obtenue par un moteur externe (les moteurs sont des modules chargeables
+        indiquer une clé obtenue par un «&nbsp;moteur&nbsp;» externe
+        (les moteurs sont des modules chargeables
         d'<productname>OpenSSL</productname>). La spécification d'un moteur
         externe devrait consister en un nom de moteur et un identifiant de
         clé spécifique au moteur, les deux séparés par une virgule. Ce paramètre
@@ -1554,7 +1560,7 @@ typedef struct
         certificats de l'autorité de certification SSL
         (<acronym>CA</acronym>). Si le fichier existe, le certificat du
         serveur sera vérifié. La signature devra appartenir à une de ces
-        autorités. La valeur par défaut de ce paramètre est
+        autorités. La valeur par défaut est
         <filename>~/.postgresql/root.crt</filename>.
        </para>
       </listitem>
@@ -1566,8 +1572,8 @@ typedef struct
        <para>
         Ce paramètre indique le nom du fichier de la liste de révocation
         du certificat SSL. Les certificats listés dans ce fichier, s'il
-        existe bien, seront rejetés lors d'une tentative d'authentification
-        avec le certificat du serveur. La valeur par défaut de ce paramètre
+        existe, seront rejetés lors d'une tentative d'authentification
+        avec le certificat du serveur. La valeur par défaut
         est <filename>~/.postgresql/root.crl</filename>.
        </para>
       </listitem>
@@ -1577,23 +1583,23 @@ typedef struct
       <term><literal>requirepeer</literal></term>
       <listitem>
        <para>
-        Ce paramètre indique le nom d'utilisateur du serveur au
-        niveau du système d'exploitation, par exemple
+        Ce paramètre indique le nom d'utilisateur auprès
+        du système d'exploitation, par exemple
         <literal>requirepeer=postgres</literal>. Lors d'une connexion
         par socket de domaine Unix, si ce paramètre est configuré, le
-        client vérifie au début de la connexion si le processus
-        serveur est exécuté par le nom d'utilisateur indiqué&nbsp;;
-        dans le cas contraire, la connexion est annulée avec une
+        client vérifie au début de la connexion que le processus
+        tourne sous le nom d'utilisateur indiqué&nbsp;;
+        dans le cas contraire, la connexion échoue avec une
         erreur. Ce paramètre peut être utilisé pour fournir une
         authentification serveur similaire à celle disponible pour les
         certificats SSL avec les connexions TCP/IP. (Notez que, si
         la socket de domaine Unix est dans <filename>/tmp</filename>
         ou tout espace autorisé en écriture pour tout le monde,
-        n'importe quel utilisateur peut mettre un serveur en écoute à
-        cet emplacement. Utilisez ce paramètre pour vous assurer que
-        le serveur est exécuté par un utilisateur de confiance.) Cette
-        option est seulement supportée par les plateformes sur
-        lesquelles la méthode d'authentification <literal>peer</literal>
+        n'importe quel utilisateur peut y mettre un serveur en écoute.
+        Utilisez ce paramètre pour vous assurer que vous êtes connecté à
+        un serveur est exécuté par un utilisateur de confiance.) Cette
+        option est seulement supportée par les plateformes où
+        la méthode d'authentification <literal>peer</literal>
         est disponible&nbsp;; voir <xref linkend="auth-peer"/>.
        </para>
       </listitem>
@@ -1606,7 +1612,7 @@ typedef struct
         Nom du service Kerberos à utiliser lors de l'authentification avec
         GSSAPI. Il doit correspondre avec le nom du service spécifié dans
         la configuration du serveur pour que l'authentification Kerberos puisse
-        réussir (voir aussi la <xref linkend="gssapi-auth"/>.)
+        réussir. (Voir aussi la <xref linkend="gssapi-auth"/>.)
        </para>
       </listitem>
      </varlistentry>
@@ -1615,11 +1621,10 @@ typedef struct
       <term><literal>gsslib</literal></term>
       <listitem>
        <para>
-        Bibliothèque GSS à utiliser pour l'authentification GSSAPI. Utilisée
+        Bibliothèque GSS à utiliser pour l'authentification GSSAPI. Utilisé
         seulement sur Windows.
         Configurer à <literal>gssapi</literal> pour forcer libpq à utiliser
-        la bibliothèque GSSAPI pour l'authentification au lieu de SSPI par
-        défaut.
+        la bibliothèque GSSAPI pour l'authentification au lieu du défaut SSPI.
        </para>
       </listitem>
      </varlistentry>
@@ -1631,9 +1636,9 @@ typedef struct
         Nom du service à utiliser pour des paramètres supplémentaires. Il spécifie
         un nom de service dans <filename>pg_service.conf</filename> contenant
         des paramètres de connexion supplémentaires. Ceci permet aux
-        applications de spécifier uniquement un nom de service, donc les
-        paramètres de connexion peuvent être maintenus de façon centrale. Voir
-        <xref linkend="libpq-pgservice"/>.
+        applications de spécifier uniquement un nom de service pour que les
+        paramètres de connexion puissent être maintenus de façon centralisée.
+        Voir <xref linkend="libpq-pgservice"/>.
        </para>
       </listitem>
      </varlistentry>
@@ -1644,10 +1649,10 @@ typedef struct
        <para>
         Si ce paramètre est positionné à <literal>read-write</literal>, seule
         une connexion dans laquelle les transactions en lecture/écriture sont
-        acceptées par défaut est considéré comme acceptable.  La requête
+        acceptées par défaut est considéré comme acceptable. La requête
         <literal>SHOW transaction_read_only</literal> sera envoyée à chaque
         connexion réussie; si elle retourne <literal>on</literal>, la connexion
-        sera fermée.  Si plusieurs hôtes étaient spécifiés dans la chaîne de
+        sera fermée. Si plusieurs hôtes étaient spécifiés dans la chaîne de
         connexion, chaque serveur restant sera testé tout comme si la tentative
         de connexion avait échouée.  La valeur par défaut pour ce paramètre,
         <literal>any</literal>, considère toutes les connexions comme
@@ -1675,10 +1680,10 @@ typedef struct
     <indexterm><primary>libpq-fe.h</primary></indexterm>
     <indexterm><primary>libpq-int.h</primary></indexterm>
     Les développeurs d'application <application>libpq</application> devraient être
-    attentif au maintien de leur abstraction <structname>PGconn</structname>.
+    attentif à maintenir l'abstraction <structname>PGconn</structname>.
     Utilisez les fonctions d'accès décrites ci-dessous pour obtenir le
     contenu de <structname>PGconn</structname>.
-    Référence les champs internes de <structname>PGconn</structname> en utilisant
+    Référencer les champs internes de <structname>PGconn</structname> en utilisant
     <filename>libpq-int.h</filename> n'est pas recommandé parce qu'ils sont sujets
     à modification dans le futur.
    </para>
@@ -1687,10 +1692,10 @@ typedef struct
   <para>
    Les fonctions suivantes renvoient les valeurs des paramètres utilisés
    pour la connexion. Ces valeurs sont fixes pour la durée de vie de la
-   connexion.  Si une chaîne de connexion multi hôte est utilisée, les valeurs
+   connexion. Si une chaîne de connexion multi-hôtes est utilisée, les valeurs
    de <function>PQhost</function>, <function>PQport</function>, et
    <function>PQpass</function> peuvent changer si une nouvelle connexion est
-   établie en utilisant le même objet <structname>PGconn</structname>.  Les
+   établie en utilisant le même objet <structname>PGconn</structname>. Les
    autres valeurs sont figées pour la durée de vie de l'objet
    <structname>PGconn</structname>.
 
@@ -1729,14 +1734,14 @@ typedef struct
       </para>
 
       <para>
-       <function>PQpass</function> will return either the password specified
-       in the connection parameters, or if there was none and the password
-       was obtained from the <link linkend="libpq-pgpass">password
-       file</link>, it will return that.  In the latter case,
-       if multiple hosts were specified in the connection parameters, it is
-       not possible to rely on the result of <function>PQpass</function> until
-       the connection is established.  The status of the connection can be
-       checked using the function <function>PQstatus</function>.
+       <function>PQpass</function> retournera soit le mot de passe spécifié dans
+       les paramètres de connexion, soit, s'il n'y en avait pas, le mot
+       de passe obtenu grâce au <link linkend="libpq-pgpass">fichier de mots de
+       passe</link>. Dans ce dernier cas, si plusieurs hôtes était spécifiées
+       dans les paramètres de connexion, il n'est pas possible de se fier au
+       résultat de <function>PQpass</function> jusqu'à l'établissement de la
+       connexion. Le statut de la connexion peut être vérifié avec la
+       fonction <function>PQstatus</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -1746,36 +1751,38 @@ typedef struct
      <listitem>
       <para>
        Renvoie le nom d'hôte du serveur utilisé pour la connexion. Cela peut
-       être un nom d'hôte, une adresse IP ou un chemin de répertoire (pour ce
-       dernier, ceci ne survient que si la connexion est réalisée via un socket
-       Unix). Le cas du chemin peut être distingué car il sera toujours un
-       chemin absolu, commençant avec <literal>/</literal>.)
+       être un nom d'hôte, une adresse IP ou un chemin de répertoire si la
+       connexion est réalisée via un socket Unix. (Le cas du chemin se distingue
+       par le fait que ce sera toujours un chemin absolu commençant par
+       <literal>/</literal>.)
        <synopsis>char *PQhost(const PGconn *conn);
        </synopsis>
       </para>
 
       <para>
-       If the connection parameters specified both <literal>host</literal> and
-       <literal>hostaddr</literal>, then <function>PQhost</function> will
-       return the <literal>host</literal> information.  If only
-       <literal>hostaddr</literal> was specified, then that is returned.
-       If multiple hosts were specified in the connection parameters,
-       <function>PQhost</function> returns the host actually connected to.
+        Si les paramètres de connexion <literal>host</literal> and
+        <literal>hostaddr</literal> sont tous les deux précisés,
+        alors <function>PQhost</function> retournera
+        <literal>host</literal>. Si seul <literal>hostaddr</literal> a été
+        spécifié, c'est cela qui est retourné. Si plusieurs hôtes étaient spécifiées
+        dans les paramètres de connexion, <function>PQhost</function> retourne
+        l'hôte à qui l'on s'est effectivement connecté.
       </para>
 
       <para>
-       <function>PQhost</function> returns <symbol>NULL</symbol> if the
-       <parameter>conn</parameter> argument is <symbol>NULL</symbol>.
-       Otherwise, if there is an error producing the host information (perhaps
-       if the connection has not been fully established or there was an
-       error), it returns an empty string.
+        <function>PQhost</function> retourne <symbol>NULL</symbol> si l'argument
+        <parameter>conn</parameter> est <symbol>NULL</symbol>.
+        Sinon, s'il y a une erreur en déterminant l'<literal>host</literal>
+        (peut-être que la connexion n'a pas été complètement établie ou qu'il y
+        a eu une erreur), il retourne une chaîne vide.
       </para>
 
       <para>
-       If multiple hosts were specified in the connection parameters, it is
-       not possible to rely on the result of <function>PQhost</function> until
-       the connection is established.  The status of the connection can be
-       checked using the function <function>PQstatus</function>.
+       Si plusieurs hôtes ont été spécifiés dans les paramètres de connexion,
+       il n'est pas possible de se baser sur le résultat de
+       <function>PQhost</function> avant l'établissement de la connexion.
+       Le statut de la connexion peut être vérifié avec la fonction
+       <function>PQstatus</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -1790,23 +1797,25 @@ typedef struct
       </para>
 
       <para>
-       If multiple ports were specified in the connection parameters,
-       <function>PQport</function> returns the port actually connected to.
+        Si de multiples ports étaient spécifiés dans les paramètres de connexion,
+        <function>PQport</function> renvoie le port auquel l'on est effectivement
+        connecté.
       </para>
 
       <para>
-       <function>PQport</function> returns <symbol>NULL</symbol> if the
-       <parameter>conn</parameter> argument is <symbol>NULL</symbol>.
-       Otherwise, if there is an error producing the port information (perhaps
-       if the connection has not been fully established or there was an
-       error), it returns an empty string.
+       <function>PQport</function> retourne <symbol>NULL</symbol> si l'argument
+       <parameter>conn</parameter> est <symbol>NULL</symbol>.
+       Sinon, s'il y a une erreur en déterminant le <literal>port</literal>
+       (peut-être que la connexion n'a pas été complètement établie ou qu'il y
+       a eu une erreur), il retourne une chaîne vide.
       </para>
 
       <para>
-       If multiple ports were specified in the connection parameters, it is
-       not possible to rely on the result of <function>PQport</function> until
-       the connection is established.  The status of the connection can be
-       checked using the function <function>PQstatus</function>.
+       Si plusieurs ports ont été spécifiés dans les paramètres de connexion,
+       il n'est pas possible de se baser sur le résultat de
+       <function>PQport</function> avant l'établissement de la connexion.
+       Le statut de la connexion peut être vérifié avec la fonction
+       <function>PQstatus</function>.
       </para>
      </listitem>
     </varlistentry>
@@ -1817,8 +1826,8 @@ typedef struct
       <para>
        Renvoie le <acronym>TTY</acronym> de débogage pour la connexion
        (ceci est obsolète car le serveur ne fait plus attention au
-       paramétrage du <acronym>TTY</acronym> mais les fonctions restent pour
-       des raisons de compatibilité ascendante).
+       paramétrage du <acronym>TTY</acronym> mais la fonction reste pour
+       la compatibilité ascendante).
        <synopsis>char *PQtty(const PGconn *conn);
        </synopsis>
       </para>
@@ -1840,8 +1849,8 @@ typedef struct
   </para>
 
   <para>
-   Les fonctions suivantes renvoient le statut car il peut changer suite à
-   l'exécution d'opérations sur l'objet <structname>PGconn</structname>.
+   Les fonctions suivantes renvoient des données de statut qui peuvent changer
+   suite à des opérations sur l'objet <structname>PGconn</structname>.
 
    <variablelist>
     <varlistentry id="libpq-pqstatus">
@@ -1854,22 +1863,22 @@ typedef struct
       </para>
 
       <para>
-       Le statut peut faire partie d'un certain nombre de valeurs. Néanmoins,
-       seules deux ne concernent pas les procédures de connexion
+       Le statut peut prendre un certain nombre de valeurs. Néanmoins,
+       deux seulement ne concernent pas les procédures de connexion
        asynchrone&nbsp;: <literal>CONNECTION_OK</literal> et
-       <literal>CONNECTION_BAD</literal>. Une bonne connexion de la base de
-       données a l'état <literal>CONNECTION_OK</literal>. Une tentative échouée
-       de connexion est signalée par le statut
-       <literal>CONNECTION_BAD</literal>. D'habitude, un état OK restera ainsi
-       jusqu'à <function>PQfinish</function> mais un échec de communications
-       pourrait résulter en un statut changeant prématurément
-       <literal>CONNECTION_BAD</literal>. Dans ce cas, l'application pourrait
+       <literal>CONNECTION_BAD</literal>. Une bonne connexion à la base de
+       données a l'état <literal>CONNECTION_OK</literal>. Une tentative de
+       connexion ayant échoué est signalée par le statut
+       <literal>CONNECTION_BAD</literal>. D'habitude, un état OK le restera
+       jusqu'à <function>PQfinish</function> mais un échec dans les communications
+       peut résulter en un statut changeant prématurément en
+       <literal>CONNECTION_BAD</literal>. Dans ce cas, l'application peut
        essayer de récupérer en appelant <function>PQreset</function>.
       </para>
 
       <para>
        Voir l'entrée de <function>PQconnectStartParams</function>, <function>PQconnectStart</function> et de
-       <function>PQconnectPoll</function> en regard aux autres codes de statut, qui
+       <function>PQconnectPoll</function> à propos des autres codes de statut qui
        pourraient être renvoyés.
       </para>
      </listitem>
@@ -1885,11 +1894,11 @@ typedef struct
 
        Le statut peut être <literal>PQTRANS_IDLE</literal> (actuellement inactif),
        <literal>PQTRANS_ACTIVE</literal> (une commande est en cours),
-       <literal>PQTRANS_INTRANS</literal> (inactif, dans un bloc valide de
-       transaction) ou <literal>PQTRANS_INERROR</literal> (inactif, dans un bloc de
-       transaction échoué). <literal>PQTRANS_UNKNOWN</literal> est reporté si la
-       connexion est mauvaise. <literal>PQTRANS_ACTIVE</literal> est reporté seulement
-       quand une requête a été envoyée au serveur mais qu'elle n'est pas terminée.
+       <literal>PQTRANS_INTRANS</literal> (inactif, dans un bloc de transaction
+       valide) ou <literal>PQTRANS_INERROR</literal> (inactif, dans un bloc de
+       transaction échoué). <literal>PQTRANS_UNKNOWN</literal> est rapporté si la
+       connexion est mauvaise. <literal>PQTRANS_ACTIVE</literal> n'est rapporté
+       que si une requête a été envoyée au serveur et n'est pas encore terminée.
       </para>
      </listitem>
     </varlistentry>
@@ -1898,18 +1907,18 @@ typedef struct
      <term><function>PQparameterStatus</function><indexterm><primary>PQparameterStatus</primary></indexterm></term>
      <listitem>
       <para>
-       Recherche un paramétrage actuel du serveur.
+       Recherche la valeur en cours d'un paramètre du serveur.
        <synopsis>const char *PQparameterStatus(const PGconn *conn, const char *paramName);
        </synopsis>
 
-       Certaines valeurs de paramètres sont reportées par le serveur automatiquement ou
+       Certaines valeurs de paramètres sont rapportées par le serveur automatiquement ou
        lorsque leur valeurs changent. <function>PQparameterStatus</function> peut être utilisé
-       pour interroger ces paramétrages. Il renvoie la valeur actuelle d'un
+       pour interroger ces paramètres. Il renvoie la valeur en cours d'un
        paramètre s'il est connu et <symbol>NULL</symbol> si le paramètre est inconnu.
       </para>
 
       <para>
-       Les paramètres reportés pour la version actuelle incluent
+       Les paramètres renvoyées par la version actuelle incluent
        <varname>server_version</varname>,
        <varname>server_encoding</varname>,
        <varname>client_encoding</varname>,
@@ -1922,47 +1931,46 @@ typedef struct
        <varname>integer_datetimes</varname> et
        <varname>standard_conforming_strings</varname>.
        (<varname>server_encoding</varname>, <varname>TimeZone</varname> et
-       <varname>integer_datetimes</varname> n'étaient pas rapportés dans les versions
+       <varname>integer_datetimes</varname> n'étaient pas renvoyés dans les versions
        antérieures à la 8.0&nbsp;;
-       <varname>standard_conforming_strings</varname> n'était pas rapporté dans les versions
-       antérieures à la 8.1; <varname>IntervalStyle</varname> n'était pas rapporté dans les versions
+       <varname>standard_conforming_strings</varname> n'était pas renvoyés dans les versions
+       antérieures à la 8.1; <varname>IntervalStyle</varname> n'était pas renvoyé dans les versions
        antérieures à la 8.4;
-       <varname>application_name</varname>  n'était pas rapporté dans les versions
+       <varname>application_name</varname>  n'était pas renvoyé dans les versions
        antérieures à la 9.0).
        Notez que
        <varname>server_version</varname>,
        <varname>server_encoding</varname> et
        <varname>integer_datetimes</varname>
-       ne peuvent pas changer après le lancement du
-       serveur.
+       ne peuvent pas changer après le lancement du serveur.
       </para>
 
       <para>
-       Les serveurs utilisant un protocole antérieur à la 3.0 ne reportent pas la
+       Les serveurs utilisant un protocole antérieur à la 3.0 ne rapportent pas la
        configuration des paramètres mais <application>libpq</application> inclut la logique pour
        obtenir des valeurs pour <varname>server_version</varname> et
        <varname>client_encoding</varname>. Les applications sont encouragées à utiliser
        <function>PQparameterStatus</function> plutôt qu'un code
-       <foreignphrase>ad-hoc</foreignphrase> modifiant ces valeurs
-       (néanmoins, attention, les connexions pré-3.0, changeant
+       <foreignphrase>ad-hoc</foreignphrase> pour trouver ces valeurs.
+       (Notez cependant que pour les connexions pré-3.0, changer
        <varname>client_encoding</varname> via <command>SET</command> après le lancement de la
-       connexion, ne seront pas reflétées par <function>PQparameterStatus</function>). Pour
+       connexion ne sera pas reflété par <function>PQparameterStatus</function>). Pour
        <varname>server_version</varname>, voir aussi <function>PQserverVersion</function>, qui renvoie
        l'information dans un format numérique qui est plus facile à comparer.
       </para>
 
       <para>
        Si aucune valeur n'est indiquée pour <varname>standard_conforming_strings</varname>,
-       les applications pourraient supposer qu'elle vaut <literal>off</literal>,
+       les applications peuvent considérer qu'elle vaut <literal>off</literal>,
        c'est-à-dire que les antislashs sont traités comme des échappements dans les
-       chaînes littérales. De plus, la présence de ce paramètre pourrait être pris
-       comme une indication que la syntaxe d'échappement d'une chaîne
+       chaînes littérales. De plus, la présence de ce paramètre peut être pris
+       comme une indication que la syntaxe d'échappement de chaîne
        (<literal>E'...'</literal>) est acceptée.
       </para>
 
       <para>
        Bien que le pointeur renvoyé est déclaré <literal>const</literal>, il pointe en fait
-       vers un stockage mutable associé avec la structure <literal>PGconn</literal>. Il est
+       vers un stockage mutable associé à la structure <literal>PGconn</literal>. Il est
        déconseillé de supposer que le pointeur restera valide pour toutes les
        requêtes.
       </para>
@@ -1976,12 +1984,12 @@ typedef struct
        Interroge le protocole interface/moteur lors de son utilisation.
        <synopsis>int PQprotocolVersion(const PGconn *conn);
        </synopsis>
-       Les applications souhaitent utiliser ceci pour déterminer si certaines
+       Les applications peuvent utiliser ceci pour déterminer si certaines
        fonctionnalités sont supportées. Actuellement, les seules valeurs possible sont
        2 (protocole 2.0), 3 (protocole 3.0) ou zéro (mauvaise connexion). La version du
        protocole ne
-       changera pas après la fin du lancement de la connexion mais cela pourrait être
-       changé théoriquement avec une réinitialisation de la connexion. Le protocole
+       changera pas après la fin du lancement de la connexion mais il pourrait
+       théoriquement changer lors d'une réinitialisation de la connexion. Le protocole
        3.0 sera normalement utilisé lors de la communication avec les serveurs
        <productname>PostgreSQL</productname> 7.4 ou ultérieures&nbsp;; les serveurs
        antérieurs à la 7.4 supportent uniquement le protocole 2.0 (le protocole 1.0
@@ -1999,7 +2007,7 @@ typedef struct
       </para>
 
       <para>
-       Les applications pourraient utiliser cette fonction pour déterminer la
+       Les applications peuvent utiliser cette fonction pour déterminer la
        version du serveur de bases de données où ils sont connectés Le
        résultat est obtenu en multipliant le numéro de version majeure de la
        bibliothèque par 10000 et en ajoutant le numéro de version mineure. Par
@@ -2041,13 +2049,13 @@ typedef struct
       <para>
        Pratiquement toutes les fonctions <application>libpq</application> initialiseront
        un message pour <function>PQerrorMessage</function> en cas d'échec.
-       Notez que, par la convention <application>libpq</application>, un résultat
-       non vide de <function>PQerrorMessage</function> peut être sur plusieurs lignes
-       et contiendra un retour
-       chariot à la fin. L'appelant ne devrait pas libérer directement le
-       résultat. Il sera libéré quand la poignée <structname>PGconn</structname> associée
-       est passée à <function>PQfinish</function>. Vous ne devriez pas supposer
-       que la chaîne résultante reste identique suite à toutes les opérations
+       Notez que, par convention dans <application>libpq</application>, un résultat
+       non vide de <function>PQerrorMessage</function> peut courir sur plusieurs lignes
+       et finira par un retour.
+       L'appelant ne devrait pas libérer directement le
+       résultat. Il sera libéré quand le handle <structname>PGconn</structname> associé
+       sera passé à <function>PQfinish</function>. La chaîne résultante n'est pas
+       supposée rester la même pendant les opérations
        sur la structure <literal>PGconn</literal>.
       </para>
      </listitem>
@@ -2107,7 +2115,7 @@ typedef struct
       </para>
 
       <para>
-       Cette fonction peut être utilisée après une tentative échouée de
+       Cette fonction peut être utilisée après un échec de tentative de
        connexion pour décider de la demande d'un utilisateur pour un mot de
        passe.
       </para>
@@ -2358,15 +2366,15 @@ void *PQgetssl(const PGconn *conn);
 
    La chaîne de la commande peut inclure plusieurs commandes SQL (séparées par des points
    virgules). Les requêtes multiples envoyées
-   dans un simple appel à <function>PQexec</function> sont exécutées dans une seule
-   transaction sauf si des commandes explicites
-   <command>BEGIN</command>/<command>COMMIT</command> sont incluses dans la chaîne
-   de requête pour la diviser dans de nombreuses transactions. (See <xref
-   linkend="protocol-flow-multi-statement"/> for more details about how the
-   server handles multi-query strings.) Néanmoins, notez
+   dans un unique appel à <function>PQexec</function> sont exécutées dans une seule
+   transaction sauf si des commandes <command>BEGIN</command>/<command>COMMIT
+   </command>  explicites sont incluses dans la chaîne
+   de requête pour la diviser en de multiples transactions. (Voir <xref
+   linkend="protocol-flow-multi-statement"/> pour plus de détails sur comment le
+   serveur traite les chaînes multi-requêtes.) Notez néanmoins
    que la structure <structname>PGresult</structname> renvoyée décrit seulement
    le résultat de la dernière commande exécutée à partir de la chaîne. Si une des
-   commandes doit échouer, l'exécution de la chaîne s'arrête et le
+   commandes échoue, l'exécution de la chaîne s'arrête et le
    <structname>PGresult</structname> renvoyé décrit la condition d'erreur.
   </para>
 
@@ -5990,7 +5998,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
      chaque partie. Par exemple, la version 9.1.5 renverra 90105, et la
      version 9.2.0 renverra 90200.
     </para>
- 
+
     <para>
      De ce fait, pour déterminer la compatibilité de certaines
      fonctionnalités, les applications devrait diviser le résultat de
@@ -7080,12 +7088,11 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
 
  <para>
   Le fichier <filename>.pgpass</filename>, situé dans le répertoire personnel de
-  l'utilisateur est un
-  fichier contenant les mots de passe à utiliser si la
+  l'utilisateur est un fichier contenant les mots de passe à utiliser si la
   connexion requiert un mot de passe (et si aucun mot de passe n'a été spécifié).
   Sur Microsoft Windows, le fichier est nommé
   <filename>%APPDATA%\postgresql\pgpass.conf</filename> (où <filename>%APPDATA%</filename>
-  fait référence au sous-répertoire Application Data du profile de l'utilisateur).
+  fait référence au sous-répertoire Application Data du profil de l'utilisateur).
   De manière alternative, un fichier de mots de passe peut être spécifié en
   utilisant le paramètre de connexion <xref linkend="libpq-connect-passfile"/>
   ou la variable d'environnement <envar>PGPASSFILE</envar>.
@@ -7094,33 +7101,34 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
  <para>
   Ce fichier devra être composé de lignes au format suivant (une ligne par connexion)&nbsp;:
   <synopsis><replaceable>nom_hote</replaceable>:<replaceable>port</replaceable>:<replaceable>database</replaceable>:<replaceable>nomutilisateur</replaceable>:<replaceable>motdepasse</replaceable> </synopsis>
-   (Vous pouvez ajouter en commentaire dans le fichier cette ligne que vous
-   précédez d'un dièse (<literal>#</literal>).)
-   Chacun des quatre premiers champs
-   pourraient être une valeur littérale ou <literal>*</literal> (qui correspond à
-   tout). La première ligne réalisant une correspondance pour les paramètres de
-   connexion sera utilisée (du coup, placez les entrées plus spécifiques en premier
-   lorsque vous utilisez des jokers). Si une entrée a besoin de contenir
+   (Vous pouvez ajouter un rappel en commentaire dans le fichier en copiant
+   cette ligne et en la précédant d'un dièse (<literal>#</literal>).)
+   Chacun des quatre premiers champs peut être une valeur littérale ou
+   <literal>*</literal>, qui correspond à tout.
+   La première ligne correspondant aux paramètres de
+   connexion sera utilisée (du coup, placez les entrées les plus spécifiques
+   en premier lorsque vous utilisez des jokers). Si une entrée doit contenir
    <literal>:</literal> ou <literal>\</literal>, échappez ce caractère avec
-   <literal>\</literal>. The host name field is matched to the <literal>host</literal> connection
-   parameter if that is specified, otherwise to
-   the <literal>hostaddr</literal> parameter if that is specified; if neither
-   are given then the host name <literal>localhost</literal> is searched for.
-   The host name <literal>localhost</literal> is also searched for when
-   the connection is a Unix-domain socket connection and
-   the <literal>host</literal> parameter
-   matches <application>libpq</application>'s default socket directory path.
-   In a standby server, a database field of <literal>replication</literal>
-   matches streaming replication connections made to the master server.
-   The database field is of limited usefulness otherwise, because users have
-   the same password for all databases in the same cluster.
+   <literal>\</literal>. Le nom de l'hôte est rapproché du paramètre de connexion
+   <literal>host</literal> s'il est spécifié, sinon au paramètre
+   <literal>hostaddr</literal> si spécifié. Si ni l'un ni l'autre ne sont
+   fournis, l'hôte <literal>localhost</literal> sera alors recherché.
+   L'hôte <literal>localhost</literal> est également cherché si la connexion
+   est une socket de domaine Unix et que le paramètre <literal>host</literal>
+   correspond au répertoire par défaut de la <application>libpq</application>.
+
+   Sur un serveur secondaire, un champ <literal>database</literal> à
+   <literal>replication</literal> correspond aux connexions de réplication
+   par flux au serveur maître. Le champ <literal>database</literal> est d'une
+   utilité limitée sinon, puisque les utilisateurs ont le même mot de passe
+   pour toutes les bases de données de l'instance.
   </para>
 
   <para>
    Sur les systèmes Unix, les droits sur un fichier de mots de passe doivent
-   interdire l'accès au groupe et au reste du monde&nbsp;; faites-le par cette
-   commande&nbsp;: <command>chmod 0600 ~/.pgpass</command>. Si les droits sont
-   moins stricts que cela, le fichier sera ignoré. Sur Microsoft Windows, il est
+   interdire l'accès au groupe et au reste du monde&nbsp;; faites-le avec une
+   commande comme <command>chmod 0600 ~/.pgpass</command>. Si les droits sont
+   moins stricts, le fichier sera ignoré. Sur Microsoft Windows, il est
    supposé que le fichier est stocké dans un répertoire qui est sécurisé, donc
    aucune vérification des droits n'est effectuée.
   </para>

--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -2068,9 +2068,8 @@ typedef struct
        Obtient le descripteur de fichier du socket de la connexion au serveur.
        Un descripteur valide sera plus grand ou égal à 0&nbsp;; un résultat de
        -1 indique qu'aucune connexion au serveur n'est actuellement ouverte
-       (ceci ne changera pas lors de l'opération normale mais pourra changer
-       lors d'une configuration de l'initialisation ou lors d'une
-       réinitialisation).
+       (ceci ne changera pas lors du fonctionnement habituel, mais pourrait changer
+       lors de la mise en place de la connection ou lors d'une réinitialisation).
        <synopsis>int PQsocket(const PGconn *conn);
        </synopsis>
       </para>
@@ -2090,7 +2089,7 @@ typedef struct
       </para>
 
       <para>
-       Le <acronym>PID</acronym> du moteur est utile pour des raisons de
+       Le <acronym>PID</acronym> du processus backend est utile pour des raisons de
        débogage et pour la comparaison avec les messages
        <command>NOTIFY</command> (qui incluent le <acronym>PID</acronym> du
        processus serveur lançant la notification). Notez que le
@@ -2196,7 +2195,7 @@ const char *PQsslAttribute(const PGconn *conn, const char *attribute_name);
          <term><literal>protocol</literal></term>
           <listitem>
            <para>
-             SSL/TLS version utilisée. Les valeurs courantes sont
+             Version de SSL/TLS utilisée. Les valeurs courantes sont
              <literal>"TLSv1"</literal>, <literal>"TLSv1.1"</literal>
              and <literal>"TLSv1.2"</literal>, mais une implémentation
              peut renvoyer d'autres chaînes si d'autres protocoles
@@ -2208,7 +2207,7 @@ const char *PQsslAttribute(const PGconn *conn, const char *attribute_name);
          <term><literal>key_bits</literal></term>
           <listitem>
            <para>
-            Nombre de bits clefs utilisés par l'algorithme de chiffrement.
+            Nombre de bits de la clef utilisée par l'algorithme de chiffrement.
            </para>
           </listitem>
          </varlistentry>
@@ -2313,8 +2312,8 @@ void *PQgetssl(const PGconn *conn);
        nouvelles applications, car la structure renvoyée est spécifique
        à OpenSSL et ne sera pas disponible si une autre implémentation
        SSL est utilisée. Pour vérifier si une connexion utilise SSL,
-       appeler à la place la fonction <function>PQsslInUse</function>,
-       et pour plus de détails à propos de la connexion, utilisez
+       appelez plutôt <function>PQsslInUse</function>,
+       et, pour plus de détails à propos de la connexion, utilisez
        <function>PQsslAttribute</function>.
       </para>
     </listitem>
@@ -2326,7 +2325,7 @@ void *PQgetssl(const PGconn *conn);
  </sect1>
 
  <sect1 id="libpq-exec">
-  <title>Fonctions de commandes d'exécution</title>
+  <title>Fonctions d'exécution des commandes</title>
 
   <para>
    Une fois la connexion au serveur de la base de données établie avec
@@ -2356,7 +2355,7 @@ void *PQgetssl(const PGconn *conn);
        sérieuses telles que l'incapacité à envoyer la commande au serveur.
        La fonction <function>PQresultStatus</function> devrait être appelée pour
        vérifier le code retour  pour toute erreur (incluant la valeur d'un
-       pointeur nul, auquel cas il renverra <symbol>PGRES_FATAL_ERROR</symbol>).
+       pointeur NULL, auquel cas il renverra <symbol>PGRES_FATAL_ERROR</symbol>).
        Utilisez <function>PQerrorMessage</function> pour obtenir plus
        d'informations sur l'erreur.
       </para>
@@ -2455,7 +2454,7 @@ void *PQgetssl(const PGconn *conn);
            paramètres. Si <parameter>paramTypes</parameter> est <symbol>NULL</symbol>
            ou si tout élément spécifique du tableau est zéro, le serveur infère un
            type de donnée pour le symbole de paramètre de la même façon qu'il le
-           ferait pour une chaîne litérale sans type.
+           ferait pour une chaîne littérale sans type.
           </para>
          </listitem>
         </varlistentry>
@@ -2464,7 +2463,7 @@ void *PQgetssl(const PGconn *conn);
          <term><parameter>paramValues[]</parameter></term>
          <listitem>
           <para>
-           Spécifie les vraies valeurs des paramètres. Un pointeur nul dans ce
+           Spécifie les vraies valeurs des paramètres. Un pointeur NULL dans ce
            tableau signifie que le paramètre correspondant est NULL&nbsp;; sinon,
            le pointeur pointe vers une chaîne texte terminée par un octet nul
            (pour le format texte) ou vers des données binaires dans le format
@@ -2489,15 +2488,15 @@ void *PQgetssl(const PGconn *conn);
          <term><parameter>paramFormats[]</parameter></term>
          <listitem>
           <para>
-           Spécifie si les paramètres sont du texte (placez un zéro dans la ligne du
-           tableau pour le paramètre correspondant) ou binaire (placez un un dans la
+           Spécifie si les paramètres sont du texte (place un zéro dans la ligne du
+           tableau pour le paramètre correspondant) ou binaire (place un un dans la
            ligne du tableau pour le paramètre correspondant). Si le pointeur du
            tableau est nul, alors tous les paramètres sont présumés être des chaînes
            de texte.
           </para>
           <para>
            Les valeurs passées dans le format binaire nécessitent de connaître la
-           représentation interne attendue par le moteur. Par exemple, les entiers
+           représentation interne attendue par le processus backend. Par exemple, les entiers
            doivent être passés dans l'ordre réseau pour les octets. Passer des
            valeurs <type>numeric</type> requiert de connaître le format de stockage
            du serveur, comme implémenté dans
@@ -2526,9 +2525,10 @@ void *PQgetssl(const PGconn *conn);
   </para>
 
   <para>
-   Le principal avantage de <function>PQexecParams</function> sur <function>PQexec</function> est
-   que les valeurs de paramètres pourraient être séparés à partir de la chaîne de
-   commande, évitant ainsi le besoin de guillemets et d'échappements.
+   Le principal avantage de <function>PQexecParams</function> sur
+   <function>PQexec</function> est que les valeurs de paramètres peuvent être
+   séparées à partir de la chaîne de commande, évitant ainsi le besoin
+   de guillemets et d'échappements, toujours pénibles et sources d'erreurs.
   </para>
 
   <para>
@@ -2542,8 +2542,8 @@ void *PQgetssl(const PGconn *conn);
   <tip>
    <para>
     Spécifier les types de paramètres via des OID est difficile, tout
-    particulièrement si vous préférez ne pas coder en dur les valeurs OID
-    particulières dans vos programmes. Néanmoins, vous pouvez éviter de le faire
+    particulièrement si vous préférez ne pas coder en dur des valeurs OID
+    particulières dans vos programmes. Néanmoins, vous pouvez éviter de le faire,
     même dans des cas où le serveur lui-même ne peut pas déterminer le type du
     paramètre ou choisit un type différent de celui que vous voulez. Dans le texte
     de commande SQL, attachez une conversion explicite au symbole de paramètre pour
@@ -2582,18 +2582,19 @@ void *PQgetssl(const PGconn *conn);
         fonction autorise les commandes à être exécutées de façon répétée sans
         être analysées et planifiées à chaque fois&nbsp;; voir <xref
         linkend="sql-prepare"/> pour les détails.
-        <function>PQprepare</function> est uniquement supporté par les
+        <function>PQprepare</function> est supporté uniquement par les
         connexions utilisant le protocole 3.0 et ses versions
         ultérieures&nbsp;; elle échouera avec le protocole 2.0.
        </para>
 
        <para>
         La fonction crée une instruction préparée nommée <parameter>stmtName</parameter>
-        à partir de la chaîne <parameter>query</parameter>, devant contenir une seule
-        commande SQL. <parameter>stmtName</parameter> pourrait être une chaîne vide pour
+        à partir de la chaîne <parameter>query</parameter>,
+        qui ne doit contenir qu'une seule commande SQL.
+        <parameter>stmtName</parameter> peut être  <literal>""</literal> pour
         créer une instruction non nommée, auquel cas toute instruction non nommée
-        déjà existante est automatiquement remplacée par cette dernière.
-        Une erreur sera rapportée si le nom de l'instruction est déjà définie
+        déjà existante est automatiquement remplacée par cette dernière&nbsp;
+        sinon une erreur sera levée si le nom de l'instruction est déjà définie
         dans la session en cours. Si des paramètres sont utilisés, ils sont
         référencés dans la requête avec <literal>$1</literal>, <literal>$2</literal>, etc.
         <parameter>nParams</parameter> est le nombre de paramètres pour lesquels des types
@@ -2604,10 +2605,10 @@ void *PQgetssl(const PGconn *conn);
         Si <parameter>paramTypes</parameter> est <symbol>NULL</symbol> ou si un élément
         particulier du tableau vaut zéro, le serveur affecte un type de données
         au symbole du paramètre de la même façon qu'il le ferait pour une chaîne
-        littérale non typée. De plus, la requête pourrait utiliser des symboles
+        littérale non typée. De plus, la requête peut utiliser des symboles
         de paramètre avec des nombres plus importants que
         <parameter>nParams</parameter>&nbsp;; les types de données seront aussi inférés
-        pour ces symboles. (Voir <function>PQdescribePrepared</function> comme un
+        pour ces symboles. (Voir <function>PQdescribePrepared</function> pour un
         moyen de trouver les types de données inférés.)
        </para>
 
@@ -2655,15 +2656,15 @@ void *PQgetssl(const PGconn *conn);
        commandes utilisées de façon répétée d'être analysées et planifiées seulement
        une fois plutôt que chaque fois qu'ils sont exécutés.
        L'instruction doit avoir été préparée précédemment dans la session en cours.
-       <function>PQexecPrepared</function> est supporté seulement dans les connexions
-       du protocole 3.0 et ses versions ultérieures&nbsp;; il échouera lors de
+       <function>PQexecPrepared</function> est supporté seulement pour des connexions
+       en protocole 3.0 et versions ultérieures&nbsp;; il échouera lors de
        l'utilisation du protocole 2.0.
       </para>
 
       <para>
        Les paramètres sont identiques à <function>PQexecParams</function>, sauf que le nom
-       d'une instruction préparée est donné au lieu d'une chaîne de requête et le
-       paramètre <parameter>paramTypes[]</parameter> n'est pas présente (il n'est pas
+       d'une instruction préparée est donné au lieu d'une chaîne de requête et
+       que le paramètre <parameter>paramTypes[]</parameter> n'est pas présent (il n'est pas
        nécessaire car les types des paramètres de l'instruction préparée ont été
        déterminés à la création).
       </para>
@@ -2683,7 +2684,7 @@ void *PQgetssl(const PGconn *conn);
 
       <para>
        <function>PQdescribePrepared</function> permet à une application d'obtenir des
-       informations si une instruction préparée précédemment.
+       informations sur une instruction préparée précédemment.
        <function>PQdescribePrepared</function> est seulement supporté avec des
        connexions utilisant le protocole 3.0 et ultérieures&nbsp;; il échouera lors
        de l'utilisation du protocole 2.0.
@@ -2696,10 +2697,10 @@ void *PQgetssl(const PGconn *conn);
        renvoyé avec le code retour <literal>PGRES_COMMAND_OK</literal>. Les fonctions
        <function>PQnparams</function> et <function>PQparamtype</function> peuvent
        utiliser ce <structname>PGresult</structname> pour obtenir des
-       informations sur les paramètres d'une instruction préparée, et les fonctions
+       informations sur les paramètres de l'instruction préparée, et les fonctions
        <function>PQnfields</function>, <function>PQfname</function>,
-       <function>PQftype</function>, etc fournissent des informations sur les colonnes
-       résultantes (au cas où) de l'instruction.
+       <function>PQftype</function>, etc. fournissent des informations sur les colonnes
+       résultantes (s'il y en a) de l'instruction.
       </para>
      </listitem>
     </varlistentry>
@@ -2722,7 +2723,7 @@ void *PQgetssl(const PGconn *conn);
        fonction pour inspecter les propriétés d'un curseur créé avec la commande
        SQL <command>DECLARE CURSOR</command>.)
        <function>PQdescribePortal</function> est seulement supporté dans les connexions
-       via le protocole 3.0 et ultérieurs&nbsp;; il échouera lors de l'utilisation du
+       en protocole 3.0 et ultérieurs&nbsp;; il échouera lors de l'utilisation du
        protocole 2.0.
       </para>
 
@@ -2732,9 +2733,9 @@ void *PQgetssl(const PGconn *conn);
        existant. En cas de succès, un <structname>PGresult</structname> est renvoyé
        avec le code de retour <literal>PGRES_COMMAND_OK</literal>. Les fonctions
        <function>PQnfields</function>, <function>PQfname</function>,
-       <function>PQftype</function>, etc peuvent utiliser ce
+       <function>PQftype</function>, etc. peuvent utiliser ce
        <structname>PGresult</structname> pour obtenir des informations sur les colonnes
-       résultats (au cas où) du portail.
+       résultantes (s'il y en a) du portail.
       </para>
      </listitem>
     </varlistentry>
@@ -2748,8 +2749,8 @@ void *PQgetssl(const PGconn *conn);
    <application>libpq</application> devraient faire attention au maintien de
    l'abstraction de <structname>PGresult</structname>. Utilisez les fonctions
    d'accès ci-dessous pour obtenir le contenu de <structname>PGresult</structname>.
-   Évitez la référence aux champs de la structure <structname>PGresult</structname>
-   car ils sont sujets à des changements dans le futur.
+   Évitez de référencer directement les champs de la structure <structname>PGresult</structname>
+   car ils sont sujets à changements dans le futur.
 
    <variablelist>
     <varlistentry id="libpq-pqresultstatus">
@@ -2832,7 +2833,8 @@ void *PQgetssl(const PGconn *conn);
            Lancement du transfert de données Copy In/Out (vers et à
            partir du serveur). Cette fonctionnalité est seulement
            utilisée par la réplication en flux,
-           so this status should not occur in ordinary applications.
+           ce statut ne devrait donc pas apparaître dans les applications
+           ordinaires.
           </para>
          </listitem>
         </varlistentry>
@@ -2853,7 +2855,7 @@ void *PQgetssl(const PGconn *conn);
        Si le statut du résultat est <literal>PGRES_TUPLES_OK</literal> ou <literal>PGRES_SINGLE_TUPLE</literal>, alors les
        fonctions décrites ci-dessous peuvent être utilisées pour récupérer les lignes
        renvoyées par la requête. Notez qu'une commande <command>SELECT</command> qui
-       arrive à récupérer aucune ligne affichera toujours
+       récupère zéro ligne affichera toujours
        <literal>PGRES_TUPLES_OK</literal>. <literal>PGRES_COMMAND_OK</literal> est
        pour les commandes qui ne peuvent jamais renvoyer de lignes
        (<command>INSERT</command> ou <command>UPDATE</command> sans une clause <literal>RETURNING</literal>, etc.). Une réponse
@@ -2893,17 +2895,17 @@ void *PQgetssl(const PGconn *conn);
        </synopsis>
        S'il y a eu une erreur, la chaîne renvoyée incluera un retour chariot en fin.
        L'appelant ne devrait pas libérer directement le résultat. Il sera libéré quand
-       la poignée <structname>PGresult</structname> associée est passée à
+       le handle <structname>PGresult</structname> associé sera passé à
        <function>PQclear</function>.
       </para>
 
       <para>
-       Suivant immédiatement un appel à <function>PQexec</function> ou
+       Immédiatement après un appel à <function>PQexec</function> ou
        <function>PQgetResult</function>, <function>PQerrorMessage</function> (sur la
        connexion) renverra la même chaîne que <function>PQresultErrorMessage</function>
        (sur le résultat). Néanmoins, un <structname>PGresult</structname> conservera
        son message d'erreur jusqu'à destruction alors que le message d'erreur de la
-       connexion changera lorsque des opérations suivantes seront réalisées. Utiliser
+       connexion changera lorsque des opérations suivantes seront réalisées. Utilisez
        <function>PQresultErrorMessage</function> quand vous voulez connaître le statut
        associé avec un <structname>PGresult</structname> particulier&nbsp;; utilisez
        <function>PQerrorMessage</function> lorsque vous souhaitez connaître le statut
@@ -2934,8 +2936,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
         <function>PQresultVerboseErrorMessage</function> couvre ce besoin en
         traitant le message tel qu'il aurait été produit par
         <function>PQresultErrorMessage</function> si la configuration souhaitée
-        de la verbosité était en effet pour la connexion quand l'objet
-        <structname>PGresult</structname> donné a été généré. Si le
+        de la verbosité était activée pour la connexion au moment où l'objet
+        <structname>PGresult</structname> indiqué a été généré. Si le
         <structname>PGresult</structname> ne correspond pas une erreur,
         <quote>PGresult is not an error result</quote> est renvoyé à la place.
         La chaîne renvoyée inclut un retour à la ligne en fin de chaîne.
@@ -2950,7 +2952,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        </para>
 
        <para>
-        Un NULL est possible en retour s'il n'y a pas suffisamment de mémoire.
+        Un NULL en retour est possible en retour s'il n'y a pas suffisamment de mémoire.
        </para>
       </listitem>
      </varlistentry>
@@ -2967,8 +2969,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        <structname>PGresult</structname> n'est pas un résultat d'erreur ou
        d'avertissement, ou n'inclut pas le champ spécifié. Les valeurs de champ
        n'incluront normalement pas un retour chariot en fin. L'appelant ne devrait pas
-       libérer directement le résultat. Il sera libéré quand la poignée
-       <structname>PGresult</structname> associée est passée à
+       libérer directement le résultat. Il sera libéré quand le handle
+       <structname>PGresult</structname> associé sera passé à
        <function>PQclear</function>.
       </para>
 
@@ -2984,7 +2986,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
            <literal>FATAL</literal> ou <literal>PANIC</literal> dans un message d'erreur, ou
            <literal>WARNING</literal>, <literal>NOTICE</literal>, <literal>DEBUG</literal>,
            <literal>INFO</literal> ou <literal>LOG</literal> dans un message de notification, ou une
-           traduction localisée de ceux-ci. Toujours présent.
+           traduction localisée d'un de ceux-ci. Toujours présent.
           </para>
          </listitem>
         </varlistentry>
@@ -3000,7 +3002,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
            <literal>DEBUG</literal>, <literal>INFO</literal> ou
            <literal>LOG</literal> (dans un message de notification). C'est
            identique au champ <symbol>PG_DIAG_SEVERITY</symbol> sauf que le
-           contenu n'est jamais traduit. C'est présent uniquement dans les
+           contenu n'est jamais traduit. Il est présent uniquement dans les
            rapports générés par les versions 9.6 et ultérieurs de
            <productname>PostgreSQL</productname>.
           </para>
@@ -3017,8 +3019,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
           </indexterm>
           <para>
            Le code SQLSTATE de l'erreur. Ce code identifie le type d'erreur qui est
-           survenu&nbsp;; il peut être utilisé par des interfaces qui réalisent les
-           opérations spécifiques (telles que la gestion des erreurs) en réponse à une
+           survenu&nbsp;; il peut être utilisé par des interfaces utilisateur pour
+           des opérations spécifiques (telles que la gestion des erreurs) en réponse à une
            erreur particulière de la base de données. Pour une liste des codes SQLSTATE
            possibles, voir l'<xref linkend="errcodes-appendix"/>. Ce champ n'est pas
            localisable et est toujours présent.
@@ -3030,7 +3032,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
          <term><symbol>PG_DIAG_MESSAGE_PRIMARY</symbol></term>
          <listitem>
           <para>
-           Le principal message d'erreur, compréhensible par un humain (typiquement sur
+           Le message d'erreur principal, compréhensible par un humain (typiquement sur
            une ligne). Toujours présent.
           </para>
          </listitem>
@@ -3041,7 +3043,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
          <listitem>
           <para>
            Détail&nbsp;: un message d'erreur secondaire et optionnel proposant plus
-           d'informations sur le problème. Pourrait être composé de plusieurs lignes.
+           d'informations sur le problème. Pourrait courir sur plusieurs lignes.
           </para>
          </listitem>
         </varlistentry>
@@ -3053,7 +3055,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
            Astuce&nbsp;: une suggestion supplémentaire sur ce qu'il faut faire suite à
            ce problème. Elle a pour but de différer du détail car elle
            offre un conseil (potentiellement inapproprié) plutôt que des faits établis.
-           Pourrait être composé de plusieurs lignes.
+           Pourrait courir sur plusieurs lignes.
           </para>
          </listitem>
         </varlistentry>
@@ -3062,9 +3064,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
          <term><symbol>PG_DIAG_STATEMENT_POSITION</symbol></term>
          <listitem>
           <para>
-           Une chaîne contenant un entier décimal indiquant le position du curseur d'erreur
-           comme index dans la chaîne d'instruction originale. Le premier caractère se
-           trouve à l'index 1 et les positions sont mesurées en caractères, et non pas en
+           Une chaîne contenant un entier décimal indiquant une position du curseur d'erreur
+           comme index dans la chaîne d'instruction originale. Le premier caractère
+           a l'index 1 et les positions sont mesurées en caractères, et non en
            octets.
           </para>
          </listitem>
@@ -3075,7 +3077,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
          <listitem>
           <para>
            Ceci est défini de la même façon que le champ <symbol>PG_DIAG_STATEMENT_POSITION</symbol>
-           mais c'est utilisé quand la position du curseur fait référence à une commande
+           mais est utilisé quand la position du curseur fait référence à une commande
            générée en interne plutôt qu'une soumise par le client. Le champ
            <symbol>PG_DIAG_INTERNAL_QUERY</symbol> apparaîtra toujours quand ce champ apparaît.
           </para>
@@ -3086,7 +3088,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
          <term><symbol>PG_DIAG_INTERNAL_QUERY</symbol></term>
          <listitem>
           <para>
-           Le texte d'une commande échouée, générée en interne. Ceci pourrait être, par
+           Le texte d'une commande générée en interne et échouée. Ce pourrait être, par
            exemple, une requête SQL lancée par une fonction PL/pgSQL.
           </para>
          </listitem>
@@ -3097,9 +3099,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
          <listitem>
           <para>
            Une indication du contexte dans lequel l'erreur est apparue. Actuellement, cela
-           inclut une trace de la pile d'appels des fonctions actives de langages de
-           procédures et de requêtes générées en interne. La trace a une
-           entrée par ligne, la plus récente se trouvant au début.
+           inclut une trace de la pile d'appels des fonctions du langage
+           procédural actif et de requêtes générées en interne. La trace a une
+           entrée par ligne, la plus récente au début.
           </para>
          </listitem>
         </varlistentry>
@@ -3192,20 +3194,20 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <note>
        <para>
         Les champs pour les noms du schéma, de la table, de la colonne, du
-        type de données et de la contrainte sont seulement fournis pour un
+        type de données et de la contrainte sont fournis seulement pour un
         nombre limité de types d'erreurs&nbsp;; voir <xref
         linkend="errcodes-appendix"/>. Ne supposez pas que la présence d'un
         de ces champs garantisse la présence d'un autre champ. Les sources
         d'erreurs du moteur observent les relations notées ci-dessus mais les
         fonctions utilisateurs peuvent utiliser ces champs d'une autre
         façon. Dans la même idée, ne supposez pas que ces champs indiquent
-        des objets actuels dans la base de données courante.
+        des objets encore existants dans la base de données courante.
        </para>
       </note>
 
       <para>
        Le client est responsable du formatage des informations affichées suivant
-       à ses besoins&nbsp;; en particulier, il doit supprimer les longues
+       ses besoins&nbsp;; en particulier, il doit supprimer les longues
        lignes si nécessaires. Les caractères de retour chariot apparaissant dans les
        champs de message d'erreur devraient être traités comme des changements de
        paragraphes, pas comme des changements de lignes.
@@ -3215,7 +3217,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        Les erreurs générées en interne par <application>libpq</application> auront une
        sévérité et un message principal mais aucun autre champ. Les erreurs renvoyées
        par un serveur utilisant un protocole antérieure à la 3.0 inclueront la
-       sévérité, le message principal et, quelques fois, un message détaillé mais
+       sévérité, le message principal et parfois un message détaillé, mais
        aucun autre champ.
       </para>
 
@@ -3244,8 +3246,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        aussi longtemps que vous en avez besoin&nbsp;; il ne part pas lorsque
        vous lancez une nouvelle commande, même pas si vous fermez la
        connexion. Pour vous en débarrasser, vous devez appeler
-       <function>PQclear</function>. En cas d'oubli, ceci résultera en des
-       pertes mémoires pour votre application.
+       <function>PQclear</function>. En cas d'oubli, le résultat sera une
+       fuite de mémoire dans votre application.
       </para>
      </listitem>
     </varlistentry>
@@ -3255,18 +3257,18 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  </sect2>
 
  <sect2 id="libpq-exec-select-info">
-  <title>Récupérer l'information provenant des résultats des requêtes</title>
+  <title>Récupérer l'information dans le résultat des requêtes</title>
 
   <para>
    Ces fonctions sont utilisées pour extraire des informations provenant d'un objet
    <structname>PGresult</structname> représentant un résultat valide pour une
-   requête (statut <literal>PGRES_TUPLES_OK</literal> ou <literal>PGRES_SINGLE_TUPLE</literal>). Ils peuvent aussi être
+   requête (statut <literal>PGRES_TUPLES_OK</literal> ou
+   <literal>PGRES_SINGLE_TUPLE</literal>). Elles peuvent aussi être
    utilisés pour extraire des informations à partir d'une opération Describe
    réussie&nbsp;: le résultat d'un Describe a les mêmes informations de colonnes
-   qu'une exécution réelle de la requête aurait fournie, mais elle ne renvoie pas
-   de lignes. Pour les objets
-   ayant d'autres valeurs de statut, ces fonctions agiront comme si le résultat n'avait
-   aucune ligne et aucune colonne.
+   qu'une exécution réelle de la requête aurait fournie, mais avec zéro ligne.
+   Pour les objets avec d'autres valeurs de statut, ces fonctions agiront comme
+   si le résultat avait zéro ligne et zéro colonne.
   </para>
 
   <variablelist>
@@ -3274,7 +3276,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQntuples</function><indexterm><primary>PQntuples</primary></indexterm></term>
     <listitem>
      <para>
-      Renvoie le nombre de lignes (tuples) du résultat de la requête.
+      Renvoie le nombre de lignes (enregistrements, ou
+      <foreignphrase>tuples</foreignphrase>) du résultat de la requête.
       (Notez que les objets <structname>PGresult</structname> sont limités à
       au plus <literal>INT_MAX</literal> lignes, donc un résultat de type
       <type>int</type> est suffisant.)
@@ -3302,7 +3305,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       Renvoie le nom de la colonne associé avec le numéro de colonne donnée.
       Les numéros de colonnes commencent à zéro. L'appelant ne devrait pas
-      libérer directement le numéro. Il sera libéré quand la poignée
+      libérer directement le résultat. Il sera libéré quand le handle
       <structname>PGresult</structname> associée est passée à <function>PQclear</function>.
       <synopsis>char *PQfname(const PGresult *res,
                       int column_number);
@@ -3334,7 +3337,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Le nom donné est traité comme un identifiant dans une commande SQL,
       c'est-à-dire qu'il est mis en minuscule sauf s'il est entre des
       guillemets doubles. Par exemple, pour le résultat de la requête
-      suivante
+      suivante&nbsp;:
       <programlisting>SELECT 1 AS FOO, 2 AS "BAR";
       </programlisting>
       nous devons obtenir les résultats suivants&nbsp;:
@@ -3354,8 +3357,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <listitem>
      <para>
       Renvoie l'OID de la table à partir de laquelle la colonne donnée a été
-      récupérée. Les numéros de colonnes commencent à zéro mais les colonnes des
-      tables ont des numéros différents de zéro.
+      récupérée. Les numéros de colonnes commencent à 0.
       <synopsis>Oid PQftable(const PGresult *res,
                     int column_number);
       </synopsis>
@@ -3363,15 +3365,15 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <para>
       <literal>InvalidOid</literal> est renvoyé si le numéro de colonne est en dehors de la
-      plage ou si la colonne spécifiée n'est pas une simple référence à une colonne de
+      plage, ou si la colonne spécifiée n'est pas une simple référence à une colonne de
       table, ou lors de l'utilisation d'un protocole antérieur à la version 3.0. Vous
-      pouvez lancer des requêtes vers la table système <literal>pg_class</literal>
+      pouvez requêter la table système <literal>pg_class</literal>
       pour déterminer exactement quelle table est référencée.
      </para>
 
      <para>
       Le type <type>Oid</type> et la constante
-      <literal>InvalidOid</literal> sera définie lorsque vous incluerez le
+      <literal>InvalidOid</literal> seront définis lorsque vous incluerez le
       fichier d'en-tête <application>libpq</application>. Ils auront le même
       type entier.
      </para>
@@ -3382,9 +3384,10 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQftablecol</function><indexterm><primary>PQftablecol</primary></indexterm></term>
     <listitem>
      <para>
-      Renvoie le numéro de colonne (à l'intérieur de la table) de la colonne
+      Renvoie le numéro de colonne (dans sa table) de la colonne
       correspondant à la colonne spécifiée de résultat de la requête. Les numéros de
-      la colonne résultante commencent à 0.
+      colonne du résultat commencent à 0, mais les colonnes de table ont des
+      numéros supérieurs à zéro.
       <synopsis>int PQftablecol(const PGresult *res,
                       int column_number);
       </synopsis>
@@ -3410,7 +3413,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      Le code de format zéro indique une représentation textuelle des données
+      Le code de format zéro indique une représentation textuelle des données,
       alors qu'un code de format un indique une représentation binaire (les
       autres codes sont réservés pour des définitions futures).
      </para>
@@ -3433,8 +3436,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Vous pouvez lancer des requêtes sur la table système <literal>pg_type</literal>
       pour obtenir les noms et propriétés des différents types de données.
       Les <acronym>OID</acronym> des types de données intégrés sont définis dans le
-      fichier <filename>src/include/catalog/pg_type.h</filename> de la distribution
-      des sources.
+      fichier <filename>src/include/catalog/pg_type.h</filename> dans le code
+      source.
      </para>
     </listitem>
    </varlistentry>
@@ -3452,8 +3455,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <para>
       L'interprétation des valeurs du modificateur est spécifique au type&nbsp;;
-      elles indiquent la précision ou les limites de taille. La valeur -1 est
-      utilisée pour indiquer qu'<quote>aucune information n'est disponible</quote>. La
+      typiquement elles indiquent la précision ou les limites de taille.
+      La valeur -1 est
+      utilisée pour indiquer <quote>aucune information disponible</quote>. La
       plupart des types de données n'utilisent pas les modificateurs, auquel cas la
       valeur est toujours -1.
      </para>
@@ -3465,7 +3469,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <listitem>
      <para>
       Renvoie la taille en octets de la colonne associée au numéro de
-      colonne donné. Les numéros de colonnes commencent à zéro.
+      colonne donné. Les numéros de colonnes commencent à 0.
       <synopsis>int PQfsize(const PGresult *res,
                    int column_number);
       </synopsis>
@@ -3474,7 +3478,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       <function>PQfsize</function> renvoie l'espace alloué pour cette colonne dans une ligne
       de la base de données, en d'autres termes la taille de la représentation
-      interne du serveur du type de données (de façon cohérente, ce n'est pas
+      interne du serveur du type de données (en conséquence ce n'est pas
       réellement utile pour les clients). Une valeur négative indique que les types de
       données ont une longueur variable.
      </para>
@@ -3495,7 +3499,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Cette fonction est obsolète (sauf dans le cas d'une utilisation en relation avec
       <command>COPY</command>) car un seul <structname>PGresult</structname> peut contenir du texte
       dans certaines colonnes et des données binaires dans d'autres.
-      <function>PQfformat</function> est la fonction préférée. <function>PQbinaryTuples</function>
+      <function>PQfformat</function> est à préférer. <function>PQbinaryTuples</function>
       renvoie 1 seulement si toutes les colonnes du résultat sont dans un format
       binaire (format 1).
      </para>
@@ -3509,8 +3513,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Renvoie la valeur d'un seul champ d'une seule ligne d'un
       <structname>PGresult</structname>. Les numéros de lignes et de
       colonnes commencent à zéro. L'appelant ne devrait pas libérer
-      directement le résultat. Il sera libéré quand la poignée
-      <structname>PGresult</structname> associée est passée à
+      directement le résultat. Il sera libéré quand le handle
+      <structname>PGresult</structname> associé sera passé à
       <function>PQclear</function>.
       <synopsis>char* PQgetvalue(const PGresult *res,
                         int row_number,
@@ -3524,23 +3528,23 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       caractères terminée par un octet nul de la valeur du champ. Pour les données au
       format binaire, la valeur dans la représentation binaire est déterminée par le
       type de la donnée, fonctions <function>typsend</function> et
-      <function>typreceive</function> (la valeur est en fait suivie d'un octet zéro dans ce
-      cas aussi mais ce n'est pas réellement utile car la valeur a des chances de
-      contenir d'autres valeurs NULL embarquées).
+      <function>typreceive</function>. (La valeur est en fait suivie d'un octet
+      zéro dans ce cas aussi, mais ce n'est pas réellement utile car la valeur
+      a des chances de contenir d'autres valeurs NULL embarquées).
      </para>
 
      <para>
       Une chaîne vide est renvoyée si la valeur du champ est NULL. Voir
-      <function>PQgetisnull</function> pour distinguer les valeurs NULL des valeurs de
-      chaîne vide.
+      <function>PQgetisnull</function> pour distinguer les valeurs NULL des
+      chaînes vides.
      </para>
 
      <para>
       Le pointeur renvoyé par <function>PQgetvalue</function> pointe vers le stockage
       qui fait partie de la structure <structname>PGresult</structname>. Personne ne
-      devrait modifier les données vers lesquelles il pointe et tout le monde
-      devrait copier explicitement les données dans un autre stockage s'il n'est
-      pas utilisé après la durée de vie de la struture
+      devrait modifier les données vers lesquelles il pointe, et tout le monde
+      devrait copier explicitement les données dans un autre stockage s'il doit
+      être utilisé après la durée de vie de la struture
       <structname>PGresult</structname>.
      </para>
     </listitem>
@@ -3552,8 +3556,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <indexterm><primary>valeur NULL</primary><secondary sortas="libpq">dans
        libpq</secondary></indexterm>
      <para>
-      Teste un champ pour savoir s'il est nul. Les numéros de lignes et de
-      colonnes commencent à zéro.
+      Teste un champ pour savoir s'il est NULL. Les numéros de lignes et de
+      colonnes commencent à 0.
       <synopsis>int PQgetisnull(const PGresult *res,
                        int row_number,
                        int column_number);
@@ -3563,7 +3567,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       Cette fonction renvoie 1 si le champ est nul et 0 s'il contient une valeur non
       NULL (notez que <function>PQgetvalue</function> renverra une chaîne vide, et
-      non pas un pointeur nul, pour un champ nul).
+      non pas un pointeur NULL, pour un champ NULL).
      </para>
     </listitem>
    </varlistentry>
@@ -3573,7 +3577,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <listitem>
      <para>
       Renvoie la longueur réelle de la valeur d'un champ en octet. Les
-      numéros de lignes et de colonnes commencent à zéro.
+      numéros de lignes et de colonnes commencent à 0.
       <synopsis>int PQgetlength(const PGresult *res,
                       int row_number,
                       int column_number);
@@ -3581,12 +3585,12 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      C'est la longueur réelle des données pour la valeur particulière des données,
+      C'est la longueur réelle des données pour cette donnée en particulier,
       c'est-à-dire la taille de l'objet pointé par <function>PQgetvalue</function>.
       Pour le format textuel, c'est identique à <function>strlen()</function>. Pour le format
-      binaire, c'est une information essentielle. Notez que <emphasis>personne</emphasis> ne
-      devrait se fier à <function>PQfsize</function> pour obtenir la taille réelle
-      des données.
+      binaire, c'est une information essentielle. Notez que l'on ne devrait
+      <emphasis>pas</emphasis> se fier à <function>PQfsize</function> pour
+      obtenir la taille réelle des données.
      </para>
     </listitem>
    </varlistentry>
@@ -3602,9 +3606,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      Cette fonction est seulement utile pour inspecter le résultat de
-      <function>PQdescribePrepared</function>. Pour les autres types de requêtes, il
-      renverra zéro.
+      Cette fonction est utile seulement pour inspecter le résultat de
+      <function>PQdescribePrepared</function>. Pour les autres types de requêtes,
+      elle renverra zéro.
      </para>
     </listitem>
    </varlistentry>
@@ -3613,17 +3617,17 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQparamtype</function><indexterm><primary>PQparamtype</primary></indexterm></term>
     <listitem>
      <para>
-      Renvoie le type de donnée du paramètre indiqué de l'instruction.
-      Le numérotage des paramètres commence à 0.
+      Renvoie le type de donnée du paramètre indiqué dans l'instruction.
+      Les numéros des paramètres commencent à 0.
       <synopsis>
        Oid PQparamtype(const PGresult *res, int param_number);
       </synopsis>
      </para>
 
      <para>
-      Cette fonction est seulement utile pour inspecyer le résultat de
-      <function>PQdescribePrepared</function>. Pour les autres types de requêtes, il
-      renverra zéro.
+      Cette fonction est utile seulement pour inspecter le résultat de
+      <function>PQdescribePrepared</function>. Pour les autres types de requêtes,
+      elle renverra zéro.
      </para>
     </listitem>
    </varlistentry>
@@ -3680,17 +3684,17 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQcmdStatus</function><indexterm><primary>PQcmdStatus</primary></indexterm></term>
     <listitem>
      <para>
-      Renvoie l'état de la commande depuis l'instruction SQL qui a généré le
-      <structname>PGresult</structname>. L'appelant ne devrait pas libérer
-      directement le résultat. Il sera libéré quand la poignée
-      <structname>PGresult</structname> associée est passée à
-      <function>PQclear</function>.
+      Renvoie l'état de la commande de l'instruction SQL qui a généré le
+      <structname>PGresult</structname>.
       <synopsis>char * PQcmdStatus(PGresult *res);
       </synopsis>
      </para>
      <para>
-      D'habitude, c'est juste le nom de la commande mais elle pourrait inclure des
+      D'habitude, c'est juste le nom de la commande mais elle peut inclure des
       données supplémentaires comme le nombre de lignes traitées.
+      L'appelant ne devrait pas libérer directement le résultat. Il sera libéré
+      quand le handle <structname>PGresult</structname> associée sera passé à
+      <function>PQclear</function>.
      </para>
     </listitem>
    </varlistentry>
@@ -3707,15 +3711,16 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       Cette fonction renvoie une chaîne contenant le nombre de lignes affectées par
       l'instruction <acronym>SQL</acronym> qui a généré <structname>PGresult</structname>. Cette
-      fonction peut seulement être utilisée après l'exécution d'une instruction
+      fonction ne peut être utilisée qu'après l'exécution d'une instruction
       <command>SELECT</command>, <command>CREATE TABLE AS</command>, <command>INSERT</command>,
       <command>UPDATE</command>, <command>DELETE</command>, <command>MOVE</command>,
-      <command>FETCH</command> ou <command>COPY</command>, ou <command>EXECUTE</command> avec une instruction préparée
+      <command>FETCH</command> ou <command>COPY</command>,
+      ou un <command>EXECUTE</command> d'une instruction préparée
       contenant une instruction <command>INSERT</command>, <command>UPDATE</command> ou
       <command>DELETE</command>. Si la commande qui a généré <structname>PGresult</structname> était
       autre chose, <function>PQcmdTuples</function> renverrait directement une chaîne vide.
       L'appelant ne devrait pas libérer la valeur de retour directement. Elle sera
-      libérée quand la poignée <structname>PGresult</structname> associée est passée à
+      libérée quand le handle <structname>PGresult</structname> associée sera passé à
       <function>PQclear</function>.
      </para>
     </listitem>
@@ -3726,12 +3731,12 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <listitem>
      <para>
       Renvoie l'OID<indexterm><primary>OID</primary><secondary>dans
-        libpq</secondary></indexterm> de la ligne insérée, si la commande
-      <acronym>SQL</acronym> était une instruction
+      libpq</secondary></indexterm> de la ligne insérée, si la commande
+      <acronym>SQL</acronym> était un
       <command>INSERT</command> qui a inséré exactement une ligne dans une
-      table comprenant des OID ou un <command>EXECUTE</command> d'une requête
+      table comprenant des OID, ou un <command>EXECUTE</command> d'une requête
       préparée contenant une instruction <command>INSERT</command> convenable.
-      Sinon, cette fonction renvoie <literal>InvalidOid</literal>. Cette
+      Sinon cette fonction renvoie <literal>InvalidOid</literal>. Cette
       fonction renverra aussi <literal>InvalidOid</literal> si la table
       touchée par l'instruction <command>INSERT</command> ne contient pas d'OID.
       <synopsis>Oid PQoidValue(const PGresult *res);
@@ -3759,7 +3764,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  </sect2>
 
  <sect2 id="libpq-exec-escape-string">
-  <title>Chaîne d'échappement à inclure dans les commandes SQL</title>
+  <title>Échapper les chaînes dans les commandes SQL</title>
 
   <indexterm zone="libpq-exec-escape-string">
    <primary>chaînes d'échappement</primary>
@@ -3787,7 +3792,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       dans une commande SQL. C'est utile pour insérer des données comme des
       constantes dans des commandes SQL. Certains caractères, comme les
       guillemets et les antislashs, doivent être traités avec des caractères
-      d'échappement pour éviter qu'ils soient traités d'après leur
+      d'échappement pour éviter qu'ils ne soient traités d'après leur
       signification spéciale par l'analyseur SQL.
       <function>PQescapeLiteral</function> réalise cette opération.
      </para>
@@ -3797,15 +3802,15 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       paramètre <parameter>str</parameter> dans une mémoire allouée avec
       <function>malloc()</function>. Cette mémoire devra être libérée en
       utilisant <function>PQfreemem()</function> quand le résultat ne sera
-      plus utile. Un octet zéro de fin n'est pas requis et ne doit pas être
-      compté dans <parameter>length</parameter>. (Si un octet zéro de fin est
-      découvert avant la fin du traitement des <parameter>length</parameter>
+      plus utile. Un octet zéro final n'est pas requis et ne doit pas être
+      compté dans <parameter>length</parameter>. (Si un octet zéro est
+      découvert avant le traitement de <parameter>length</parameter>
       octets, <function>PQescapeLiteral</function> s'arrête au zéro&nbsp;; ce
-      comportement est identique à celui de <function>strncpy</function>.) Les
+      comportement est celui de <function>strncpy</function>.) Les
       caractères spéciaux de la chaîne en retour ont été remplacés pour qu'ils
       puissent être traités correctement par l'analyseur de chaînes de
       <productname>PostgreSQL</productname>. Un octet zéro final est aussi
-      ajouté. Les guillemets simples qui doivent entourer les chaînes litérales
+      ajouté. Les guillemets simples qui doivent entourer les chaînes littérales
       avec <productname>PostgreSQL</productname> sont inclus dans la chaîne
       résultante.
      </para>
@@ -3813,7 +3818,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <para>
       En cas d'erreur, <function>PQescapeLiteral</function> renvoit
       <symbol>NULL</symbol> et
-      un message convenable est stocké dans l'objet
+      un message adéquat est stocké dans l'objet
       <parameter>conn</parameter>.
      </para>
 
@@ -3821,7 +3826,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <para>
        Il est particulièrement important de faire un échappement propre lors
        de l'utilisation de chaînes provenant d'une source qui n'est pas
-       forcément de confiance. Sinon, il existe un risque de sécurité&nbsp;:
+       de confiance. Sinon, il existe un risque de sécurité&nbsp;:
        vous vous exposez à une attaque de type <quote>injection SQL</quote>
        avec des commandes SQL non voulues injectées dans votre base de
        données.
@@ -3830,8 +3835,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <para>
       Notez qu'il n'est pas nécessaire ni correct de faire un échappement quand
-      une valeur est passé en tant que paramètre séparé dans
-      <function>PQexecParams</function> ou ce type de routine.
+      une valeur est passée en tant que paramètre séparé dans
+      <function>PQexecParams</function> ou ses routines sœurs.
      </para>
     </listitem>
    </varlistentry>
@@ -3856,9 +3861,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       puisse être utilisé en tant qu'identifiant SQL, par exemple pour le
       nom d'une table, d'une colonne ou d'une fonction. C'est utile quand un
       identifiant fourni par un utilisateur pourrait contenir des caractères
-      spéciaux qui pourraient autrement ne pas être interprétés comme faisant
-      parti de l'identifiant par l'analyseur SQL ou lorsque l'identifiant
-      pourrait contenir des caractères en majuscule, auquel cas le casse doit
+      spéciaux, qui sinon ne seraient pas interprétés comme faisant
+      partie de l'identifiant par l'analyseur SQL, ou lorsque l'identifiant
+      pourrait contenir des caractères en majuscule, dont la casse doit
       être préservée.
      </para>
 
@@ -3867,30 +3872,30 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <parameter>str</parameter> échappée comme doit l'être un identifiant SQL,
       dans une mémoire allouée avec <function>malloc()</function>. Cette
       mémoire doit être libérée en utilisant <function>PQfreemem()</function>
-      quand le résultat n'est plus nécessaire. Un octet zéro de fin n'est pas
+      quand le résultat n'est plus nécessaire. Un octet zéro final n'est pas
       nécessaire et ne doit pas être comptabilisé dans
-      <parameter>length</parameter>. (Si un octet zéro de fin est trouvé avant
-      le traitement des <parameter>length</parameter> octets,
+      <parameter>length</parameter>. (Si un octet zéro est trouvé avant
+      le traitement de <parameter>length</parameter> octets,
       <function>PQescapeIdentifier</function> s'arrête au zéro&nbsp;; ce
-      comportement est identique à celui de <function>strncpy</function>.) Les
+      comportement est celui de <function>strncpy</function>.) Les
       caractères spéciaux de la chaîne en retour ont été remplacés pour que
       ce dernier soit traité proprement comme un identifiant SQL. Un octet
-      zéro de fin est aussi ajouté. La chaîne de retour sera aussi entourée de
+      zéro final est aussi ajouté. La chaîne de retour sera aussi entourée de
       guillemets doubles.
      </para>
 
      <para>
       En cas d'erreur, <function>PQescapeIdentifier</function> renvoit
       <symbol>NULL</symbol> et
-      un message d'erreur convenable est stockée dans l'objet
+      un message d'erreur adéquat est stocké dans l'objet
       <parameter>conn</parameter>.
      </para>
 
      <tip>
       <para>
-       Comme avec les chaînes litérales, pour empêcher les attaques d'injection
-       SQL, les identifiants SQL doivent être échappés lorsqu'elles proviennent
-       de source non sûre.
+       Comme avec les chaînes litérales, pour empêcher les attaques par injection
+       SQL, les identifiants SQL doivent être échappés lorsqu'ils proviennent
+       d'une source non sûre.
       </para>
      </tip>
     </listitem>
@@ -3914,43 +3919,43 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      </para>
 
      <para>
-      <function>PQescapeStringConn</function> échappe les chaînes litérales de
+      <function>PQescapeStringConn</function> échappe les chaînes littérales de
       la même façon que <function>PQescapeLiteral</function>. Contrairement à
       <function>PQescapeLiteral</function>, l'appelant doit fournir un tampon
       d'une taille appropriée. De plus, <function>PQescapeStringConn</function>
-      n'ajoute pas de guillemets simples autour des chaînes litérales de
+      n'ajoute pas de guillemets simples autour des chaînes littérales de
       <productname>PostgreSQL</productname>&nbsp;; elles doivent être ajoutées
       dans la commande SQL où ce résultat sera inséré. Le paramètre
-      <parameter>from</parameter> pointe vers le premier caractère d'une chaîne
+      <parameter>from</parameter> pointe vers le premier caractère de la chaîne
       à échapper, et le paramètre <parameter>length</parameter> précise le
-      nombre d'octets contenus dans cette chaîne. Un octet zéro de fin n'est
+      nombre d'octets contenus dans cette chaîne. Un octet zéro final n'est
       pas nécessaire et ne doit pas être comptabilisé dans
-      <parameter>length</parameter>. (Si un octet zéro de fin est trouvé avant
-      le traitement des <parameter>length</parameter> octets,
+      <parameter>length</parameter>. (Si un octet zéro est trouvé avant
+      le traitement de <parameter>length</parameter> octets,
       <function>PQescapeStringConn</function> s'arrête au zéro&nbsp;; ce
-      comportement est identique à celui de <function>strncpy</function>.)
+      comportement est celui de <function>strncpy</function>.)
       <parameter>to</parameter> doit pointer vers un tampon qui peut contenir
       au moins un octet de plus que deux fois la valeur de
       <parameter>length</parameter>, sinon le comportement de la fonction
-      n'est pas connue. Le comportement est aussi non défini si les chaînes
-      <parameter>to</parameter> et <parameter>from</parameter> se surchargent.
+      est indéfini. Le comportement est indéfini si les chaînes
+      <parameter>to</parameter> et <parameter>from</parameter> se recouvrent.
      </para>
 
      <para>
       Si le paramètre <parameter>error</parameter> est différent de <symbol>NULL</symbol>,
-      alors <literal>*error</literal> est configuré à zéro en cas de succès
-      et est différent de zéro en cas d'erreur. Actuellement, les seuls
+      alors <literal>*error</literal> est configuré à zéro en cas de succès,
+      et est différent de zéro en cas d'erreur. Actuellement, les seules
       conditions permettant une erreur impliquent des encodages multi-octets
       dans la chaîne source. La chaîne en sortie est toujours générée en cas
-      d'erreur mais il est possible que le serveur la rejettera comme une
-      chaîne malformée. En cas d'erreur, un message convenable est stocké dans
+      d'erreur mais on peut s'attendre à ce que le serveur la rejette comme une
+      chaîne malformée. En cas d'erreur, un message adéquat est stocké dans
       l'objet <parameter>conn</parameter>, que <parameter>error</parameter>
       soit <symbol>NULL</symbol> ou non.
      </para>
 
      <para>
       <function>PQescapeStringConn</function> renvoit le nombre d'octets écrits
-      dans <parameter>to</parameter>, sans inclure l'octet zéro de fin.
+      dans <parameter>to</parameter>, sans inclure l'octet zéro final.
      </para>
     </listitem>
    </varlistentry>
@@ -3965,7 +3970,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
     <listitem>
      <para>
-      <function>PQescapeString</function> est une ancienne version de
+      <function>PQescapeString</function> est une version ancienne et obsolète de
       <function>PQescapeStringConn</function>.
       <synopsis>
         size_t PQescapeString (char *to, const char *from, size_t length);
@@ -3977,20 +3982,20 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       dans le fait que <function>PQescapeString</function> n'a pas de
       paramètres <parameter>conn</parameter> et <parameter>error</parameter>.
       À cause de cela, elle ne peut ajuster son
-      comportement avec les propriétés de la connexion (comme l'encodage des
-      caractères) et du coup, <emphasis>elle pourrait founir de mauvais
-       résultats</emphasis>. De plus, elle ne peut pas renvoyer de conditions
+      comportement en fonction des propriétés de la connexion (comme l'encodage des
+      caractères) et du coup, <emphasis>elle pourrait founir des résultats
+      erronés</emphasis>. De plus, elle ne peut pas renvoyer de conditions
       d'erreur.
      </para>
 
      <para>
-      <function>PQescapeString</function> peut être utilisé proprement avec
-      des programmes utilisant une seule connexion
+      <function>PQescapeString</function> peut être utilisé en toute sécurité avec
+      des programmes client utilisant une seule connexion
       <productname>PostgreSQL</productname> à la fois (dans ce cas,
       il peut trouver ce qui l'intéresse <quote>en arrière-plan</quote>).
       Dans d'autres contextes, c'est un risque en terme de sécurité. Cette
-      fonction devrait être évitée et remplacée autant que possible par la
-      fonction <function>PQescapeStringConn</function>.
+      fonction devrait être évitée et remplacée par
+      <function>PQescapeStringConn</function>.
      </para>
     </listitem>
    </varlistentry>
@@ -4021,7 +4026,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <para>
        Le paramètre <parameter>from</parameter> pointe sur le premier octet de la
        chaîne à échapper et le paramètre <parameter>from_length</parameter> donne le
-       nombre d'octets de cette chaîne binaire (un octet zéro de terminaison n'est
+       nombre d'octets de cette chaîne binaire (un octet zéro final n'est
        ni nécessaire ni compté). Le paramètre <parameter>to_length</parameter>
        pointe vers une variable qui contiendra la longueur de la chaîne échappée
        résultante. Cette longueur inclut l'octet zéro de terminaison.
@@ -4034,9 +4039,9 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        <function>PQfreemem</function> lorsque le résultat n'est plus nécessaire. Tous les
        caractères spéciaux de la chaîne de retour sont remplacés de façon à ce
        qu'ils puissent être traités proprement par l'analyseur de chaînes littérales
-       de <productname>PostgreSQL</productname> et par l'entrée
-       <type>bytea</type> de la fonction. Un octet zéro de terminaison est aussi
-       ajouté. Les guillemets simples qui englobent les chaînes littérales de
+       de <productname>PostgreSQL</productname> et par la fonction d'entrée
+       <type>bytea</type>. Un octet zéro final est aussi
+       ajouté. Les guillemets simples qui encadrent les chaînes littérales de
        <productname>PostgreSQL</productname> ne font pas partie de la chaîne
        résultante.
       </para>
@@ -4052,7 +4057,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
      <term><function>PQescapeBytea</function><indexterm><primary>PQescapeBytea</primary></indexterm></term>
      <listitem>
       <para>
-       <function>PQescapeBytea</function> est une version obsolète de
+       <function>PQescapeBytea</function> est une version ancienne et obsolète de
        <function>PQescapeByteaConn</function>.
        <synopsis>
         unsigned char *PQescapeBytea(const unsigned char *from,
@@ -4065,12 +4070,12 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       La seule différence avec <function>PQescapeByteaConn</function> est que
       <function>PQescapeBytea</function> ne prend pas de paramètre
       <structname>PGconn</structname>. De ce fait, <function>PQescapeBytea</function>
-      peut seulement être utilisé correctement dans des programmes qui n'utilisent
+      ne peut être utilisé en toute sécurité que dans des programmes qui n'utilisent
       qu'une seule connexion <productname>PostgreSQL</productname> à la fois (dans
       ce cas, il peut trouver ce dont il a besoin <quote>en arrière-plan</quote>).
-      Il <emphasis>pourrait donner de mauvais résultats</emphasis> s'il était
+      Elle <emphasis>pourrait donner des résultats erronés</emphasis> si elle est
       utilisé dans des programmes qui utilisent plusieurs connexions de bases de
-      données (dans ce cas, utilisez plutôt <function>PQescapeByteaConn</function>).
+      données (dans ce cas, utilisez <function>PQescapeByteaConn</function>).
      </para>
     </listitem>
    </varlistentry>
@@ -4079,7 +4084,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQunescapeBytea</function><indexterm><primary>PQunescapeBytea</primary></indexterm></term>
     <listitem>
      <para>
-      Convertit une représentation de la chaîne en donnés binaires --
+      Convertit une représentation de la chaîne en donnés binaires —
       l'inverse de <function>PQescapeBytea</function>. Ceci est nécessaire lors de
       la récupération de données <type>bytea</type> en format texte, mais pas lors
       de sa récupération au format binaire.
@@ -4090,20 +4095,21 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <para>
       Le paramètre <parameter>from</parameter> pointe vers une chaîne de
-      telle façon qu'elle pourrait provenir de <function>PQgetvalue</function>
+      telle qu'elle pourrait provenir de <function>PQgetvalue</function>
       lorsque la colonne est de type <type>bytea</type>.
       <function>PQunescapeBytea</function> convertit cette représentation de la
       chaîne en sa représentation binaire. Elle renvoie un pointeur vers le tampon
       alloué avec <function>malloc()</function>, ou <symbol>NULL</symbol> en cas d'erreur, et place
       la taille du tampon dans <parameter>to_length</parameter>. Le résultat doit
-      être libéré en utilisant <function>PQfreemem</function> lorsque celui-ci n'est plus
+      être libéré en utilisant <function>PQfreemem</function> lorsqu'il n'est plus
       nécessaire.
      </para>
 
      <para>
       Cette conversion n'est pas l'inverse exacte de <function>PQescapeBytea</function>
-      car la chaîne n'est pas échappée avec <function>PQgetvalue</function>. Cela
-      signifie en particulier qu'il n'y a pas besoin de réfléchir à la mise entre
+      car la chaîne n'est pas supposée être "échappée" quelle est est renvoyée
+      par <function>PQgetvalue</function>. Cela veut dire, notamment,
+      qu'il n'y a pas besoin de réfléchir à la mise entre
       guillemets de la chaîne, et donc pas besoin d'un paramètre <structname>PGconn</structname>.
      </para>
     </listitem>
@@ -5103,7 +5109,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <para>
       L'application pourrait diviser le flux de données de <command>COPY</command>
-      dans des chargements de tampon de taille convenable. Les limites n'ont pas de
+      dans des chargements de tampon de taille adéquate. Les limites n'ont pas de
       signification sémantique lors de l'envoi. Le contenu du flux de données doit
       correspondre au format de données attendu par la commande
       <command>COPY</command>&nbsp;; voir <xref linkend="sql-copy"/>
@@ -5238,7 +5244,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   <para>
    Ces fonctions représentent d'anciennes méthodes de gestion de
    <command>COPY</command>. Bien qu'elles fonctionnent toujours, elles sont obsolètes à
-   cause de leur pauvre gestion des erreurs, des méthodes non convenables de
+   cause de leur pauvre gestion des erreurs, des méthodes inadéquates de
    détection d'une fin de transmission, et du manque de support des transferts
    binaires et des transferts non bloquants.
   </para>

--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -262,7 +262,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
       <para>
        C'est une macro faisant appel à <function>PQsetdbLogin</function> avec des
        pointeurs nuls pour les paramètres <parameter>login</parameter> et <parameter>pwd</parameter>.
-       Elle est fournie pour une compatibilité ascendante des très vieux programmes.
+       Elle est fournie pour la compatibilité avec les très vieux programmes.
       </para>
      </listitem>
     </varlistentry>
@@ -444,7 +444,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
          <term><symbol>CONNECTION_SETENV</symbol></term>
          <listitem>
           <para>
-           Négociation des paramétres de l'environnement.
+           Négociation des paramètres de l'environnement.
           </para>
          </listitem>
         </varlistentry>
@@ -1021,7 +1021,7 @@ typedef struct
        </para>
        <para>
         Une liste de noms d'hôtes séparés par des virgules est aussi acceptée,
-        auquel cas chaque nom d'hôte est testé dans cet ordre&nbsp;;
+        auquel cas chaque nom d'hôte est testé dans l'ordre&nbsp;;
         un élément vide dans la liste implique le comportement par
         défaut comme décrit plus haut. Voir
         <xref linkend="libpq-multiple-hosts"/> pour les détails.
@@ -1079,12 +1079,12 @@ typedef struct
         <literal>host</literal> n'est pas le nom du serveur
         à l'adresse réseau <literal>hostaddr</literal>. Et quand
         <literal>host</literal> et <literal>hostaddr</literal> sont tous deux
-        spécifiés, seul  <literal>host</literal> est utilisé pour identifier
+        spécifiés, seul <literal>host</literal> est utilisé pour identifier
         la connexion dans un fichier de mots de passe (voir la <xref
         linkend="libpq-pgpass"/>).
        </para>
        <para>
-        Une liste d'adresses <literal>hostaddr</literal>, séparées par des
+        Une liste d'adresses <literal>hostaddr</literal> séparées par des
         virgules est aussi acceptée, auquel cas chaque hôte est essayé dans cet
         ordre. Un élément vide dans la liste mène à l'utilisation du nom d'hôte
         correspondant, ou, s'il est vide aussi, de la valeur par défaut.
@@ -1108,8 +1108,8 @@ typedef struct
         <indexterm><primary>port</primary></indexterm>
         Si plusieurs hôtes sont indiquées dans les paramètres
         <literal>host</literal> ou <literal>hostaddr</literal>,
-        ce paramètre spécifie une liste de ports, séparés par des virgules,
-        liste de même taille que la liste
+        ce paramètre spécifie une liste de ports séparés par des virgules
+        et de même taille que la liste
         des hôtes, ou bien il peut préciser un seul port à tester pour tous les hôtes.
         Une chaîne vide, ou un élément vide de la liste, indique le numéro de
         port par défaut établi à la compilation de
@@ -1136,7 +1136,8 @@ typedef struct
        <para>
         Nom de l'utilisateur <productname>PostgreSQL</productname> qui se
         connecte.
-        Par défaut, il s'agit du nom d'utilisateur système ayant lancé l'application.
+        Par défaut, il s'agit du même nom que l'utilisateur système lançant
+        l'application.
        </para>
       </listitem>
      </varlistentry>
@@ -1345,7 +1346,7 @@ typedef struct
          <listitem>
           <para>
            La connexion passe en mode réplication logique, se connectant à la
-           base donnée spécifiée par le paramètre <literal>dbname</literal>.
+           base spécifiée par le paramètre <literal>dbname</literal>.
           </para>
          </listitem>
         </varlistentry>
@@ -1366,8 +1367,8 @@ typedef struct
       </para>
 
       <para>
-       En mode réplication physique ou logique, seul le protocole simple de
-       requête peut être utilisé.
+       En mode réplication physique ou logique, seul le protocole simple
+       peut être utilisé.
       </para>
       </listitem>
      </varlistentry>
@@ -1415,7 +1416,7 @@ typedef struct
           <term><literal>require</literal></term>
           <listitem>
            <para>
-            essaie seulement une connexion <acronym>SSL</acronym>
+            essaie seulement une connexion <acronym>SSL</acronym>.
             Si un certificat racine d'autorité (<acronym>CA</acronym>)
             est présent, vérifie le certificat de la même façon que si
             <literal>verify-ca</literal> était spécifié
@@ -1542,7 +1543,7 @@ typedef struct
         le certificat client. Il peut soit indiquer un nom de fichier qui
         sera utilisé à la place du fichier
         <filename>~/.postgresql/postgresql.key</filename> par défaut, soit
-        indiquer une clé obtenue par un «&nbsp;moteur&nbsp;» externe
+        indiquer une clé obtenue par un <quote>moteur</quote> externe
         (les moteurs sont des modules chargeables
         d'<productname>OpenSSL</productname>). La spécification d'un moteur
         externe devrait consister en un nom de moteur et un identifiant de
@@ -1583,7 +1584,7 @@ typedef struct
       <term><literal>requirepeer</literal></term>
       <listitem>
        <para>
-        Ce paramètre indique le nom d'utilisateur auprès
+        Ce paramètre indique le nom d'utilisateur du serveur auprès
         du système d'exploitation, par exemple
         <literal>requirepeer=postgres</literal>. Lors d'une connexion
         par socket de domaine Unix, si ce paramètre est configuré, le
@@ -1597,7 +1598,7 @@ typedef struct
         ou tout espace autorisé en écriture pour tout le monde,
         n'importe quel utilisateur peut y mettre un serveur en écoute.
         Utilisez ce paramètre pour vous assurer que vous êtes connecté à
-        un serveur est exécuté par un utilisateur de confiance.) Cette
+        un serveur exécuté par un utilisateur de confiance.) Cette
         option est seulement supportée par les plateformes où
         la méthode d'authentification <literal>peer</literal>
         est disponible&nbsp;; voir <xref linkend="auth-peer"/>.
@@ -1736,8 +1737,8 @@ typedef struct
       <para>
        <function>PQpass</function> retournera soit le mot de passe spécifié dans
        les paramètres de connexion, soit, s'il n'y en avait pas, le mot
-       de passe obtenu grâce au <link linkend="libpq-pgpass">fichier de mots de
-       passe</link>. Dans ce dernier cas, si plusieurs hôtes était spécifiées
+       de passe obtenu depuis le <link linkend="libpq-pgpass">fichier de mots de
+       passe</link>. Dans ce dernier cas, si plusieurs hôtes était spécifiés
        dans les paramètres de connexion, il n'est pas possible de se fier au
        résultat de <function>PQpass</function> jusqu'à l'établissement de la
        connexion. Le statut de la connexion peut être vérifié avec la
@@ -1764,7 +1765,7 @@ typedef struct
         <literal>hostaddr</literal> sont tous les deux précisés,
         alors <function>PQhost</function> retournera
         <literal>host</literal>. Si seul <literal>hostaddr</literal> a été
-        spécifié, c'est cela qui est retourné. Si plusieurs hôtes étaient spécifiées
+        spécifié, c'est cela qui est retourné. Si plusieurs hôtes sont spécifiés
         dans les paramètres de connexion, <function>PQhost</function> retourne
         l'hôte à qui l'on s'est effectivement connecté.
       </para>
@@ -1798,7 +1799,7 @@ typedef struct
 
       <para>
         Si de multiples ports étaient spécifiés dans les paramètres de connexion,
-        <function>PQport</function> renvoie le port auquel l'on est effectivement
+        <function>PQport</function> renvoie le port auquel on est effectivement
         connecté.
       </para>
 
@@ -1827,7 +1828,7 @@ typedef struct
        Renvoie le <acronym>TTY</acronym> de débogage pour la connexion
        (ceci est obsolète car le serveur ne fait plus attention au
        paramétrage du <acronym>TTY</acronym> mais la fonction reste pour
-       la compatibilité ascendante).
+       la compatibilité descendante).
        <synopsis>char *PQtty(const PGconn *conn);
        </synopsis>
       </para>
@@ -1873,7 +1874,7 @@ typedef struct
        jusqu'à <function>PQfinish</function> mais un échec dans les communications
        peut résulter en un statut changeant prématurément en
        <literal>CONNECTION_BAD</literal>. Dans ce cas, l'application peut
-       essayer de récupérer en appelant <function>PQreset</function>.
+       essayer de rattraper la situation en appelant <function>PQreset</function>.
       </para>
 
       <para>
@@ -1933,9 +1934,10 @@ typedef struct
        (<varname>server_encoding</varname>, <varname>TimeZone</varname> et
        <varname>integer_datetimes</varname> n'étaient pas renvoyés dans les versions
        antérieures à la 8.0&nbsp;;
-       <varname>standard_conforming_strings</varname> n'était pas renvoyés dans les versions
-       antérieures à la 8.1; <varname>IntervalStyle</varname> n'était pas renvoyé dans les versions
-       antérieures à la 8.4;
+       <varname>standard_conforming_strings</varname> n'était pas renvoyé
+       dans les versions antérieures à la 8.1&nbsp;;
+       <varname>IntervalStyle</varname> n'était pas renvoyé dans les versions
+       antérieures à la 8.4&nbsp;;
        <varname>application_name</varname>  n'était pas renvoyé dans les versions
        antérieures à la 9.0).
        Notez que
@@ -1953,10 +1955,12 @@ typedef struct
        <function>PQparameterStatus</function> plutôt qu'un code
        <foreignphrase>ad-hoc</foreignphrase> pour trouver ces valeurs.
        (Notez cependant que pour les connexions pré-3.0, changer
-       <varname>client_encoding</varname> via <command>SET</command> après le lancement de la
-       connexion ne sera pas reflété par <function>PQparameterStatus</function>). Pour
-       <varname>server_version</varname>, voir aussi <function>PQserverVersion</function>, qui renvoie
-       l'information dans un format numérique qui est plus facile à comparer.
+       <varname>client_encoding</varname> via <command>SET</command>
+       après le lancement de la connexion ne sera pas reflété par
+        <function>PQparameterStatus</function>). Pour
+       <varname>server_version</varname>, voir aussi
+       <function>PQserverVersion</function>, qui renvoie
+       l'information dans un format numérique plus facile à comparer.
       </para>
 
       <para>
@@ -2051,7 +2055,7 @@ typedef struct
        un message pour <function>PQerrorMessage</function> en cas d'échec.
        Notez que, par convention dans <application>libpq</application>, un résultat
        non vide de <function>PQerrorMessage</function> peut courir sur plusieurs lignes
-       et finira par un retour.
+       et finira par un retour chariot.
        L'appelant ne devrait pas libérer directement le
        résultat. Il sera libéré quand le handle <structname>PGconn</structname> associé
        sera passé à <function>PQfinish</function>. La chaîne résultante n'est pas
@@ -2114,9 +2118,8 @@ typedef struct
       </para>
 
       <para>
-       Cette fonction peut être utilisée après un échec de tentative de
-       connexion pour décider de la demande d'un utilisateur pour un mot de
-       passe.
+       Cette fonction peut être utilisée après un échec de
+       connexion pour décider s'il faut demander un mot de passe à l'utilisateur.
       </para>
      </listitem>
     </varlistentry>
@@ -2325,7 +2328,7 @@ void *PQgetssl(const PGconn *conn);
  </sect1>
 
  <sect1 id="libpq-exec">
-  <title>Fonctions d'exécution des commandes</title>
+  <title>Fonctions d'exécution de commandes</title>
 
   <para>
    Une fois la connexion au serveur de la base de données établie avec
@@ -2366,7 +2369,7 @@ void *PQgetssl(const PGconn *conn);
    La chaîne de la commande peut inclure plusieurs commandes SQL (séparées par des points
    virgules). Les requêtes multiples envoyées
    dans un unique appel à <function>PQexec</function> sont exécutées dans une seule
-   transaction sauf si des commandes <command>BEGIN</command>/<command>COMMIT
+   transaction, sauf si des commandes <command>BEGIN</command>/<command>COMMIT
    </command>  explicites sont incluses dans la chaîne
    de requête pour la diviser en de multiples transactions. (Voir <xref
    linkend="protocol-flow-multi-statement"/> pour plus de détails sur comment le
@@ -2541,13 +2544,13 @@ void *PQgetssl(const PGconn *conn);
 
   <tip>
    <para>
-    Spécifier les types de paramètres via des OID est difficile, tout
-    particulièrement si vous préférez ne pas coder en dur des valeurs OID
-    particulières dans vos programmes. Néanmoins, vous pouvez éviter de le faire,
+    Spécifier les types de paramètres via des OID est difficile,
+    surtout si vous préférez ne pas coder en dur des valeurs OID
+    particulières dans vos programmes. Néanmoins vous pouvez éviter de le faire,
     même dans des cas où le serveur lui-même ne peut pas déterminer le type du
-    paramètre ou choisit un type différent de celui que vous voulez. Dans le texte
-    de commande SQL, attachez une conversion explicite au symbole de paramètre pour
-    montrer le type de données que vous enverrez. Par exemple&nbsp;:
+    paramètre ou choisit un type différent de celui que vous voulez. Dans le
+    texte de la commande SQL, ajoutez une conversion explicite au symbole de
+    paramètre pour indiquer le type de données que vous enverrez. Par exemple&nbsp;:
     <programlisting>SELECT * FROM ma_table WHERE x = $1::bigint;
     </programlisting>
     Ceci impose le traitement du paramètre <literal>$1</literal> en tant que <type>bigint</type>
@@ -2684,7 +2687,7 @@ void *PQgetssl(const PGconn *conn);
 
       <para>
        <function>PQdescribePrepared</function> permet à une application d'obtenir des
-       informations sur une instruction préparée précédemment.
+       informations sur une instruction préparée précédente.
        <function>PQdescribePrepared</function> est seulement supporté avec des
        connexions utilisant le protocole 3.0 et ultérieures&nbsp;; il échouera lors
        de l'utilisation du protocole 2.0.
@@ -2904,8 +2907,8 @@ void *PQgetssl(const PGconn *conn);
        <function>PQgetResult</function>, <function>PQerrorMessage</function> (sur la
        connexion) renverra la même chaîne que <function>PQresultErrorMessage</function>
        (sur le résultat). Néanmoins, un <structname>PGresult</structname> conservera
-       son message d'erreur jusqu'à destruction alors que le message d'erreur de la
-       connexion changera lorsque des opérations suivantes seront réalisées. Utilisez
+       son message d'erreur jusqu'à destruction, alors que le message d'erreur de la
+       connexion changera avec les opérations suivantes. Utilisez
        <function>PQresultErrorMessage</function> quand vous voulez connaître le statut
        associé avec un <structname>PGresult</structname> particulier&nbsp;; utilisez
        <function>PQerrorMessage</function> lorsque vous souhaitez connaître le statut
@@ -2931,7 +2934,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
                                   PGVerbosity verbosity,
                                   PGContextVisibility show_context);
 </synopsis>
-        Dans certaines situations, un client pourrait souhaiter obtenir une
+        Dans certaines situations, un client pourrait vouloir une
         version plus détaillée d'une erreur déjà rapportée.
         <function>PQresultVerboseErrorMessage</function> couvre ce besoin en
         traitant le message tel qu'il aurait été produit par
@@ -2952,7 +2955,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
        </para>
 
        <para>
-        Un NULL en retour est possible en retour s'il n'y a pas suffisamment de mémoire.
+        Un NULL en retour est possible s'il n'y a pas suffisamment de mémoire.
        </para>
       </listitem>
      </varlistentry>
@@ -3414,7 +3417,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <para>
       Le code de format zéro indique une représentation textuelle des données,
-      alors qu'un code de format un indique une représentation binaire (les
+      alors qu'un code un indique une représentation binaire (les
       autres codes sont réservés pour des définitions futures).
      </para>
     </listitem>
@@ -3543,8 +3546,8 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       Le pointeur renvoyé par <function>PQgetvalue</function> pointe vers le stockage
       qui fait partie de la structure <structname>PGresult</structname>. Personne ne
       devrait modifier les données vers lesquelles il pointe, et tout le monde
-      devrait copier explicitement les données dans un autre stockage s'il doit
-      être utilisé après la durée de vie de la struture
+      devrait copier les données dans un autre stockage explicitement si elles
+      doivent être utilisées après la durée de vie de la struture
       <structname>PGresult</structname>.
      </para>
     </listitem>
@@ -3893,7 +3896,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
 
      <tip>
       <para>
-       Comme avec les chaînes litérales, pour empêcher les attaques par injection
+       Comme avec les chaînes littérales, pour empêcher les attaques par injection
        SQL, les identifiants SQL doivent être échappés lorsqu'ils proviennent
        d'une source non sûre.
       </para>
@@ -4133,7 +4136,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
    <listitem>
     <para>
      <function>PQexec</function> attend que la commande se termine. L'application
-     pourrait avoir du travail ailleur (comme le rafraîchissement de
+     pourrait avoir du travail ailleurs (comme le rafraîchissement de
      l'interface utilisateur), auquel cas elle ne voudra pas être bloquée en attente
      de la réponse.
     </para>
@@ -4412,7 +4415,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       si leur état a changé.
      </para>
      <para>
-      <function>PQconsumeInput</function> peut être appelé même si l'application
+      <function>PQconsumeInput</function> peut être appelée même si l'application
       n'est pas encore préparée à traiter un résultat ou une notification. La fonction
       lira les données disponibles et les sauvegardera dans un tampon indiquant
       ainsi qu'une lecture d'un <function>select()</function> est possible.
@@ -4572,7 +4575,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  <para>
   D'habitude, <application>libpq</application> récupère le résultat complet
   d'une commande SQL et la renvoie à l'application sous la forme d'une seule
-  structure <structname>PGresult</structname>. Ce peut être imparaticable
+  structure <structname>PGresult</structname>. Ce peut être impraticable
   pour les commandes renvoyant un grand nombre de lignes. Dans
   de tels cas, les applications peuvent utiliser
   <function>PQsendQuery</function> et <function>PQgetResult</function> dans
@@ -4837,7 +4840,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   d'arguments déclarés de la fonction. Quand le champ
   <parameter>isint</parameter> d'une structure est vrai, la valeur de
   <parameter>u.integer</parameter> est envoyée au serveur en tant qu'entier de
-  la longueur indiquée (qui doit être 2 ou 4 octets)&nbsp;; les permtutations
+  la longueur indiquée (qui doit être 2 ou 4 octets)&nbsp;; les permutations
   d'octets adéquates sont opérées.
   Quand <parameter>isint</parameter> est faux, le nombre
   d'octets indiqué sur <parameter>*u.ptr</parameter> est envoyé sans
@@ -4910,7 +4913,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
  <para>
   La fonction <function>PQnotifies</function> renvoie la prochaine notification à
   partir d'une liste de messages de notification non gérés reçus à partir du
-  serveur. Il renvoie un pointeur NULL s'il n'existe pas de notifications en
+  serveur. Il renvoie un pointeur NULL s'il n'existe pas de notification en
   attente. Une fois qu'une notification est renvoyée à partir de
   <function>PQnotifies</function>, elle est considérée comme étant gérée et sera supprimée
   de la liste des notifications.
@@ -4958,7 +4961,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   serveur, donc sans utiliser de <acronym>CPU</acronym> sauf
   lorsqu'il y a quelque chose à faire (voir <function>PQsocket</function> pour
   obtenir le numéro du descripteur de fichiers à utiliser avec
-  <function>select()</function>). Notez que ceci fonctionnera que
+  <function>select()</function>). Notez que ceci fonctionnera que vous
   soumettiez les commandes avec
   <function>PQsendQuery</function>/<function>PQgetResult</function> ou que vous
   utilisiez simplement <function>PQexec</function>. Néanmoins, vous devriez vous
@@ -5182,7 +5185,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
   </para>
 
   <variablelist>
-   <varlistentry id="libpq-">
+   <varlistentry id="libpq-pqgetcopydata">
     <term><function>PQgetCopyData</function><indexterm><primary>PQgetCopyData</primary></indexterm></term>
     <listitem>
      <para>
@@ -5399,7 +5402,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       <synopsis>int PQendcopy(PGconn *conn);
       </synopsis>
       Cette fonction attend que le serveur ait terminé la copie. Elle devrait
-      indiquer soit le moment om la dernière chaîne a été envoyée au serveur en utilisant
+      indiquer soit le moment où la dernière chaîne a été envoyée au serveur en utilisant
       <function>PQputline</function>, soit le moment où la dernière chaîne a été reçue
       du serveur en utilisant <function>PGgetline</function>. Si ce n'est pas fait,
       le serveur renverra un <quote>out of sync</quote> (perte de
@@ -6157,8 +6160,8 @@ char *PQencryptPassword(const char *passwd, const char *user);
   Le pointeur passthrough ne change jamais pendant toute la durée du
   <structname>PGconn</structname> et des <structname>PGresult</structname>
   générés grâce à lui&nbsp;; donc s'il est utilisé, il doit pointer vers
-  des données à longue vie. De plus, il existe une pointeur de <firstterm>données
-   instanciées</firstterm>, qui commence à NULL dans chaque objet
+  des données à longue vie. De plus, il existe un pointeur de <firstterm>données
+  instanciées</firstterm>, qui commence à NULL dans chaque objet
   <structname>PGconn</structname> et <structname>PGresult</structname>. Ce
   pointeur peut être manipulé en utilisant les fonctions
   <function>PQinstanceData</function>, <function>PQsetInstanceData</function>,
@@ -6318,7 +6321,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
       L'événement de copie du résultat est déclenché en réponse à un
       <function>PQcopyResult</function>. Cet événement se déclenchera
       seulement une fois la copie terminée. Seules les procédures qui ont
-      gérée avec succès l'événement <literal>PGEVT_RESULTCREATE</literal>
+      géré avec succès l'événement <literal>PGEVT_RESULTCREATE</literal>
       ou <literal>PGEVT_RESULTCOPY</literal> pour le résultat source recevront
       les événements <literal>PGEVT_RESULTCOPY</literal>.
 
@@ -6459,7 +6462,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
      </para>
 
      <para>
-      Une procédure d'évenement doit être enregistrée une fois pour chaque
+      Une procédure d'événement doit être enregistrée une fois pour chaque
       <structname>PGconn</structname> pour lequel vous souhaitez recevoir des
       événements. Il n'existe pas de limite, autre que la mémoire, sur le
       nombre de procédures d'événements qui peuvent être enregistrées avec
@@ -6496,7 +6499,8 @@ char *PQencryptPassword(const char *passwd, const char *user);
       <parameter>conn</parameter> pour la
       procédure <parameter>proc</parameter>.
       Cette fonction renvoit zéro en cas d'échec et autre chose en cas de réussite.
-      (L'échec est seulement possible si <parameter>proc</parameter> n'a pas été correctement enregistré dans <parameter>conn</parameter>)
+      (L'échec est seulement possible si <parameter>proc</parameter> n'a pas
+      été correctement enregistré dans <parameter>conn</parameter>.)
 
       <synopsis>
         int PQsetInstanceData(PGconn *conn, PGEventProc proc, void *data);
@@ -7115,7 +7119,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
    Sur un serveur secondaire, un champ <literal>database</literal> à
    <literal>replication</literal> correspond aux connexions de réplication
    par flux au serveur maître. À part cela, le champ <literal>database</literal>
-   est d'une utilité limitée sinon, puisque les utilisateurs ont le même mot de
+   est d'une utilité limitée, puisque les utilisateurs ont le même mot de
    passe pour toutes les bases de données de l'instance.
   </para>
 
@@ -7173,7 +7177,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
     port=5433
     user=admin
   </programlisting>
-  <filename>share/pg_service.conf.sample</filename> est fourni comment
+  <filename>share/pg_service.conf.sample</filename> est fourni comme
   fichier d'exemple.
  </para>
 </sect1>
@@ -7215,7 +7219,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
   recherche LDPA réussie, mais continue si le serveur LDAP ne peut pas
   être contacté. Cela fournit un moyen de préciser d'autres URL LDAP pointant
   vers d'autres serveurs LDAP, des paires classiques <literal>motclé =
-   valeur</literal> ou les options de connexion par défaut. Si dans ce case
+   valeur</literal> ou les options de connexion par défaut. Si dans ce cas
    vous préférez avoir un message d'erreur, ajoutez une ligne syntaxiquement
    incorrecte après l'URL LDAP.
  </para>
@@ -7315,7 +7319,7 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
    Une fois qu'une chaîne de confiance a été établie, il existe deux façons
    pour le client de valider le certificat feuille envoyé par le serveur. Si
    le paramètre <literal>sslmode</literal> est configuré à
-   <literal>verify- ca</literal>, libpq vérifiera qu'il peut faire confiance
+   <literal>verify-ca</literal>, libpq vérifiera qu'il peut faire confiance
    au serveur en vérifiant
    la chaîne des certificats jusqu'au certificat racine stocké sur le client.
    Si <literal>sslmode</literal> est configuré à
@@ -7372,7 +7376,7 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
 
   <note>
    <para>
-    Pour la compatibilité ascendante avec les anciennes versions de
+    Par compatibilité avec les anciennes versions de
     PostgreSQL, si un certificat racine d'autorité existe, le comportement
     de <literal>sslmode</literal>=<literal>require</literal> sera identique
     à celui de <literal>verify-ca</literal>. Cela signifie que le
@@ -7452,12 +7456,12 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
        voir et modifier les données <emphasis>y compris si elles sont
        chiffrées</emphasis>. La tierce partie peut ensuite renvoyer les
        informations de connexion et les données au serveur d'origine, rendant
-       impossible à ce dernier la détection de l'attaque. Les vecteurs communs
+       impossible à ce dernier la détection de l'attaque. Les vecteurs habituels
        pour parvenir à ce type d'attaque sont l'empoisonnement des DNS
        (<foreignphrase>DNS poisoning</foreignphrase>) et le détournement
        d'adresses (<foreignphrase>address hijacking</foreignphrase>),
        où le client est dirigé vers un autre serveur
-       que celui attendu. Il existe encore plusieurs autres méthodes d'attaque
+       que celui attendu. Il existe encore plusieurs autres méthodes
        pour accomplir ceci. <acronym>SSL</acronym> utilise la vérification des
        certificats pour l'empêcher, en authentifiant le serveur auprès du
        client.
@@ -7497,7 +7501,7 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
   <para>
    Une fois que le serveur est authentifié, le client peut envoyer des données
    sensibles. Cela signifie que, jusqu'à ce point, le client n'a pas besoin de
-   savoir si les certificats seront utilisés pour l'authentification&nbsp;ne
+   savoir si les certificats seront utilisés pour l'authentification&nbsp; ne
    le spécifier que dans la configuration du serveur est donc sûr.
   </para>
 
@@ -7517,7 +7521,7 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
     <thead>
      <row>
       <entry><literal>sslmode</literal></entry>
-      <entry>Écoute clandestine</entry>
+      <entry>Protection contre l'écoute clandestine</entry>
       <entry>Protection contre l'attaque <acronym>MITM</acronym></entry>
       <entry>Remarques</entry>
      </row>
@@ -7805,8 +7809,8 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
  <para>
   Une restriction&nbsp;: il ne doit pas y avoir deux threads
   manipulant le même objet <structname>PGconn</structname> à la fois. En particulier, vous
-  ne pouvez pas lancer des commandes concurrentes à partir depuis des threads
-  différents à partir du même objet de connexion (si vous avez besoin de lancer des
+  ne pouvez pas lancer des commandes concurrentes depuis des threads
+  différents à travers le même objet de connexion (si vous avez besoin de lancer des
   commandes concurrentes, utilisez plusieurs connexions).
  </para>
 
@@ -7906,8 +7910,7 @@ ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
      l'emplacement du répertoire. À la place, vous pouvez exécuter l'outil
      <command>pg_config</command><indexterm><primary>pg_config</primary><secondary
       sortas="libpq">avec libpq</secondary></indexterm> pour trouver
-      où sont placés les fichiers
-     d'en-tête sur le système local&nbsp;:
+      où sont placés les fichiers d'en-tête sur le système local&nbsp;:
      <screen><prompt>$</prompt> pg_config --includedir
       <computeroutput>/usr/local/include</computeroutput>
      </screen>
@@ -8110,7 +8113,7 @@ main(int argc, char **argv)
         printf("%-15s", PQfname(res, i));
     printf("\n\n");
 
-    /* puis afficher les lignes */
+    /* puis affiche les lignes */
     for (i = 0; i < PQntuples(res); i++)
     {
         for (j = 0; j < nFields; j++)
@@ -8145,11 +8148,11 @@ main(int argc, char **argv)
  *
  *
  * testlibpq2.c
- *      Teste l'interface de notrification asynchrone
+ *      Teste l'interface de notification asynchrone
  *
  * Démarrez ce programme, puis depuis psql dans une autre fenêtre faites
  *   NOTIFY TBL2;
- * Répétez quatre fois pour que terminer ce programme.
+ * Répétez quatre fois pour terminer ce programme.
  *
  * Ou, si vous voulez vous faire plaisir, faites ceci :
  * remplissez une base avec les commandes suivantes
@@ -8258,7 +8261,7 @@ main(int argc, char **argv)
     while (nnotifies < 4)
     {
         /*
-         * Dort jusqu'à ce que quelque chose arrive sur la connexion. nous
+         * Dort jusqu'à ce que quelque chose arrive sur la connexion. Nous
          * utilisons select(2) pour attendre une entrée, mais vous pouvez
          * utiliser poll() ou des fonctions similaires.
          */
@@ -8361,7 +8364,7 @@ exit_nicely(PGconn *conn)
 /*
  * Cette fonction affiche un résultat qui est la récupération
  * au format binaire d'une table définie dans le commentaire ci-dessus.
- * Nous fractionnons car la fonction main() l'utilise deux fois.
+ * Nous l'avons extraite car la fonction main() l'utilise deux fois.
  */
 static void
 show_binary_results(PGresult *res)
@@ -8390,7 +8393,7 @@ show_binary_results(PGresult *res)
 
         /*
          * Récupère les valeurs des champs
-         * (on ignore la possibilités qu'ils  soient NULL !)
+         * (on ignore la possibilités qu'ils soient NULL !)
          */
         iptr = PQgetvalue(res, i, i_fnum);
         tptr = PQgetvalue(res, i, t_fnum);
@@ -8478,10 +8481,10 @@ main(int argc, char **argv)
      * données binaires.
      *
      * Ce premier exemple transmet les paramètres en tant que texte, mais
-     * reçoit les résultats en format binaire. En utilisant des paramètres
-     * inhabituels nous pouvons éviter beaucoup de nettoyage fastidieux en
+     * reçoit les résultats en format binaire. Avec des paramètres
+     * un peu délicats il n'y a pas besoin de nettoyage fastidieux en
      * terme de guillemets et d'échappement, même si les données sont du
-     * texte. Notez que nous ne faisons tien de spécial avec les guillemets
+     * texte. Notez que nous ne faisons rien de spécial avec les guillemets
      * dans la valeur du paramètre.
      */
 
@@ -8496,7 +8499,7 @@ main(int argc, char **argv)
                        NULL,    /* pas besoin de la longueur des paramètres,
                                    c'est du texte */
                        NULL,    /* par défaut tous les paramètres sont du texte */
-                       1);      /* demnde le résultat en binaire */
+                       1);      /* demande le résultat en binaire */
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
     {

--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -4084,7 +4084,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
     <term><function>PQunescapeBytea</function><indexterm><primary>PQunescapeBytea</primary></indexterm></term>
     <listitem>
      <para>
-      Convertit une représentation de la chaîne en donnés binaires —
+      Convertit une représentation de la chaîne en donnés binaires &mdash;
       l'inverse de <function>PQescapeBytea</function>. Ceci est nécessaire lors de
       la récupération de données <type>bytea</type> en format texte, mais pas lors
       de sa récupération au format binaire.
@@ -5801,9 +5801,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
    <listitem>
     <para>
      Déclenche un événement <literal>PGEVT_RESULTCREATE</literal> (voir <xref
-     linkend="libpq-events"/>) pour chaque procédure d'événement enregistré
+     linkend="libpq-events"/>) pour chaque procédure d'événement enregistrée
      dans l'objet <structname>PGresult</structname>. Renvoit autre chose que
-     zéro en cas de succès, zéro si la procédure d'événement échoue.
+     zéro en cas de succès, zéro si une des procédures d'événement échoue.
 
      <synopsis>
        int PQfireResultCreateEvents(PGconn *conn, PGresult *res);
@@ -5813,7 +5813,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <para>
      L'argument <literal>conn</literal> est passé aux procédures d'événement
      mais n'est pas utilisé directement. Il peut être <literal>NULL</literal>
-     si les procédures de l'événement ne l'utiliseront pas.
+     si les procédures de l'événement ne l'utilisent pas.
     </para>
 
     <para>
@@ -5844,7 +5844,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <para>
      Fait une copie de l'objet <structname>PGresult</structname>. La copie
      n'est liée en aucune façon au résultat source et
-     <function>PQclear</function> doit être appelée dans que la copie n'est
+     <function>PQclear</function> doit être appelée quand la copie n'est
      plus nécessaire. Si la fonction échoue, <symbol>NULL</symbol> est renvoyé.
 
      <synopsis>
@@ -5855,9 +5855,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <para>
      Cela n'a pas pour but de faire une copie exacte. Le résultat renvoyé a
      toujours le statut <literal>PGRES_TUPLES_OK</literal>, et ne copie aucun
-     message d'erreur dans la source. (Néanmoins, il copie la chaîne de statut
-     de commande.) L'argument <parameter>flags</parameter> détermine le reste
-     à copier. C'est un OR bit à bit de plusieurs drapeaux.
+     message d'erreur de la source. (Néanmoins, elle copie la chaîne de statut
+     de commande.) L'argument <parameter>flags</parameter> détermine ce qui
+     copié. C'est un OR bit à bit de plusieurs drapeaux.
      <literal>PG_COPYRES_ATTRS</literal> indique la copie des attributs du
      résultat source (définition des colonnes).
      <literal>PG_COPYRES_TUPLES</literal> indique la copie des lignes du
@@ -5928,7 +5928,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
      si <parameter>value</parameter> est <literal>NULL</literal>, la valeur
      du champ sera configurée à la valeur SQL <literal>NULL</literal>.
      <parameter>value</parameter> est copié dans le stockage privé du résultat,
-     donc n'est plus nécessaire au retour de la fonction. Si la fonction échoue,
+     donc n'est plus nécessaire après le retour de la fonction. Si la fonction échoue,
      la valeur de retour est zéro. Dans le cas contraire, elle a une valeur
      différente de zéro.
     </para>
@@ -5953,8 +5953,8 @@ char *PQencryptPassword(const char *passwd, const char *user);
     </para>
 
     <para>
-     Toute mémoire allouée avec cette fonction est libérée quand
-     <parameter>res</parameter> est effacée. Si la fonction échoue, la valeur
+     Toute mémoire allouée avec cette fonction sera libérée quand
+     <parameter>res</parameter> sera effacé. Si la fonction échoue, la valeur
      de retour vaut <literal>NULL</literal>. Le résultat est garanti d'être
      correctement aligné pour tout type de données, comme pour un
      <function>malloc</function>.
@@ -6006,7 +6006,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
 
     <para>
      De ce fait, pour déterminer la compatibilité de certaines
-     fonctionnalités, les applications devrait diviser le résultat de
+     fonctionnalités, les applications devraient diviser le résultat de
      <function>PQlibVersion</function> par 100, et non pas par 10000, pour
      déterminer le numéro de version majeure logique. Dans toutes les
      versions, seuls les deux derniers chiffres diffèrent entre des versions
@@ -6015,8 +6015,8 @@ char *PQencryptPassword(const char *passwd, const char *user);
 
     <note>
      <para>
-      Cette fonction apparaît en version 9.1 de
-      <productname>PostgreSQL</productname>, donc elle ne peut pas être
+      Cette fonction apparaît dans <productname>PostgreSQL</productname>9.1,
+      donc elle ne peut pas être
       utilisée pour détecter des fonctionnalités des versions
       précédentes car l'appeler créera une dépendance sur la
       version 9.1 et les versions ultérieures.
@@ -6082,7 +6082,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
 
   Chacune de ces fonctions reçoit le pointeur de fonction du précédent receveur
   ou émetteur de messages et configure la nouvelle valeur. Si vous fournissez un
-  pointeur de fonction nul, aucune action n'est réalisée mais le pointeur actuel
+  pointeur de fonction NULL, aucune action n'est réalisée mais le pointeur actuel
   est renvoyé.
  </para>
 
@@ -6105,15 +6105,15 @@ char *PQencryptPassword(const char *passwd, const char *user);
  </para>
 
  <para>
-  Ce dernier est responsable de la gestion du message de note ou d'avertissement
-  donné au format texte. La chaîne texte du message est passée avec un retour
-  chariot supplémentaire, plus un pointeur sur void identique à celui passé à
+  Ce dernier est responsable de la gestion du message de note ou d'avertissement,
+  fourni en format texte. La chaîne texte du message est passée (avec un retour
+  chariot final), plus un pointeur sur void identique à celui passé à
   <function>PQsetNoticeProcessor</function> (ce pointeur est utilisé pour
   accéder à un état spécifique de l'application si nécessaire).
  </para>
 
  <para>
-  Le traitement des messages par défaut est simplement
+  Le traitement des messages par défaut est simplement&nbsp;:
   <programlisting>static void
     defaultNoticeProcessor(void * arg, const char * message)
     {
@@ -6127,7 +6127,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
   messages, vous devez vous attendre à ce que la fonction soit appelée aussi
   longtemps que l'objet <structname>PGconn</structname> ou qu'un objet
   <structname>PGresult</structname> réalisé à partir de celle-ci existent. À la création
-  d'un <structname>PGresult</structname>, les pointeurs de gestion actuels de
+  d'un <structname>PGresult</structname>, les pointeurs de gestion courants de
   <structname>PGconn</structname> sont copiés dans <structname>PGresult</structname> pour une
   utilisation possible par des fonctions comme <function>PQgetvalue</function>.
  </para>
@@ -6152,12 +6152,12 @@ char *PQencryptPassword(const char *passwd, const char *user);
   Chaque gestionnaire d'événement enregistré est associé avec deux types de
   données, connus par <application>libpq</application> comme des pointeurs
   opaques, c'est-à-dire <literal>void *</literal>. Il existe un pointeur
-  <firstterm>passthrough</firstterm> fournie par l'application quand le
+  <firstterm>passthrough</firstterm> fourni par l'application quand le
   gestionnaire d'événements est enregistré avec un <structname>PGconn</structname>.
   Le pointeur passthrough ne change jamais pendant toute la durée du
   <structname>PGconn</structname> et des <structname>PGresult</structname>
   générés grâce à lui&nbsp;; donc s'il est utilisé, il doit pointer vers
-  des données vivantes. De plus, il existe une pointeur de <firstterm>données
+  des données à longue vie. De plus, il existe une pointeur de <firstterm>données
    instanciées</firstterm>, qui commence à NULL dans chaque objet
   <structname>PGconn</structname> et <structname>PGresult</structname>. Ce
   pointeur peut être manipulé en utilisant les fonctions
@@ -6176,8 +6176,8 @@ char *PQencryptPassword(const char *passwd, const char *user);
   <title>Types d'événements</title>
 
   <para>
-   La variable <literal>PGEventId</literal> de type enum précise tous les types
-   d'événements gérés par le système d'événements. Toutes ces valeurs ont des
+   L'enum <literal>PGEventId</literal> précise tous les types
+   d'événements gérés par le système d'événements. Toutes ses valeurs ont des
    noms commençant avec <literal>PGEVT</literal>. Pour chaque type d'événement,
    il existe une structure d'informations sur l'événement, précisant les
    paramètres passés aux gestionnaires d'événement. Les types d'événements
@@ -6190,7 +6190,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <listitem>
      <para>
       L'événement d'enregistrement survient quand <function>PQregisterEventProc</function>
-      est appelé.; C'est le moment idéal pour initialiser toute structure
+      est appelé. C'est le moment idéal pour initialiser toute structure
       <literal>instanceData</literal> qu'une procédure d'événement pourrait avoir
       besoin. Seul un événement d'enregistrement sera déclenché par gestionnaire
       d'évévenement sur une connexion. Si la procédure échoue, l'enregistrement
@@ -6221,7 +6221,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <listitem>
      <para>
       L'événement de réinitialisation de connexion est déclenché après un
-      <function>PQreset</function> ou un <function>PQresetPoll</function>.  Dans
+      <function>PQreset</function> ou un <function>PQresetPoll</function>. Dans
       les deux cas, l'événement est seulement déclenché si la ré-initialisation
       est réussie. Si la procédure échoue, la réinitialisation de connexion
       échouera&nbsp;; la structure <structname>PGconn</structname> est placée
@@ -6253,11 +6253,11 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <term><literal>PGEVT_CONNDESTROY</literal></term>
     <listitem>
      <para>
-      L'événement de destruction de la connexion est déclenchée en réponse
+      L'événement de destruction de la connexion est déclenché en réponse
       à <function>PQfinish</function>. Il est de la responsabilité de la
       procédure de l'événement de nettoyer proprement ses données car
       libpq n'a pas les moyens de gérer cette mémoire. Un échec du
-      nettoyage amènera des pertes mémoire.
+      nettoyage amènera des fuites de mémoire.
 
       <synopsis>
         typedef struct
@@ -6302,8 +6302,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
       résultat. C'est le moment idéal pour initialiser tout
       <literal>instanceData</literal> qui doit être associé avec le résultat.
       Si la procédure échoue, le résultat sera effacé et l'échec sera propagé.
-      Le procédure d'événement ne doit pas tenter un <function>PQclear</function>
-      sur l'objet résultat lui-même. Lors du renvoi d'un code d'échec, tout le
+      La procédure d'événement ne doit pas tenter elle-même un
+      <function>PQclear</function> sur l'objet résultat.
+      Lors du renvoi d'un code d'échec, tout le
       nettoyage doit être fait car aucun événement
       <literal>PGEVT_RESULTDESTROY</literal> ne sera envoyé.
      </para>
@@ -6317,7 +6318,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
       L'événement de copie du résultat est déclenché en réponse à un
       <function>PQcopyResult</function>. Cet événement se déclenchera
       seulement une fois la copie terminée. Seules les procédures qui ont
-      gérées avec succès l'événement <literal>PGEVT_RESULTCREATE</literal>
+      gérée avec succès l'événement <literal>PGEVT_RESULTCREATE</literal>
       ou <literal>PGEVT_RESULTCOPY</literal> pour le résultat source recevront
       les événements <literal>PGEVT_RESULTCOPY</literal>.
 
@@ -6332,7 +6333,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
       Quand un événement <literal>PGEVT_RESULTCOPY</literal> est reçu, le
       pointeur <parameter>evtInfo</parameter> doit être converti en un
       <structname>PGEventResultCopy *</structname>. Le résultat
-      résultat <parameter>src</parameter> correspond à ce qui a été copié
+      <parameter>src</parameter> correspond à ce qui a été copié
       alors que le résultat <parameter>dest</parameter> correspond à la
       destination. Cet événement peut être utilisé pour fournir une copie
       complète de <literal>instanceData</literal>, ce que
@@ -6351,9 +6352,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
     <listitem>
      <para>
       L'événement de destruction de résultat est déclenché en réponse à la
-      fonction <function>PQclear</function>. C'est de la responsabilité de
+      fonction <function>PQclear</function>. Il est de la responsabilité de
       l'événement de nettoyer proprement les données de l'événement car libpq
-      n'a pas cette capacité en matière de gestion de mémoire. Si le nettoyage
+      n'a pas la capacité de gérer cette mémoire. Si le nettoyage
       échoue, cela sera la cause de pertes mémoire.
 
       <synopsis>
@@ -6421,12 +6422,12 @@ char *PQencryptPassword(const char *passwd, const char *user);
       <para>
        Sur Windows, les fonctions peuvent avoir deux adresses différentes&nbsp;:
        une visible de l'extérieur de la DLL et une visible de l'intérieur. Il
-       faut faire attention que seule une de ces adresses est utilisée avec les
+       faut faire attention que seule une de ces adresses soit utilisée avec les
        fonctions d'événement de la <application>libpq</application>, sinon une
-       confusion en résultera. La règle la plus simple pour écrire du code qui
-       fonctionnera est de s'assurer que les procédures d'événements sont
+       confusion en résultera. La règle la plus simple pour écrire du code
+       fonctionnel est de s'assurer que les procédures d'événements sont
        déclarées <literal>static</literal>. Si l'adresse de la procédure doit
-       être disponible en dehors de son propre fichier source,  il faut exposer
+       être disponible en dehors de son propre fichier source, il faut exposer
        une fonction séparée pour renvoyer l'adresse.
       </para>
      </caution>
@@ -6458,9 +6459,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
      </para>
 
      <para>
-      Une procédure d'évenement doit être enregistré une fois pour chaque
+      Une procédure d'évenement doit être enregistrée une fois pour chaque
       <structname>PGconn</structname> pour lequel vous souhaitez recevoir des
-      événements. Il n'existe pas de limites, autre que la mémoire, sur le
+      événements. Il n'existe pas de limite, autre que la mémoire, sur le
       nombre de procédures d'événements qui peuvent être enregistrées avec
       une connexion. La fonction renvoie une valeur différente de zéro en cas
       de succès, et zéro en cas d'échec.
@@ -6472,9 +6473,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
       <literal>instanceData</literal>. L'argument <parameter>name</parameter>
       est utilisé pour faire référence à la procédure d'évenement dans les
       messages d'erreur. Cette valeur ne peut pas être <symbol>NULL</symbol> ou une chaîne de
-      longueur nulle. La chaîne du nom est copiée dans
-      <structname>PGconn</structname>, donc ce qui est passé n'a pas besoin de
-      durer longtemps. Le pointeur <parameter>passThrough</parameter> est
+      longueur nulle. La chaîne <parameter>name</parameter> est copiée dans
+      <structname>PGconn</structname>, donc ce qui est passé n'a pas besoin
+      d'exister longtemps. Le pointeur <parameter>passThrough</parameter> est
       passé à <parameter>proc</parameter> à chaque arrivée d'un événement. Cet
       argument peut être <symbol>NULL</symbol>.
      </para>
@@ -6490,11 +6491,12 @@ char *PQencryptPassword(const char *passwd, const char *user);
     </term>
     <listitem>
      <para>
-      Initialise <literal>instanceData</literal> de la connexion pour la
-      procédure <parameter>proc</parameter> avec <parameter>data</parameter>.
+      Initialise avec <parameter>data</parameter>
+      l'<literal>instanceData</literal> de la connexion
+      <parameter>conn</parameter> pour la
+      procédure <parameter>proc</parameter>.
       Cette fonction renvoit zéro en cas d'échec et autre chose en cas de réussite.
-      (L'échec est seulement possible si <parameter>proc</parameter> n'a pas été correctement
-      enregistré dans le résultat.)
+      (L'échec est seulement possible si <parameter>proc</parameter> n'a pas été correctement enregistré dans <parameter>conn</parameter>)
 
       <synopsis>
         int PQsetInstanceData(PGconn *conn, PGEventProc proc, void *data);
@@ -6512,8 +6514,9 @@ char *PQencryptPassword(const char *passwd, const char *user);
     </term>
     <listitem>
      <para>
-      Renvoie le <literal>instanceData</literal> de la connexion associée
-      avec <parameter>connproc</parameter> ou <symbol>NULL</symbol> s'il
+      Renvoie l'<literal>instanceData</literal> de la connexion
+      <parameter>conn</parameter> associée
+      au <parameter>proc</parameter> ou <symbol>NULL</symbol> s'il
       n'y en a pas.
 
       <synopsis>
@@ -6532,11 +6535,12 @@ char *PQencryptPassword(const char *passwd, const char *user);
     </term>
     <listitem>
      <para>
-      Initialise le <literal>instanceData</literal> du résultat pour la
-      procédure <parameter>proc</parameter> avec <parameter>data</parameter>.
+      Initialise avec <parameter>data</parameter>
+      l'<literal>instanceData</literal> du résultat pour la
+      procédure <parameter>proc</parameter>.
       Cette fonction renvoit zéro en cas d'échec et autre chose en cas de réussite.
-      (L'échec est seulement possible si proc n'a pas été correctement
-      enregistré dans le résultat.)
+      (L'échec est seulement possible si <parameter>proc</parameter> n'a pas
+      été correctement enregistré dans le résultat.)
 
       <synopsis>
         int PQresultSetInstanceData(PGresult *res, PGEventProc proc, void *data);
@@ -6554,7 +6558,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
     </term>
     <listitem>
      <para>
-      Renvoie le <literal>instanceData</literal> du résultat associé avec
+      Renvoie l'<literal>instanceData</literal> du résultat associé à
       <parameter>proc</parameter> ou <symbol>NULL</symbol> s'il n'y
       en a pas.
 
@@ -6736,7 +6740,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
   sélectionner des valeurs par défaut pour les paramètres de connexion, valeurs
   qui seront utilisées par <function>PQconnectdb</function>, <function>PQsetdbLogin</function> et
   <function>PQsetdb</function> si aucune valeur n'est directement précisée par
-  le code d'appel. Elles sont utiles pour éviter de coder en dur les
+  le code appelant. Elles sont utiles pour éviter de coder en dur les
   informations de connexion à la base de données dans les applications
   clients, par exemple.
 
@@ -6757,8 +6761,8 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
      </indexterm>
      <envar>PGHOSTADDR</envar> se comporte de la même façon que le paramètre de
      configuration <xref linkend="libpq-connect-hostaddr"/>.
-     Elle peut être initialisée avec <envar>PGHOST</envar> pour éviter
-     la surcharge des recherches DNS.
+     Elle peut être initialisée à la place ou en plus de <envar>PGHOST</envar>
+     pour éviter la charge supplémentaire d'une résolution DNS.
     </para>
    </listitem>
    <listitem>
@@ -6795,11 +6799,11 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
      </indexterm>
      <envar>PGPASSWORD</envar> se comporte de la même façon que le paramètre de
      configuration <xref linkend="libpq-connect-password"/>. L'utilisation de cette variable
-     d'environnement n'est pas recommandée pour des raisons de sécurité (certains
+     d'environnement n'est pas recommandée pour des raisons de sécurité, car certains
      systèmes d'exploitation autorisent les utilisateurs autres que root à voir les
      variables d'environnement du processus via <application>ps</application>)&nbsp;; à la
-     place, considérez l'utilisation d'un fichier de mots de passe  (voir la <xref
-     linkend="libpq-pgpass"/>).
+     place, envisagez l'utilisation d'un fichier de mots de passe (voir la <xref
+     linkend="libpq-pgpass"/>.
     </para>
    </listitem>
    <listitem>
@@ -6869,22 +6873,9 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
      </indexterm>
      <envar>PGREQUIRESSL</envar> se comporte de la même façon que le paramètre
       de configuration <xref linkend="libpq-connect-requiressl"/>.
-      Cette variable d'environnement est abandonnée au profit de la variable
-      <envar>PGSSLMODE</envar>, mais la configuration des deux variables
-      supprime l'effet de <envar>PGSSLMODE</envar>.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <indexterm>
-      <primary><envar>PGSSLKEY</envar></primary>
-     </indexterm>
-     <envar>PGSSLKEY</envar> spécifie le jeton matériel qui stocke la clé
-     secrète pour le certificat client. La valeur de cette variable doit
-     consister d'un nom de moteur séparé par une virgule (les moteurs sont
-     les modules chargeables d'<productname>OpenSSL</productname>) et un
-     identifiant de clé spécifique au moteur. Si elle n'est pas
-     configurée, la clé secrète doit être conservée dans un fichier.
+      Cette variable d'environnement est obsolète, remplaceé par la variable
+      <envar>PGSSLMODE</envar>&nbsp; si les deux variables sont initialisées,
+      <envar>PGREQUIRESSL</envar> est ignoré.
     </para>
    </listitem>
 
@@ -7002,13 +6993,12 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
  </para>
 
  <para>
-  Les variables d'environnement par défaut peuvent être utilisées pour
+  Les variables d'environnement peuvent être utilisées pour
   spécifier le comportement par défaut de chaque session
   <productname>PostgreSQL</productname> (voir aussi les commandes
   <xref linkend="sql-alterrole"/> et
   <xref linkend="sql-alterdatabase"/>
-  pour des moyens d'initialiser le
-  comportement par défaut sur des bases par utilisateur ou par bases de données).
+  pour modifier le comportement par défaut par utilisateur ou par base de données).
 
   <itemizedlist>
    <listitem>
@@ -7036,7 +7026,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
       <primary><envar>PGGEQO</envar></primary>
      </indexterm>
      <envar>PGGEQO</envar>
-     initialise le mode par défaut pour l'optimiseur générique de requêtes
+     initialise le mode par défaut pour l'optimiseur génétique de requêtes
      (équivalent à <literal>SET geqo TO ...</literal>).
     </para>
    </listitem>
@@ -7051,7 +7041,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
  <para>
   Les variables d'environnement suivantes déterminent le comportement interne
   de <application>libpq</application>&nbsp;; elles surchargent les valeurs
-  internes par défaut.
+  par défaut issues de la compilation.
 
   <itemizedlist>
    <listitem>
@@ -7061,7 +7051,7 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
      </indexterm>
      <envar>PGSYSCONFDIR</envar>
      configure le répertoire contenant le fichier
-     <filename>pg_service.conf</filename> et dans une future version
+     <filename>pg_service.conf</filename> et, peut-être dans une future version,
      d'autres fichiers de configuration globaux au système.
     </para>
    </listitem>
@@ -7118,15 +7108,15 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
    <literal>host</literal> s'il est spécifié, sinon au paramètre
    <literal>hostaddr</literal> si spécifié. Si ni l'un ni l'autre ne sont
    fournis, l'hôte <literal>localhost</literal> sera alors recherché.
-   L'hôte <literal>localhost</literal> est également cherché si la connexion
+   L'hôte <literal>localhost</literal> est également recherché si la connexion
    est une socket de domaine Unix et que le paramètre <literal>host</literal>
    correspond au répertoire par défaut de la <application>libpq</application>.
 
    Sur un serveur secondaire, un champ <literal>database</literal> à
    <literal>replication</literal> correspond aux connexions de réplication
-   par flux au serveur maître. Le champ <literal>database</literal> est d'une
-   utilité limitée sinon, puisque les utilisateurs ont le même mot de passe
-   pour toutes les bases de données de l'instance.
+   par flux au serveur maître. À part cela, le champ <literal>database</literal>
+   est d'une utilité limitée sinon, puisque les utilisateurs ont le même mot de
+   passe pour toutes les bases de données de l'instance.
   </para>
 
   <para>
@@ -7140,10 +7130,10 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
  </sect1>
 
  <sect1 id="libpq-pgservice">
-  <title>Fichier des connexions de service</title>
+  <title>Fichier des services de connexion</title>
 
   <indexterm zone="libpq-pgservice">
-   <primary>fichier des connexions de service</primary>
+   <primary>fichier des services de connexion</primary>
   </indexterm>
   <indexterm zone="libpq-pgservice">
    <primary>pg_service.conf</primary>
@@ -7153,28 +7143,28 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
   </indexterm>
 
   <para>
-   Le fichier des connexions de service autorise l'association des paramètres de
-   connexions avec un seul nom de service. Ce nom de service peut ensuite être
+   Le fichier des services de connexion permet d'associer des paramètres de
+   connexion à un nom de service unique. Ce nom de service peut ensuite être
    spécifié par une connexion libpq et les paramétrages associés seront utilisés.
-   Ceci permet de modifier les paramètres de connexion sans avoir à recompiler
+   On peut donc modifier les paramètres de connexion sans avoir à recompiler
    l'application libpq. Le nom de service peut aussi être spécifié en utilisant
    la variable d'environnement <envar>PGSERVICE</envar>.
   </para>
 
   <para>
-   Le fichier de service pour la connexion peut être un fichier par utilisateur
+   Le fichier de service peut être un fichier par utilisateur
    sur <filename>~/.pg_service.conf</filename> ou à l'emplacement indiqué par
    la variable d'environnement <envar>PGSERVICEFILE</envar>. Il peut aussi être
    un fichier global au système dans le répertoire
    <filename>`pg_config --sysconfdir`/pg_service.conf</filename> ou dans le répertoire indiqué par
-   la variable d'environnement <envar>PGSYSCONFDIR</envar>. Si les définitions
-   de service de même nom existent dans le fichier utilisateur et système,
-   le fichier utilisateur est utilisé.
+   la variable d'environnement <envar>PGSYSCONFDIR</envar>. Si des définitions
+   de service de même nom existent dans les fichier utilisateur et système,
+   le fichier utilisateur est prioritaire.
   </para>
 
   <para>
-   Le fichier utiliser le format des <quote>fichiers INI</quote> où le nom de
-   la section et les paramètres sont des paramètres de connexion&nbsp;; voir
+   Le fichier utilise le format des <quote>fichiers INI</quote> où le nom de
+   section et les paramètres sont des paramètres de connexion&nbsp;; voir
    <xref linkend="libpq-paramkeywords"/> pour une liste. Par exemple&nbsp;:
    <programlisting>
     # comment
@@ -7183,13 +7173,13 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
     port=5433
     user=admin
   </programlisting>
-  Un fichier exemple est fourni sur
-  <filename>share/pg_service.conf.sample</filename>.
+  <filename>share/pg_service.conf.sample</filename> est fourni comment
+  fichier d'exemple.
  </para>
 </sect1>
 
 <sect1 id="libpq-ldap">
- <title>Recherches LDAP des paramètres de connexion</title>
+ <title>Recherche LDAP des paramètres de connexion</title>
 
  <indexterm zone="libpq-ldap">
   <primary>Recherche LDAP des paramètres de connexion</primary>
@@ -7222,18 +7212,18 @@ myEventProc(PGEventId evtId, void *evtInfo, void *passThrough)
 
  <para>
   Le traitement de <filename>pg_service.conf</filename> se termine après une
-  recherche réussie dans LDAP, mais continu si le serveur LDAP ne peut pas
+  recherche LDPA réussie, mais continue si le serveur LDAP ne peut pas
   être contacté. Cela fournit un moyen de préciser d'autres URL LDAP pointant
   vers d'autres serveurs LDAP, des paires classiques <literal>motclé =
-   valeur</literal> ou les options de connexion par défaut. Si vous obtenez à la
-  place un message d'erreur, ajoutez une ligne syntaxiquement incorrecte après
-  l'URL LDAP.
+   valeur</literal> ou les options de connexion par défaut. Si dans ce case
+   vous préférez avoir un message d'erreur, ajoutez une ligne syntaxiquement
+   incorrecte après l'URL LDAP.
  </para>
 
  <para>
-  Un exemple d'une entrée LDAP qui a été créée à partir d'un fichier LDIF
+  À titre d'exemple, une entrée LDAP créée à partir du fichier LDIF suivant
   <programlisting>
-version: 1
+version:1
 dn:cn=mydatabase,dc=mycompany,dc=com
 changetype:add
 objectclass:top
@@ -7245,15 +7235,15 @@ description:dbname=mydb
 description:user=mydb_user
 description:sslmode=require
   </programlisting>
-  amènera l'exécution de l'URL LDAP suivante&nbsp;:
+  peut être retrouvée avec l'URL LDAP suivante&nbsp;:
   <programlisting>
-    ldap://ldap.masociété.com/dc=masociété,dc=com?description?one?(cn=mabase)
+ldap://ldap.mycompany.com/dc=mycompany,dc=com?description?one?(cn=mydatabase)
   </programlisting>
  </para>
 
  <para>
-  Vous pouvez mélanger des entrées d'un fichier de service standard avec
-  des recherches par LDAP. Voici un exemple complet dans
+  Dans le fichier de service, vous pouvez mélanger des entrées standard avec
+  des recherches LDAP. Voici un exemple complet d'un bloc dans
   <filename>pg_service.conf</filename>&nbsp;:
   <programlisting>
     # seuls l'hôte et le port sont stockés dans LDAP,
@@ -7276,7 +7266,7 @@ description:sslmode=require
 
  <para>
   <productname>PostgreSQL</productname> dispose d'un support natif des connexions
-  <acronym>SSL</acronym> pour crypter les connexions client/serveur et améliorer
+  <acronym>SSL</acronym> pour chiffrer les connexions client/serveur et améliorer
   ainsi la sécurité. Voir la <xref linkend="ssl-tcp"/> pour des détails sur la
   fonctionnalité <acronym>SSL</acronym> côté serveur.
  </para>
@@ -7286,7 +7276,7 @@ description:sslmode=require
   d'<productname>OpenSSL</productname>. Par défaut, ce fichier est nommé
   <filename>openssl.cnf</filename> et est placé dans le répertoire indiqué par
   <literal>openssl version -d</literal>. Cette valeur par défaut peut être
-  surchargé en configurant la variable d'environnement
+  surchargée en configurant la variable d'environnement
   <envar>OPENSSL_CONF</envar> avec le nom du fichier de configuration
   souhaité.
  </para>
@@ -7298,13 +7288,14 @@ description:sslmode=require
    Par défaut, <productname>PostgreSQL</productname> ne vérifie pas le certificat
    du serveur. Cela signifie qu'il est possible de se faire passer pour le
    serveur final (par exemple en modifiant un enregistrement DNS ou en prenant
-   l'adresse IP du serveur) sans que le client ne le sache. Pour empêcher ceci,
+   l'adresse IP du serveur) sans que le client ne le sache.
+   Pour empêcher cette usurpation (<foreignphrase>spoofing</foreignphrase>),
    le client doit être capable de vérifier l'identité du serveur via une
-   chaîne de confiance. Une chaîne de confiance est établie en plaçant le
-   certificat racine auto-signé d'une autorité de certificats
-   (<acronym>CA</acronym>) sur un ordinateur et un certificat feuille
-   <emphasis>signé</emphasis> par le certificat racine sur un autre
-   ordinateur. Il est aussi possible d'utiliser un certificat
+   chaîne de confiance. Une chaîne de confiance est établie en plaçant
+   sur un ordinateur le certificat racine (auto-signé) d'une autorité de
+   certification (<acronym>CA</acronym>), et sur un autre
+   ordinateur un certificat feuille <emphasis>signé</emphasis> avec
+   le certificat racine. Il est aussi possible d'utiliser un certificat
    <quote>intermédiaire</quote> signé par le certificat racine et qui signe
    des certificats feuilles.
   </para>
@@ -7323,11 +7314,13 @@ description:sslmode=require
   <para>
    Une fois qu'une chaîne de confiance a été établie, il existe deux façons
    pour le client de valider le certificat feuille envoyé par le serveur. Si
-   le paramètre <literal>sslmode</literal> est configuré à <literal>verify-
-   ca</literal>, libpq vérifiera que le serveur est de confiance en vérifiant
-   la chaîne de certificats jusqu'au certificat racine stocké sur le client.
-   Si <literal>sslmode</literal> est configuré à <literal>verify-
-   full</literal>, libpq va <emphasis>aussi</emphasis> vérifier que le nom
+   le paramètre <literal>sslmode</literal> est configuré à
+   <literal>verify- ca</literal>, libpq vérifiera qu'il peut faire confiance
+   au serveur en vérifiant
+   la chaîne des certificats jusqu'au certificat racine stocké sur le client.
+   Si <literal>sslmode</literal> est configuré à
+   <literal>verify-full</literal>, libpq va <emphasis>aussi</emphasis>
+   vérifier que le nom
    d'hôte du serveur correspond au nom stocké dans le certificat du serveur.
    La connexion SSL échouera si le certificat du serveur n'établit pas ces
    correspondances. La connexion SSL échouera si le certificat du serveur ne
@@ -7337,16 +7330,18 @@ description:sslmode=require
 
   <para>
    En mode <literal>verify-full</literal>, le nom de l'hôte est mis
-   en correspondance avec le ou les attributs "Subject Alternative
-   Name" du certificat, ou avec l'attribut "Common Name" si aucun
-   "Subject Alternative Name" de type <literal>dNSName</literal> est présent. Si le nom du
+   en correspondance avec le ou les attributs <literal>Subject Alternative
+   Name</literal> du certificat, ou avec l'attribut
+   <literal>Common Name</literal> si aucun
+   <literal>Subject Alternative Name</literal> de type
+   <literal>dNSName</literal> n'est présent. Si le nom du
    certificat débute avec le caractère étoile (<literal>*</literal>),
-   le caractère étoile sera traité comme un métacaractère qui
+   l'étoile sera traitée comme un métacaractère qui
    correspondra à tous les caractères <emphasis>à l'exception
-   du</emphasis> point. Cela signifie que le certificat ne pourra pas
-   être utilisé pour des sous-domaines complets.  Si la connexion se
+   </emphasis> du point. Cela signifie que le certificat ne pourra pas
+   correspondre à des sous-domaines. Si la connexion se
    fait en utilisant une adresse IP au lieu d'un nom d'hôte, l'adresse
-   IP sera vérifiée (sans faire de recherche DNS).
+   IP sera vérifiée (sans faire de résolution DNS).
   </para>
 
   <para>
@@ -7356,7 +7351,7 @@ description:sslmode=require
    l'utilisateur (sur Windows, le fichier est nommé
    <filename>%APPDATA%\postgresql\root.crt</filename>). Les certificats
    intermédiaires doivent aussi être ajoutés au fichier s'ils sont nécessaires
-   pour lier la chaîne de certificat envoyée par le serveur aux certificats
+   pour lier la chaîne de certificats envoyée par le serveur aux certificats
    racines stockés sur le client.
   </para>
 
@@ -7377,7 +7372,7 @@ description:sslmode=require
 
   <note>
    <para>
-    Pour une compatibilité ascendantes avec les anciennes versions de
+    Pour la compatibilité ascendante avec les anciennes versions de
     PostgreSQL, si un certificat racine d'autorité existe, le comportement
     de <literal>sslmode</literal>=<literal>require</literal> sera identique
     à celui de <literal>verify-ca</literal>. Cela signifie que le
@@ -7395,19 +7390,19 @@ description:sslmode=require
 
   <para>
    Si le serveur tente de vérifier l'identité du client en réclamant le
-   certificat feuille du client, <application>libpq</application> enverra le
-   certificat stocké dans le fichier
+   certificat feuille du client, <application>libpq</application> enverra lse
+   certificats stockés dans le fichier
    <filename>~/.postgresql/postgresql.crt</filename> du répertoire personnel
-   de l'utilisateur. Les certificats doivent chaîner vers le certificat racine
-   de confiance du serveur. Un fichier de
+   de l'utilisateur. Les certificats doivent former une chaîne jusqu'au
+   certificat racine de confiance du serveur. Un fichier de
    clé privé correspondant <filename>~/.postgresql/postgresql.key</filename>
-   doit aussi être présent. Le fichier de clé privée ne doit pas permettre son
-   accès pour le groupe ou pour le reste du monde&nbsp;; cela se fait avec la
+   doit aussi être présent. Aucun accès au fichier de clé privée ne doit
+   être autorisé pour le groupe ou pour le reste du monde&nbsp;; cela se fait avec la
    commande <command>chmod 0600 ~/.postgresql/postgresql.key</command>. Sur
    Microsoft Windows, ces fichiers sont nommés
    <filename>%APPDATA%\postgresql\postgresql.crt</filename> et
-   <filename>%APPDATA%\postgresql\postgresql.key</filename>, et il n'existe pas
-   de vérification de droits car ce répertoire est présumé sécurisé.
+   <filename>%APPDATA%\postgresql\postgresql.key</filename>, et il n'y a pas
+   de vérification des droits car ce répertoire est présumé sécurisé.
    L'emplacement des fichiers certificat et clé peut être surchargé par les
    paramètres de connexion <literal>sslcert</literal> et
    <literal>sslkey</literal>, ou les variables d'environnement
@@ -7418,7 +7413,7 @@ description:sslmode=require
    Le premier certificat dans <filename>postgresql.crt</filename> doit être le
    certificat du client parce qu'il doit correspondre à la clé privée du
    client. Les certificats <quote>intermédiaires</quote> peuvent être ajoutés
-   au fichier en option &mdash; le faire permet d'éviter d'avoir à stocker les
+   au fichier en option &mdash; faire ainsi permet d'éviter d'avoir à stocker les
    certificats intermédiaires sur le serveur (<xref linkend="guc-ssl-ca-file"/>).
   </para>
 
@@ -7437,42 +7432,45 @@ description:sslmode=require
    différents niveaux de protection. SSL peut fournir une protection contre trois types d'attaques différentes&nbsp;:
    <variablelist>
     <varlistentry>
-     <term>L'écoute</term>
+     <term>Écoute clandestine (<foreignphrase>eavesdropping</foreignphrase>)</term>
      <listitem>
-      <para>Si une troisième partie peut examiner le trafic réseau entre le
-       client et le serveur, il peut lire à la fois les informations de
-       connexion (ceci incluant le nom de l'utilisateur et son mot de passe)
-       ainsi que les données qui y passent. <acronym>SSL</acronym> utilise
+      <para>Si une tierce partie peut examiner le trafic réseau entre le
+       client et le serveur, elle peut lire à la fois les informations de
+       connexion (dont le nom de l'utilisateur et son mot de passe)
+       ainsi que les données transmises <acronym>SSL</acronym> utilise
        le chiffrement pour empêcher cela.
       </para>
      </listitem>
     </varlistentry>
 
     <varlistentry>
-     <term>Man in the middle (<acronym>MITM</acronym>)</term>
+     <term>Homme du milieu (<acronym>MITM</acronym>,
+     <foreignphrase>Man in the middle</foreignphrase>)</term>
      <listitem>
-      <para>Si une troisième partie peut modifier les données passant entre
+      <para>Si une tierce partie peut modifier les données transitant entre
        le client et le serveur, il peut prétendre être le serveur et, du coup,
        voir et modifier les données <emphasis>y compris si elles sont
-        chiffrées</emphasis>. La troisième partie peut ensuite renvoyer les
-       informations de connexion et les données au serveur d'origine, rendant à
-       ce dernier impossible la détection de cette attaque. Les vecteurs communs
-       pour parvenir à ce type d'attaque sont l'empoisonnement des DNS et la
-       récupération des adresses IP où le client est dirigé vers un autre serveur
-       que celui attendu. Il existe aussi plusieurs autres méthodes d'attaque
+       chiffrées</emphasis>. La tierce partie peut ensuite renvoyer les
+       informations de connexion et les données au serveur d'origine, rendant
+       impossible à ce dernier la détection de l'attaque. Les vecteurs communs
+       pour parvenir à ce type d'attaque sont l'empoisonnement des DNS
+       (<foreignphrase>DNS poisoning</foreignphrase>) et le détournement
+       d'adresses (<foreignphrase>address hijacking</foreignphrase>),
+       où le client est dirigé vers un autre serveur
+       que celui attendu. Il existe encore plusieurs autres méthodes d'attaque
        pour accomplir ceci. <acronym>SSL</acronym> utilise la vérification des
-       certificats pour empêcher ceci, en authentifiant le serveur auprès du
+       certificats pour l'empêcher, en authentifiant le serveur auprès du
        client.
       </para>
      </listitem>
     </varlistentry>
 
     <varlistentry>
-     <term>Impersonnification</term>
+     <term>Usurpation d'identité</term>
      <listitem>
-      <para>Si une troisième partie peut prétendre être un client autorisé, il
+      <para>Si une tierce partie peut prétendre être un client autorisé, il
        peut tout simplement accéder aux données auquel il n'a pas droit.
-       Typiquement, cela peut arrier avec une gestion incorrecte des mots de
+       Typiquement, cela peut arriver avec une gestion incorrecte des mots de
        passe. <acronym>SSL</acronym> utilise les certificats clients pour
        empêcher ceci, en s'assurant que seuls les propriétaires de certificats
        valides peuvent accéder au serveur.
@@ -7485,10 +7483,11 @@ description:sslmode=require
   <para>
    Pour qu'une connexion soit sûre, l'utilisation de SSL doit être configurée
    <emphasis>sur le client et sur le serveur</emphasis> avant que
-   la connexion ne soit effective. Si c'est seulement configuré sur le serveur,
+   la connexion ne soit effective. Si elle n'est configurée que sur le serveur,
    le client pourrait envoyer des informations sensibles (comme les mots de
-   passe) avant qu'il ne sache que le serveur réclame une sécurité importante.
-   Dans libpq, les connexions sécurisées peuvent être garanties en configurant le paramètre
+   passe) avant de savoir que le serveur exige une haute sécurité.
+   Dans libpq, les connexions sécurisées peuvent être garanties en
+   configurant le paramètre
    <literal>sslmode</literal> à <literal>verify-full</literal> ou
    <literal>verify-ca</literal>, et en fournissant au système un certificat
    racine à vérifier. Ceci est analogue à l'utilisation des <acronym>URL</acronym>
@@ -7497,16 +7496,17 @@ description:sslmode=require
 
   <para>
    Une fois que le serveur est authentifié, le client peut envoyer des données
-   sensibles. Cela signifie que jusqu'à ce point, le client n'a pas besoin de
-   savoir si les certificats seront utilisés pour l'authentification, rendant
-   particulièrement sûr de ne spécifier que ceci dans la configuration du
-   serveur.
+   sensibles. Cela signifie que, jusqu'à ce point, le client n'a pas besoin de
+   savoir si les certificats seront utilisés pour l'authentification&nbsp;ne
+   le spécifier que dans la configuration du serveur est donc sûr.
   </para>
 
   <para>
-   Toutes les options <acronym>SSL</acronym> ont une surcharge du type
-   chiffrement et échange de clés. Il y a donc une balance entre performance et
-   sécurité. <xref linkend="libpq-ssl-sslmode-statements"/> illustre les risques que les différentes valeurs
+   Toutes les options <acronym>SSL</acronym> impliquent une charge
+   supplémentaire sous forme de chiffrement et d'échange de clés.
+   Il y a donc un compromis à trouver entre performance et sécurité.
+   <xref linkend="libpq-ssl-sslmode-statements"/> illustre les risques que les
+   différentes valeurs
    de <literal>sslmode</literal> cherchent à protéger, et ce que cela apporte
    en sécurité et fait perdre en performances.
   </para>
@@ -7517,7 +7517,7 @@ description:sslmode=require
     <thead>
      <row>
       <entry><literal>sslmode</literal></entry>
-      <entry>Protection contre l'écoute</entry>
+      <entry>Écoute clandestine</entry>
       <entry>Protection contre l'attaque <acronym>MITM</acronym></entry>
       <entry>Remarques</entry>
      </row>
@@ -7528,7 +7528,7 @@ description:sslmode=require
       <entry><literal>disable</literal></entry>
       <entry>Non</entry>
       <entry>Non</entry>
-      <entry>Peu m'importe la sécurité, je ne veux pas la surcharge apportée
+      <entry>Peu m'importe la sécurité, et je ne veux pas le coût apporté
        par le chiffrement.
       </entry>
      </row>
@@ -7537,8 +7537,8 @@ description:sslmode=require
       <entry><literal>allow</literal></entry>
       <entry>Peut-être</entry>
       <entry>Non</entry>
-      <entry>Peu m'importe la sécurité, mais je vais accepter la surcharge du
-       chiffrement si le serveur insiste là-dessus.
+      <entry>Peu m'importe la sécurité, mais je vais accepter le coût du
+       chiffrement si le serveur insiste.
       </entry>
      </row>
 
@@ -7546,7 +7546,7 @@ description:sslmode=require
       <entry><literal>prefer</literal></entry>
       <entry>Peut-être</entry>
       <entry>Non</entry>
-      <entry>Peu m'importe la sécurité, mais j'accepte la surcharge du
+      <entry>Peu m'importe le chiffrement, mais j'accepte le coût du
        chiffrement si le serveur le supporte.
       </entry>
      </row>
@@ -7555,17 +7555,18 @@ description:sslmode=require
       <entry><literal>require</literal></entry>
       <entry>Oui</entry>
       <entry>Non</entry>
-      <entry>Je veux chiffrer mes données, et j'accepte la surcharge. Je fais
-       confiance au résreau pour me connecter toujours au serveur que je veux.
+      <entry>Je veux chiffrer mes données, et j'en accepte le coût. Je fais
+       confiance au réseau pour me garantir que je me connecterai toujours au
+       serveur que je veux.
       </entry>
      </row>
 
      <row>
       <entry><literal>verify-ca</literal></entry>
       <entry>Oui</entry>
-      <entry><literal>Depends on CA</literal>-policy</entry>
-      <entry>Je veux chiffrer mes données, et j'accepte la surcharge. Je veux
-       aussi être sûr que je me connecte à un serveur en qui j'ai confiance.
+      <entry>Dépend de la politique de la <literal>CA</literal></entry>
+      <entry>Je veux chiffrer mes données, et j'en accepte le coût. Je veux
+       être sûr que je me connecte à un serveur en qui j'ai confiance.
       </entry>
      </row>
 
@@ -7573,9 +7574,9 @@ description:sslmode=require
       <entry><literal>verify-full</literal></entry>
       <entry>Oui</entry>
       <entry>Oui</entry>
-      <entry>Je veux chiffrer mes données, et j'accepte la surcharge. Je veux
+      <entry>Je veux chiffrer mes données, et j'en accepte le coût. Je veux
        être sûr que je me connecte à un serveur en qui j'ai confiance et que
-       c'est bien celui que j'indique.
+       c'est bien celui que j'ai indiqué.
       </entry>
      </row>
 
@@ -7585,22 +7586,23 @@ description:sslmode=require
 
   <para>
    La différence entre <literal>verify-ca</literal> et <literal>verify-full</literal>
-   dépend de la politique du <acronym>CA</acronym> racine. Si un
+   dépend de la politique de la <acronym>CA</acronym> racine. Si une
    <acronym>CA</acronym> publique est utilisé, <literal>verify-ca</literal> permet
    les connexions à un serveur que <emphasis>quelqu'un d'autre</emphasis> a pu
-   enregistrer avec un <acronym>CA</acronym> accepté. Dans ce cas,
-   <literal>verify-full</literal> devrait toujours être utilisé. Si un
-   <acronym>CA</acronym> local est utilisé, voire même un certificat signé
-   soi-même, utiliser <literal>verify-ca</literal> fournit souvent suffisamment de
+   enregistrer pour cette <acronym>CA</acronym>. Dans ce cas,
+   <literal>verify-full</literal> devrait toujours être utilisé. Si une
+   <acronym>CA</acronym> locale est utilisé, voire un certificat auto-signé,
+   utiliser <literal>verify-ca</literal> fournit souvent suffisamment de
    protection.
   </para>
 
   <para>
    La valeur par défaut pour <literal>sslmode</literal> est <literal>prefer</literal>.
    Comme l'indique la table ci-dessus, cela n'a pas de sens d'un point de vue
-   de la sécurité, et cela ne promet qu'une surcharge en terme de performance
-   si possible. C'est uniquement fourni comme valeur par défaut pour la
-   compatibilité ascendante, et n'est pas recommandé pour les déploiements de
+   de la sécurité, et ne promet, si elle possible, qu'un surcoût en terme
+   de performance.
+   Cette valeur est fournie par défaut uniquement pour la
+   compatibilité descendante, et n'est pas recommandée pour les déploiements de
    serveurs nécessitant de la sécurité.
   </para>
 
@@ -7643,14 +7645,14 @@ description:sslmode=require
 
      <row>
       <entry><filename>~/.postgresql/root.crt</filename></entry>
-      <entry>autorité de confiance du certificat</entry>
+      <entry>autorités de confiance</entry>
       <entry>vérifie que le certificat du serveur est signé par une autorité
        de confiance</entry>
      </row>
 
      <row>
       <entry><filename>~/.postgresql/root.crl</filename></entry>
-      <entry>certificats révoqués par les autorités</entry>
+      <entry>certificats révoqués par les autorités de confiance</entry>
       <entry>le certificat du serveur ne doit pas être sur cette liste</entry>
      </row>
 
@@ -7670,7 +7672,7 @@ description:sslmode=require
    <application>libpq</application> que les bibliothèques
    <literal>libssl</literal> et/ou <literal>libcrypto</literal> ont été
    initialisées par votre application, de façon à ce que
-   <application>libpq</application> n'initialise pas elle-aussi ces
+   <application>libpq</application> n'initialise pas elle aussi ces
    bibliothèques.
    <!-- If this URL changes replace it with a URL to www.archive.org. -->
    Voir <ulink
@@ -7737,7 +7739,7 @@ description:sslmode=require
       </para>
 
       <para>
-       Cette fonction est équivalent à
+       Cette fonction est équivalente à
        <literal>PQinitOpenSSL(do_ssl, do_ssl)</literal>. C'est suffisant pour les
        applications qui initialisent à la fois <application>OpenSSL</application>
        et<literal>libcrypto</literal> ou aucune des deux.
@@ -7769,14 +7771,14 @@ description:sslmode=require
  </indexterm>
 
  <para>
-  <application>libpq</application> est réentrante et sûre avec les threads par
+  <application>libpq</application> est réentrante et compatible avec les threads par
   défaut. Vous pourriez avoir besoin d'utiliser des options de
-  compilation supplémentaires en ligne lorsque vous compiler le code de votre
-  application. Référez-vous aux documentations de votre système pour savoir
-  comment construire des applications actives au niveau thread ou recherchez
+  compilation supplémentaires en ligne lorsque vous compilez le code de votre
+  application. Référez-vous à la documentation de votre système pour savoir
+  comment construire des applications avec threads ou recherchez
   <literal>PTHREAD_CFLAGS</literal> et <literal>PTHREAD_LIBS</literal> dans
-  <filename>src/Makefile.global</filename>. Cette fonction permet d'exécuter
-  des requêtes sur le statut de <application>libpq</application> concernant les
+  <filename>src/Makefile.global</filename>. Cette fonction permet d'interroger
+  le statut de compatibilité de <application>libpq</application> avec les
   threads&nbsp;:
  </para>
 
@@ -7785,7 +7787,7 @@ description:sslmode=require
    <term><function>PQisthreadsafe</function><indexterm><primary>PQisthreadsafe</primary></indexterm></term>
    <listitem>
     <para>
-     Renvoie le statut de sûreté des threads pour <application>libpq</application>
+     Renvoie le statut de compatibilité avec les threads pour <application>libpq</application>
      library.
      <synopsis>
       int PQisthreadsafe();
@@ -7801,22 +7803,20 @@ description:sslmode=require
  </variablelist>
 
  <para>
-  Une restriction&nbsp;: il ne doit pas y avoir deux tentatives de threads
+  Une restriction&nbsp;: il ne doit pas y avoir deux threads
   manipulant le même objet <structname>PGconn</structname> à la fois. En particulier, vous
-  ne pouvez pas lancer des commandes concurrentes à partir de threads différents
-  à travers le même objet de connexion (si vous avez besoin de lancer des
+  ne pouvez pas lancer des commandes concurrentes à partir depuis des threads
+  différents à partir du même objet de connexion (si vous avez besoin de lancer des
   commandes concurrentes, utilisez plusieurs connexions).
  </para>
 
  <para>
-  Les objets <structname>PGresult</structname> sont en lecture seule après
-  leur création et, du coup, ils peuvent être passés librement entre les
-  threads. Les objets <structname>PGresult</structname> sont en lecture
-  seule après leur création et, du coup, ils peuvent être passés librement
-  entre les threads. Néanmoins, si vous utilisez une des fonctions de
-  modification d'un <structname>PGresult</structname> décrites dans <xref
-  linkend="libpq-misc"/> ou <xref linkend="libpq-events"/>, vous devez
-  aussi éviter toute opération concurrente sur le même
+  Les objets <structname>PGresult</structname> sont normalement en lecture seule
+  après leur création et, du coup, peuvent être passés librement entre les
+  threads. Néanmoins, si vous utilisez une des fonctions
+  décrites dans <xref linkend="libpq-misc"/> ou <xref linkend="libpq-events"/>
+  qui modifient <structname>PGresult</structname>, il est de votre responsabilité
+  d'éviter des opérations concurrentes sur le même
   <structname>PGresult</structname>.
  </para>
 
@@ -7824,28 +7824,29 @@ description:sslmode=require
   Les fonctions obsolètes
   <function>PQrequestCancel</function> et
   <function>PQoidStatus</function>
-  ne gèrent pas les threads et ne devraient pas être utilisées dans des programmes multithread. <function>PQrequestCancel</function> peut être
+  ne gèrent pas les threads et ne devraient pas être utilisées dans des programmes multithreads. <function>PQrequestCancel</function> peut être
   remplacé par <function>PQcancel</function>.
   <function>PQoidStatus</function> peut être remplacé par
   <function>PQoidValue</function>.
  </para>
 
  <para>
-  Si vous utilisez Kerberos avec votre application (ainsi que dans
+  Si vous utilisez Kerberos avec votre application (en plus de
   <application>libpq</application>), vous aurez besoin de verrouiller les appels
-  Kerberos car les fonctions Kerberos ne sont pas sûres lorsqu'elles sont
-  utilisées avec des threads. Voir la fonction <function>PQregisterThreadLock</function>
-  dans le code source de <application>libpq</application> pour récupérer un moyen
-  de faire un verrouillage coopératif entre <application>libpq</application> et
+  Kerberos car les fonctions Kerberos ne supportent pas les threads.
+  Voir la fonction <function>PQregisterThreadLock</function>
+  dans le code source de <application>libpq</application> sur comment
+  faire un verrouillage coopératif entre <application>libpq</application> et
   votre application.
  </para>
 
  <para>
-  Si vous expérimentez des problèmes avec les applications utilisant des threads,
+  Si vous rencontrez des problèmes avec les applications utilisant des threads,
   lancez le programme dans <filename>src/tools/thread</filename> pour voir si votre
-  plateforme à des fonctions non compatibles avec les threads. Ce programme
+  plateforme possède des fonctions incompatibles avec les threads. Ce programme
   est lancé par <filename>configure</filename> mais, dans le cas des
-  distributions binaires, votre bibliothèque pourrait ne pas correspondre à la bibliothèque utilisée pour construire les binaires.
+  distributions binaires, votre bibliothèque peut ne pas correspondre à
+  la bibliothèque utilisée pour construire les binaires.
  </para>
 </sect1>
 
@@ -7867,11 +7868,11 @@ description:sslmode=require
   <itemizedlist>
    <listitem>
     <para>
-     Incluez le fichier d'en-tête <filename>libpq-fe.h</filename>&nbsp;:
+     Ajoutez le fichier d'en-tête <filename>libpq-fe.h</filename>&nbsp;:
      <programlisting>#include &lt;libpq-fe.h&gt;
      </programlisting>
-     Si vous ne le faites pas, alors vous obtiendrez normalement les messages
-     d'erreurs similaires à ceci
+     Si vous ne le faites pas, alors vous obtiendrez normalement des messages
+     d'erreurs similaires à&nbsp;:
      <screen>foo.c: In function `main':
        foo.c:34: `PGconn' undeclared (first use in this function)
        foo.c:35: `PGresult' undeclared (first use in this function)
@@ -7884,10 +7885,10 @@ description:sslmode=require
 
    <listitem>
     <para>
-     Pointez votre compilateur sur le répertoire où les fichiers d'en-tête
-     de <productname>PostgreSQL</productname> ont été installés en fournissant l'option
-     <literal>-I<replaceable>répertoire</replaceable></literal> à votre
-     compilateur (dans certains cas, le compilateur cherchera dans le
+     Faites pointer votre compilateur sur le répertoire où les fichiers d'en-tête
+     de <productname>PostgreSQL</productname> ont été installés, en lui
+     fournissant l'option <literal>-I<replaceable>répertoire</replaceable>
+     </literal> (dans certains cas, le compilateur cherchera dans le
      répertoire en question par défaut, donc vous pouvez omettre cette
      option). Par exemple, votre ligne de commande de compilation devrait
      ressembler à ceci&nbsp;:
@@ -7900,11 +7901,12 @@ description:sslmode=require
     </para>
 
     <para>
-     S'il existe une chance pour que votre programme soit compilé par
+     S'il y a une chance que votre programme soit compilé par
      d'autres utilisateurs, alors vous ne devriez pas coder en dur
      l'emplacement du répertoire. À la place, vous pouvez exécuter l'outil
      <command>pg_config</command><indexterm><primary>pg_config</primary><secondary
-      sortas="libpq">avec libpq</secondary></indexterm> pour trouver où sont placés les fichiers
+      sortas="libpq">avec libpq</secondary></indexterm> pour trouver
+      où sont placés les fichiers
      d'en-tête sur le système local&nbsp;:
      <screen><prompt>$</prompt> pg_config --includedir
       <computeroutput>/usr/local/include</computeroutput>
@@ -7914,17 +7916,16 @@ description:sslmode=require
     <para>
      Si vous avez installé <command>pkg-config</command>
      <indexterm><primary>pkg-config</primary><secondary sortas="libpq">avec
-       libpq</secondary></indexterm>, vous pouvez lancé à la place&nbsp;:
+       libpq</secondary></indexterm>, vous pouvez lancer à la place&nbsp;:
      <screen>
        <prompt>$</prompt> pkg-config --cflags libpq
        <computeroutput>-I/usr/local/include</computeroutput>
      </screen>
-     Notez qu'il sera déjà inclus avec l'option <option>-I</option> au début
-     du chemin.
+     Notez que l'option <option>-I</option> sera déjà précisée au début du chemin.
     </para>
 
     <para>
-     Un échec sur la spécification de la bonne option au compilateur
+     Une erreur dans la spécification de la bonne option au compilateur
      résultera en un message d'erreur tel que
      <screen>testlibpq.c:8:22: libpq-fe.h: No such file or directory
      </screen>
@@ -7937,8 +7938,8 @@ description:sslmode=require
      <literal>-lpq</literal> de façon à ce que
      les bibliothèques <application>libpq</application> soient intégrées, ainsi
      que l'option <literal>-L<replaceable>répertoire</replaceable></literal>
-     pour pointer le compilateur vers le répertoire où les bibliothèques
-     <application>libpq</application> résident (de nouveau, le compilateur
+     pour faire pointer le compilateur vers le répertoire où les bibliothèques
+     <application>libpq</application> résident. (Là encore le compilateur
      cherchera certains répertoires par défaut). Pour une portabilité maximale,
      placez l'option <option>-L</option> avant l'option <option>-lpq</option>.
      Par exemple&nbsp;:
@@ -7965,7 +7966,7 @@ description:sslmode=require
     </para>
 
     <para>
-     Les messages d'erreurs, pointant vers des problèmes de ce style,
+     Les messages d'erreurs liés à des problèmes de ce style
      pourraient ressembler à ce qui suit.
      <screen>testlibpq.o: In function `main':
        testlibpq.o(.text+0x60): undefined reference to `PQsetdbLogin'
@@ -8003,7 +8004,7 @@ description:sslmode=require
  *
  * testlibpq.c
  *
- *      Test the C version of libpq, the PostgreSQL frontend library.
+ *      Teste la version C de libpq, la bibliothèque frontend de PostgreSQL.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -8027,19 +8028,20 @@ main(int argc, char **argv)
                 j;
 
     /*
-     * If the user supplies a parameter on the command line, use it as the
-     * conninfo string; otherwise default to setting dbname=postgres and using
-     * environment variables or defaults for all other connection parameters.
+     * Si l'utilisateur fournit un paramètre sur la ligne de commande,
+     * l'utiliser comme une chaîne conninfo ; sinon prendre par défaut
+     * dbname=postgres et utiliser les variables d'environnement ou les
+     * pour tous les autres paramètres de connection.
      */
     if (argc > 1)
         conninfo = argv[1];
     else
         conninfo = "dbname = postgres";
 
-    /* Make a connection to the database */
+    /* Crée une connexion à la base de données */
     conn = PQconnectdb(conninfo);
 
-    /* Check to see that the backend connection was successfully made */
+    /* Vérifier que la connexion au backend a été faite avec succès */
     if (PQstatus(conn) != CONNECTION_OK)
     {
         fprintf(stderr, "Connection to database failed: %s",
@@ -8047,7 +8049,8 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
-    /* Set always-secure search path, so malicous users can't take control. */
+    /* Initialise un search path sûr, pour qu'un utilisateur
+       malveillant ne puisse prendre le contrôle. */
     res = PQexec(conn,
                  "SELECT pg_catalog.set_config('search_path', '', false)");
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
@@ -8057,16 +8060,20 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
+    /*
+    * Il faut libérer PGresult avec PQclear dès que l'on en a plus besoin pour
+    * éviter les fuites de mémoire.
+    */
     PQclear(res);
 
     /*
-     * Our test case here involves using a cursor, for which we must be inside
-     * a transaction block.  We could do the whole thing with a single
-     * PQexec() of "select * from pg_database", but that's too trivial to make
-     * a good example.
+     * Notre exemple inclut un curseur, pour lequel il faut que nous soyons dans
+     * un bloc de transaction. On pourrait tout faire dans un seul PQexec()
+     * d'un "select * from pg_database" mais c'est trop trivial pour faire
+     * un bon exemple.
      */
 
-    /* Start a transaction block */
+    /* Démarre un bloc de transaction */
     res = PQexec(conn, "BEGIN");
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
     {
@@ -8074,15 +8081,11 @@ main(int argc, char **argv)
         PQclear(res);
         exit_nicely(conn);
     }
-
-    /*
-     * Should PQclear PGresult whenever it is no longer needed to avoid memory
-     * leaks
-     */
     PQclear(res);
 
     /*
-     * Fetch rows from pg_database, the system catalog of databases
+     * Récupère les lignes de pg_database, catalogue système des bases de
+     * données
      */
     res = PQexec(conn, "DECLARE myportal CURSOR FOR select * from pg_database");
     if (PQresultStatus(res) != PGRES_COMMAND_OK)
@@ -8101,13 +8104,13 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
-    /* first, print out the attribute names */
+    /* affiche d'abord les noms des attributs */
     nFields = PQnfields(res);
     for (i = 0; i < nFields; i++)
         printf("%-15s", PQfname(res, i));
     printf("\n\n");
 
-    /* next, print out the rows */
+    /* puis afficher les lignes */
     for (i = 0; i < PQntuples(res); i++)
     {
         for (j = 0; j < nFields; j++)
@@ -8117,15 +8120,15 @@ main(int argc, char **argv)
 
     PQclear(res);
 
-    /* close the portal ... we don't bother to check for errors ... */
+    /* ferme le portail... nous ne cherchons pas s'il y a des erreurs... */
     res = PQexec(conn, "CLOSE myportal");
     PQclear(res);
 
-    /* end the transaction */
+    /* termine la transaction */
     res = PQexec(conn, "END");
     PQclear(res);
 
-    /* close the connection to the database and cleanup */
+    /* ferme la connexion à la base et nettoie */
     PQfinish(conn);
 
     return 0;
@@ -8142,15 +8145,15 @@ main(int argc, char **argv)
  *
  *
  * testlibpq2.c
- *      Test of the asynchronous notification interface
+ *      Teste l'interface de notrification asynchrone
  *
- * Start this program, then from psql in another window do
+ * Démarrez ce programme, puis depuis psql dans une autre fenêtre faites
  *   NOTIFY TBL2;
- * Repeat four times to get this program to exit.
+ * Répétez quatre fois pour que terminer ce programme.
  *
- * Or, if you want to get fancy, try this:
- * populate a database with the following commands
- * (provided in src/test/examples/testlibpq2.sql):
+ * Ou, si vous voulez vous faire plaisir, faites ceci :
+ * remplissez une base avec les commandes suivantes
+ * (issues de src/test/examples/testlibpq2.sql):
  *
  *   CREATE SCHEMA TESTLIBPQ2;
  *   SET search_path = TESTLIBPQ2;
@@ -8161,7 +8164,7 @@ main(int argc, char **argv)
  *   CREATE RULE r1 AS ON INSERT TO TBL1 DO
  *     (INSERT INTO TBL2 VALUES (new.i); NOTIFY TBL2);
  *
- * Start this program, then from psql do this four times:
+ * Démarrez ce programme, puis depuis psql faites quatre fois :
  *
  *   INSERT INTO TESTLIBPQ2.TBL1 VALUES (10);
  */
@@ -8198,19 +8201,20 @@ main(int argc, char **argv)
     int         nnotifies;
 
     /*
-     * If the user supplies a parameter on the command line, use it as the
-     * conninfo string; otherwise default to setting dbname=postgres and using
-     * environment variables or defaults for all other connection parameters.
+     * Si l'utilisateur fournit un paramètre sur la ligne de commande,
+     * l'utiliser comme une chaîne conninfo ; sinon prendre par défaut
+     * dbname=postgres et utiliser les variables d'environnement ou les
+     * pour tous les autres paramètres de connection.
      */
     if (argc > 1)
         conninfo = argv[1];
     else
         conninfo = "dbname = postgres";
 
-    /* Make a connection to the database */
+    /* Se connecte à la base */
     conn = PQconnectdb(conninfo);
 
-    /* Check to see that the backend connection was successfully made */
+    /* Vérifier que la connexion au backend a été faite avec succès */
     if (PQstatus(conn) != CONNECTION_OK)
     {
         fprintf(stderr, "Connection to database failed: %s",
@@ -8218,7 +8222,8 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
-    /* Set always-secure search path, so malicous users can't take control. */
+    /* Initialise un search path sûr, pour qu'un utilisateur
+       malveillant ne puisse prendre le contrôle. */
     res = PQexec(conn,
                  "SELECT pg_catalog.set_config('search_path', '', false)");
     if (PQresultStatus(res) != PGRES_COMMAND_OK)
@@ -8228,10 +8233,15 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
+    /*
+    * Il faut libérer PGresult avec PQclear dès que l'on en a plus besoin pour
+    * éviter les fuites de mémoire.
+    */
     PQclear(res);
 
     /*
-     * Issue LISTEN command to enable notifications from the rule's NOTIFY.
+     * Lance une commande LISTEN to démarrer des notifications depuis le
+     * NOTIFY.
      */
     res = PQexec(conn, "LISTEN TBL2");
     if (PQresultStatus(res) != PGRES_COMMAND_OK)
@@ -8241,20 +8251,16 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
-    /*
-     * should PQclear PGresult whenever it is no longer needed to avoid memory
-     * leaks
-     */
     PQclear(res);
 
-    /* Quit after four notifies are received. */
+    /* Quitte après avoir reçu quatre notifications. */
     nnotifies = 0;
     while (nnotifies < 4)
     {
         /*
-         * Sleep until something happens on the connection.  We use select(2)
-         * to wait for input, but you could also use poll() or similar
-         * facilities.
+         * Dort jusqu'à ce que quelque chose arrive sur la connexion. nous
+         * utilisons select(2) pour attendre une entrée, mais vous pouvez
+         * utiliser poll() ou des fonctions similaires.
          */
         int         sock;
         fd_set      input_mask;
@@ -8262,7 +8268,7 @@ main(int argc, char **argv)
         sock = PQsocket(conn);
 
         if (sock < 0)
-            break;              /* shouldn't happen */
+            break;              /* ne devrait pas arriver */
 
         FD_ZERO(&input_mask);
         FD_SET(sock, &input_mask);
@@ -8273,7 +8279,7 @@ main(int argc, char **argv)
             exit_nicely(conn);
         }
 
-        /* Now check for input */
+        /* Cherche une entrée */
         PQconsumeInput(conn);
         while ((notify = PQnotifies(conn)) != NULL)
         {
@@ -8287,7 +8293,7 @@ main(int argc, char **argv)
 
     fprintf(stderr, "Done.\n");
 
-    /* close the connection to the database and cleanup */
+    /* ferme la connexion à la base et nettoie */
     PQfinish(conn);
 
     return 0;
@@ -8304,10 +8310,10 @@ main(int argc, char **argv)
  *
  *
  * testlibpq3.c
- *      Test out-of-line parameters and binary I/O.
+ *      Teste des paramètres délicats et des entrées-sorties binaires.
  *
- * Before running this, populate a database with the following commands
- * (provided in src/test/examples/testlibpq3.sql):
+ * Avant de lancer ceci, remplissez une base avec les commandes suivantes
+ * (fournies dans src/test/examples/testlibpq3.sql):
  *
  * CREATE SCHEMA testlibpq3;
  * SET search_path = testlibpq3;
@@ -8316,7 +8322,7 @@ main(int argc, char **argv)
  * INSERT INTO test1 values (1, 'joe''s place', '\\000\\001\\002\\003\\004');
  * INSERT INTO test1 values (2, 'ho there', '\\004\\003\\002\\001\\000');
  *
- * The expected output is:
+ * La sortie attendue est :
  *
  * tuple 0: got
  *  i = (4 bytes) 1
@@ -8353,9 +8359,9 @@ exit_nicely(PGconn *conn)
 }
 
 /*
- * This function prints a query result that is a binary-format fetch from
- * a table defined as in the comment above.  We split it out because the
- * main() function uses it twice.
+ * Cette fonction affiche un résultat qui est la récupération
+ * au format binaire d'une table définie dans le commentaire ci-dessus.
+ * Nous fractionnons car la fonction main() l'utilise deux fois.
  */
 static void
 show_binary_results(PGresult *res)
@@ -8366,7 +8372,10 @@ show_binary_results(PGresult *res)
                 t_fnum,
                 b_fnum;
 
-    /* Use PQfnumber to avoid assumptions about field order in result */
+    /*
+     * Utilise PQfnumber pour éviter de deviner l'ordre des champs
+     * dans le résultat
+     */
     i_fnum = PQfnumber(res, "i");
     t_fnum = PQfnumber(res, "t");
     b_fnum = PQfnumber(res, "b");
@@ -8379,24 +8388,29 @@ show_binary_results(PGresult *res)
         int         blen;
         int         ival;
 
-        /* Get the field values (we ignore possibility they are null!) */
+        /*
+         * Récupère les valeurs des champs
+         * (on ignore la possibilités qu'ils  soient NULL !)
+         */
         iptr = PQgetvalue(res, i, i_fnum);
         tptr = PQgetvalue(res, i, t_fnum);
         bptr = PQgetvalue(res, i, b_fnum);
 
         /*
-         * The binary representation of INT4 is in network byte order, which
-         * we'd better coerce to the local byte order.
+         * La représentation binaire d'INT4 est dans l'ordre d'octets
+         * du réseau (network byte order), qu'il vaut mieux forcer à
+         * l'ordre local.
          */
         ival = ntohl(*((uint32_t *) iptr));
 
         /*
-         * The binary representation of TEXT is, well, text, and since libpq
-         * was nice enough to append a zero byte to it, it'll work just fine
-         * as a C string.
+         * La représentation binaire de TEXT est, hé bien, du texte,
+         * et puisque libpq a été assez sympa pour rajouter un octet zéro,
+         * cela marchera très bien en tant que chaîne C.
          *
-         * The binary representation of BYTEA is a bunch of bytes, which could
-         * include embedded nulls so we have to pay attention to field length.
+         * La représentation binaire de BYTEA est un paquet d'octets,
+         * pouvant incorporer des nulls, donc nous devons faire attention à
+         * la longueur des champs.
          */
         blen = PQgetlength(res, i, b_fnum);
 
@@ -8424,19 +8438,20 @@ main(int argc, char **argv)
     uint32_t    binaryIntVal;
 
     /*
-     * If the user supplies a parameter on the command line, use it as the
-     * conninfo string; otherwise default to setting dbname=postgres and using
-     * environment variables or defaults for all other connection parameters.
+     * Si l'utilisateur fournit un paramètre sur la ligne de commande,
+     * l'utiliser comme une chaîne conninfo ; sinon prendre par défaut
+     * dbname=postgres et utiliser les variables d'environnement ou les
+     * pour tous les autres paramètres de connection.
      */
     if (argc > 1)
         conninfo = argv[1];
     else
         conninfo = "dbname = postgres";
 
-    /* Make a connection to the database */
+    /* Crée une connexion à la base */
     conn = PQconnectdb(conninfo);
 
-    /* Check to see that the backend connection was successfully made */
+    /* Vérifie que la connexion à la base s'est bien déroulée */
     if (PQstatus(conn) != CONNECTION_OK)
     {
         fprintf(stderr, "Connection to database failed: %s",
@@ -8444,7 +8459,10 @@ main(int argc, char **argv)
         exit_nicely(conn);
     }
 
-    /* Set always-secure search path, so malicous users can't take control. */
+    /*
+    * Il faut libérer PGresult avec PQclear dès que l'on en a plus besoin pour
+    * éviter les fuites de mémoire.
+    */
     res = PQexec(conn, "SET search_path = testlibpq3");
     if (PQresultStatus(res) != PGRES_COMMAND_OK)
     {
@@ -8455,27 +8473,30 @@ main(int argc, char **argv)
     PQclear(res);
 
     /*
-     * The point of this program is to illustrate use of PQexecParams() with
-     * out-of-line parameters, as well as binary transmission of data.
+     * Le sujet de ce programme est d'illustrer l'utilisation de PQexecParams()
+     * avec des paramètres délicats aussi bien que la transmission de
+     * données binaires.
      *
-     * This first example transmits the parameters as text, but receives the
-     * results in binary format.  By using out-of-line parameters we can
-     * avoid a lot of tedious mucking about with quoting and escaping, even
-     * though the data is text.  Notice how we don't have to do anything
-     * special with the quote mark in the parameter value.
+     * Ce premier exemple transmet les paramètres en tant que texte, mais
+     * reçoit les résultats en format binaire. En utilisant des paramètres
+     * inhabituels nous pouvons éviter beaucoup de nettoyage fastidieux en
+     * terme de guillemets et d'échappement, même si les données sont du
+     * texte. Notez que nous ne faisons tien de spécial avec les guillemets
+     * dans la valeur du paramètre.
      */
 
-    /* Here is our out-of-line parameter value */
+    /* Voici notre paramètre délicat */
     paramValues[0] = "joe's place";
 
     res = PQexecParams(conn,
                        "SELECT * FROM test1 WHERE t = $1",
-                       1,       /* one param */
-                       NULL,    /* let the backend deduce param type */
+                       1,       /* un paramètre */
+                       NULL,    /* laissons le backend déduire le type */
                        paramValues,
-                       NULL,    /* don't need param lengths since text */
-                       NULL,    /* default to all text params */
-                       1);      /* ask for binary results */
+                       NULL,    /* pas besoin de la longueur des paramètres,
+                                   c'est du texte */
+                       NULL,    /* par défaut tous les paramètres sont du texte */
+                       1);      /* demnde le résultat en binaire */
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
     {
@@ -8489,31 +8510,33 @@ main(int argc, char **argv)
     PQclear(res);
 
     /*
-     * In this second example we transmit an integer parameter in binary
-     * form, and again retrieve the results in binary form.
+     * Dans ce second exemple, on transmet un paramètre entier sous
+     * forme binaire, et on récupère à nouveau les paramètres sous forme
+     * binaire.
      *
-     * Although we tell PQexecParams we are letting the backend deduce
-     * parameter type, we really force the decision by casting the parameter
-     * symbol in the query text.  This is a good safety measure when sending
-     * binary parameters.
+     * Bien que nous disions à PQexecParams que nous laissons le backend
+     * déduire le type du paramètre, nous forçons la décision en convertissant
+     * le symbole du paramètre dans le texte de la requête. C'est une bonne
+     * précaution quand on envoie des paramètres binaires.
      */
 
-    /* Convert integer value "2" to network byte order */
+    /* Convertit l'entier "2" dans l'ordre d'octets du réseau */
     binaryIntVal = htonl((uint32_t) 2);
 
-    /* Set up parameter arrays for PQexecParams */
+    /* Met en place les tableaux de paramètres pour PQexecParams */
     paramValues[0] = (char *) &binaryIntVal;
     paramLengths[0] = sizeof(binaryIntVal);
     paramFormats[0] = 1;        /* binary */
 
     res = PQexecParams(conn,
                        "SELECT * FROM test1 WHERE i = $1::int4",
-                       1,       /* one param */
-                       NULL,    /* let the backend deduce param type */
+                       1,       /* un paramètre */
+                       NULL,    /* laissons le backed déduire le type
+                                   du paramètre */
                        paramValues,
                        paramLengths,
                        paramFormats,
-                       1);      /* ask for binary results */
+                       1);      /* demande des résultats binaires */
 
     if (PQresultStatus(res) != PGRES_TUPLES_OK)
     {
@@ -8526,7 +8549,7 @@ main(int argc, char **argv)
 
     PQclear(res);
 
-    /* close the connection to the database and cleanup */
+    /* ferme la connexion et nettoie */
     PQfinish(conn);
 
     return 0;


### PR DESCRIPTION
Traduction des quelques modifications de la bêta. Je suis tombé dans le piège d'une relecture complète : 
- divers fautes de frappe et d'accord
- tenté d'alléger des tournures
- quelques écarts corrigés
- quelques mots d'anglais avaient été oubliés
- 2 ou 3 paragraphes mal placés ou qui n'avaient pas été effacés
- traduction des commentaires des programmes à la fin 