### PR TITLE
runtime.xml : traduction v11b3 + foreignphrase autour des huge pages

### DIFF
--- a/postgresql/runtime.xml
+++ b/postgresql/runtime.xml
@@ -133,26 +133,29 @@ root# <userinput>chown postgres /usr/local/pgsql</userinput></screen>
   </para>
 
   <para>
-   Comme le répertoire des données contient toutes les données stockées par
-   le système de bases de données, il est essentiel qu'il soit sécurisé par
-   rapport à des accès non autorisés. Du coup, <command>initdb</command>
-   supprimera les droits d'accès à tout le monde sauf l'utilisateur
-   <productname>PostgreSQL</productname>, and optionally, group.
-   Group access, when enabled, is read-only.  This allows an unprivileged
-   user in the same group as the cluster owner to take a backup of the
-   cluster data or perform other operations that only require read access.
+   Comme le répertoire des données contient toutes les données stockées
+   dans la base, il est essentiel qu'il soit protégé contre les
+   accès non autorisés. En conséquence, <command>initdb</command>
+   supprime les droits d'accès à tout le monde sauf à l'utilisateur
+   <productname>PostgreSQL</productname>, et optionnellement au groupe.
+   L'accès au groupe, s'il est autorisé, est en lecture seule.
+   Cela permet à un utilisateur non privilégié, du même groupe que le
+   propriétaire de l'instance, de faire une sauvegarde des fichiers ou d'effectuer
+   des opérations qui ne requièrent qu'un accès en lecture.
   </para>
 
   <para>
-   Note that enabling or disabling group access on an existing cluster requires
-   the cluster to be shut down and the appropriate mode to be set on all
-   directories and files before restarting
-   <productname>PostgreSQL</productname>.  Otherwise, a mix of modes might
-   exist in the data directory.  For clusters that allow access only by the
-   owner, the appropriate modes are <literal>0700</literal> for directories
-   and <literal>0600</literal> for files.  For clusters that also allow
-   reads by the group, the appropriate modes are <literal>0750</literal>
-   for directories and <literal>0640</literal> for files.
+   Notez qu'activer ou désactiver l'accès au groupe sur une instance
+   préexistante exige qu'elle soit arrêtée et que les droits soient mis en place
+   sur tous les répertoires et fichiers avant de redémarrer <productname>PostgreSQL</productname>.
+
+   Sinon, un mélange des droits pourrait exister dans le répertoire de données.
+   Pour les instances qui ne donnent accès qu'au propriétaire, les droits
+   appropriés sont <literal>0700</literal> sur les répertoires et
+   <literal>0600</literal> sur les fichiers. Pour les instances qui permettent
+   aussi la lecture par le groupe, les droits appropriés sont
+   <literal>0750</literal> sur les répertoires et <literal>0640</literal>
+   sur les fichiers.
   </para>
 
   <para>
@@ -1218,7 +1221,7 @@ project.max-msg-ids=(priv,4096,deny)
 LOG: semctl(1234567890, 0, IPC_RMID, ...) failed: Invalid argument
 </screen>
     Différents types d'objets IPC (mémoire partagée et sémaphores, System V et
-    POSIX) sont traités de manière légèrement différente par 
+    POSIX) sont traités de manière légèrement différente par
     <productname>systemd</productname>, et l'on peut observer que certaines
     ressources IPC ne sont pas supprimées de la m&ecirc;me manière que les
     autres. Il n'est toutefois pas conseillé de compter sur ces subtiles
@@ -1482,11 +1485,13 @@ export PG_OOM_ADJUST_VALUE=0
  </sect2>
 
  <sect2 id="linux-huge-pages">
-  <title>Pages mémoire de grande taille (huge pages) sous Linux</title>
+  <title>Pages mémoire de grande taille
+   (<foreignphrase>huge pages</foreignphrase>) sous Linux</title>
 
   <para>
-   L'utilisation des « huge pages » réduit la surcharge lors de l'utilisation
-   de gros morceaux contigus de mémoire, comme ce que fait
+   L'utilisation des <foreignphrase>huge pages</foreignphrase> réduit la
+   surcharge lors de l'utilisation de gros morceaux contigus de mémoire,
+   ce que fait
    <productname>PostgreSQL</productname>, tout particulièrement lors de
    l'utilisation de grosses valeurs pour <xref linkend="guc-shared-buffers"/>.
    Pour activer cette fonctionnalité avec
@@ -1494,10 +1499,13 @@ export PG_OOM_ADJUST_VALUE=0
    avec <varname>CONFIG_HUGETLBFS=y</varname> et
    <varname>CONFIG_HUGETLB_PAGE=y</varname>. Vous devez aussi configurer le
    paramètre noyau <varname>vm.nr_hugepages</varname>. Pour estimer le nombre
-   nécessaire de « huge pages », lancer <productname>PostgreSQL</productname>
-   sans activer les « huge pages » et vérifier la taille du segment de mémoire
+   nécessaire de <foreignphrase>huge pages</foreignphrase>,
+   lancer <productname>PostgreSQL</productname>
+   sans activer les  <foreignphrase>huge pages</foreignphrase>
+   et vérifiez la taille du segment de mémoire
    partagée anonyme pour le processus postmaster, ainsi que la taille
-   des « huge pages » pour le système en utilisant le système de fichiers
+   des  <foreignphrase>huge pages</foreignphrase> pour le système en utilisant
+   le système de fichiers
    <filename>/proc</filename>. Cela pourrait ressembler à ceci&nbsp;:
    <programlisting>
 $ <userinput>head -1 $PGDATA/postmaster.pid</userinput>
@@ -1509,24 +1517,27 @@ Hugepagesize:       2048 kB
    </programlisting>
    <literal>6490428</literal> / <literal>2048</literal> donne approximativement
    <literal>3169.154</literal>. Donc, dans cet exemple, nous avons besoin d'au
-   moins <literal>3170</literal> « huge pages », ce que nous pouvons configurer
-   avec&nbsp;:
+   moins <literal>3170</literal>  <foreignphrase>huge pages</foreignphrase>,
+   ce que nous pouvons configurer avec&nbsp;:
    <programlisting>
 $ <userinput>sysctl -w vm.nr_hugepages=3170</userinput>
    </programlisting>
    Une configuration plus importante serait appropriée si les autres
-   programmes du serveur avaient aussi besoin de « huge pages ». N'oubliez pas
+   programmes du serveur avaient aussi besoin de
+   <foreignphrase>huge pages</foreignphrase>. N'oubliez pas
    d'ajouter cette configuration à <filename>/etc/sysctl.conf</filename> pour
    qu'elle soit appliquée à chaque redémarrage.
    </para>
 
    <para>
    Parfois, le noyau n'est pas capable d'allouer immédiatement le nombre
-   souhaité de « huge pages », donc il peut être nécessaire de répéter cette
+   souhaité de  <foreignphrase>huge pages</foreignphrase>,
+   donc il peut être nécessaire de répéter cette
    commande ou de redémarrer. (Tout de suite après un redémarrage, la plupart
-   de la mémoire de la machine doit être disponible à une conversion en « huge
-   pages ».) Pour vérifier la situation au niveau de l'allocation des « huge
-   pages », utilisez&nbsp;:
+   de la mémoire de la machine doit être disponible à une conversion en
+    <foreignphrase>huge pages</foreignphrase>.) Pour vérifier la situation
+    au niveau de l'allocation des  <foreignphrase>huge pages</foreignphrase>,
+    utilisez&nbsp;:
 <programlisting>
 $ <userinput>grep Huge /proc/meminfo</userinput>
 </programlisting>
@@ -1541,7 +1552,8 @@ $ <userinput>grep Huge /proc/meminfo</userinput>
   </para>
 
   <para>
-   Il est aussi nécessaire de donner le droit d'utiliser les « huge pages » à
+   Il est aussi nécessaire de donner le droit d'utiliser les
+   <foreignphrase>huge pages</foreignphrase> à
    l'utilisateur système qui exécute PostgreSQL. Cela se fait en configurant
    <varname>vm.hugetlb_shm_group</varname> via
    <application>sysctl</application>, et le droit de verrouiller la mémoire
@@ -1549,19 +1561,22 @@ $ <userinput>grep Huge /proc/meminfo</userinput>
    </para>
 
    <para>
-   Le comportement par défaut pour les « huge pages » dans
+   Le comportement par défaut pour les
+   <foreignphrase>huge pages</foreignphrase> dans
    <productname>PostgreSQL</productname> est de les utiliser quand cela est
    possible et de revenir aux pages normales dans le cas contraire. Pour
-   forcer l'utilisation des « huge pages », vous pouvez configurer <xref
+   forcer l'utilisation des  <foreignphrase>huge pages</foreignphrase>,
+   vous pouvez configurer <xref
    linkend="guc-huge-pages"/> à <literal>on</literal> dans le fichier
    <filename>postgresql.conf</filename>. Notez que, avec ce paramètre
    configuré ainsi, <productname>PostgreSQL</productname> refusera de démarrer
-   s'il ne peut pas récupérer suffisamment de « huge pages ».
+   s'il ne peut pas récupérer suffisamment de
+   <foreignphrase>huge pages</foreignphrase>.
   </para>
 
   <para>
-   Pour une description détaillée des « huge pages » sous
-   <productname>Linux</productname>, lisez <ulink
+   Pour une description détaillée des  <foreignphrase>huge pages</foreignphrase>
+   sous <productname>Linux</productname>, lisez <ulink
    url="https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt">https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt</ulink>.
   </para>
 
@@ -2002,8 +2017,8 @@ surligne les étapes nécessaires.
 <para>
 Il est aussi possible d'utiliser des méthodes de réplication logique
 pour créer un serveur esclave
-avec la version à jour de <productname>PostgreSQL</productname>.
-Ceci est possible car la réplication logique permet une réplication entre des
+avec une version plus récente de <productname>PostgreSQL</productname>.
+C'est possible car la réplication logique permet une réplication entre des
 versions majeures différentes de
 <productname>PostgreSQL</productname>. L'esclave peut se trouver sur
 le même serveur ou sur un autre. Une fois qu'il est synchronisé
@@ -2013,13 +2028,12 @@ serveur maître sur le nouveau serveur et arrêter l'ancien maître.
 Ce type de bascule fait que l'arrêt requis pour la mise à jour se
 mesure seulement en secondes.
 </para>
- 
+
 <para>
- This method of upgrading can be performed using the built-in logical
- replication facilities as well as using external logical replication
- systems such as <productname>pglogical</productname>,
- <productname>Slony</productname>, <productname>Londiste</productname>, and
- <productname>Bucardo</productname>.
+ Cette méthode de mise à jour peut être mise en œuvre avec la réplication
+ logique intégrée comme avec des outils de réplication logique tels que
+ <productname>pglogical</productname>, <productname>Slony</productname>,
+ <productname>Londiste</productname>, et <productname>Bucardo</productname>.
 </para>
 
 </sect2>
@@ -2238,18 +2252,18 @@ linkend="installation"/>).
 
   <sect2 id="ssl-setup">
    <title>Basic Setup</title>
- 
+
   <para>
-   With <acronym>SSL</acronym> support compiled in, the
-   <productname>PostgreSQL</productname> server can be started with
-   <acronym>SSL</acronym> enabled by setting the parameter
-   <xref linkend="guc-ssl"/> to <literal>on</literal> in
-   <filename>postgresql.conf</filename>.  The server will listen for both normal
-   and <acronym>SSL</acronym> connections on the same TCP port, and will negotiate
-   with any connecting client on whether to use <acronym>SSL</acronym>.  By
-   default, this is at the client's option; see <xref
-   linkend="auth-pg-hba-conf"/> about how to set up the server to require
-   use of <acronym>SSL</acronym> for some or all connections.
+   Avec <acronym>SSL</acronym> intégré à la compilaton, le serveur
+   <productname>PostgreSQL</productname> peut être démarré avec
+   <acronym>SSL</acronym> activé en po sitionnant le paramètre
+   <xref linkend="guc-ssl"/> à <literal>on</literal> dans
+   <filename>postgresql.conf</filename>. Le serveur écoutera les deux types
+   de connexion, normal et  <acronym>SSL</acronym>, sur le même port TCP,
+   et négociera l'utilisation de <acronym>SSL</acronym> avec chaque client.
+   Par défaut, c'est au choix du client&nbsp;; voir <xref
+   linkend="auth-pg-hba-conf"/> pour la configuration du serveur
+   pour exiger <acronym>SSL</acronym> pour tout ou partie des connexions.
   </para>
 
 <para>
@@ -2275,12 +2289,13 @@ et <xref linkend="guc-ssl-key-file"/>.
   </para>
 
   <para>
-    If the data directory allows group read access then certificate files may
-    need to be located outside of the data directory in order to conform to the
-    security requirements outlined above.  Generally, group access is enabled
-    to allow an unprivileged user to backup the database, and in that case the
-    backup software will not be able to read the certificate files and will
-    likely error.
+    Si le répertoire des données permet l'accès en lecture au groupe,
+    alors les fichiers de certificat doivent être placés hors de ce répertoire
+    pour se conformer aux exigences de sécurité décrites ci-dessus.
+    Généralement, l'accès au groupe est autorisé pour permettre à un utilisateur
+    non privilégié de sauvegarder la base, et dans ce cas le logiciel
+    de sauvegarde sera incapable de lire les certificats et retournera
+    probablement une erreur.
   </para>
 
   <para>
@@ -2314,31 +2329,33 @@ certificat racine de la chaîne de certificats du serveur.
    <title>OpenSSL Configuration</title>
 
   <para>
-   <productname>PostgreSQL</productname> reads the system-wide
-   <productname>OpenSSL</productname> configuration file. By default, this
-   file is named <filename>openssl.cnf</filename> and is located in the
-   directory reported by <literal>openssl version -d</literal>.
-   This default can be overridden by setting environment variable
-   <envar>OPENSSL_CONF</envar> to the name of the desired configuration file.
+   <productname>PostgreSQL</productname> lit le fichier de configuration
+   <productname>OpenSSL</productname> du système. Par défaut, ce fichier
+   est nommé <filename>openssl.cnf</filename> et est situé dans le
+   répertoire désigné par <literal>openssl version -d</literal>.
+   Ce défaut peut être surchargé en remplissant la variable d'environnement
+   <envar>OPENSSL_CONF</envar> avec le nom du fichier de configuration
+   désiré.
   </para>
 
   <para>
-   <productname>OpenSSL</productname> supports a wide range of ciphers
-   and authentication algorithms, of varying strength.  While a list of
-   ciphers can be specified in the <productname>OpenSSL</productname>
-   configuration file, you can specify ciphers specifically for use by
-   the database server by modifying <xref linkend="guc-ssl-ciphers"/> in
+   <productname>OpenSSL</productname> supporte une large gamme d'algorithmes
+   de chiffrement et d'authentification de forces variables.
+   Bien qu'une liste des techniques de chiffrement soit spécifiée dans le
+   fichier de configuration d'<productname>OpenSSL</productname>,
+   vous pouvez préciser les chiffrements à utiliser par le serveur
+   en modifiant <xref linkend="guc-ssl-ciphers"/> dans
    <filename>postgresql.conf</filename>.
   </para>
 
   <note>
    <para>
-    It is possible to have authentication without encryption overhead by
-    using <literal>NULL-SHA</literal> or <literal>NULL-MD5</literal> ciphers.  However,
-    a man-in-the-middle could read and pass communications between client
-    and server.  Also, encryption overhead is minimal compared to the
-    overhead of authentication.  For these reasons NULL ciphers are not
-    recommended.
+    Il est possible d'avoir une authentification sans le coût du chiffrement
+    en utilisant les chiffres <literal>NULL-SHA</literal> ou
+    <literal>NULL-MD5</literal> ciphers. Cependant, un «&nbsp;homme
+    du milieu&nbsp;» (<foreignphrase>man-in-the-middle</foreignphrase>)
+    pourrait lire et transmettre des communications entre client et serveur.
+    Pour ces raisons les chiffrements NULL ne sont pas recommandés.
    </para>
   </note>
   </sect2>
@@ -2472,7 +2489,7 @@ localement peuvent être différents.)
 
 <sect2 id="ssl-certificate-creation">
 +<title>Créer des certificats</title>
- 
+
  <para>
 Pour créer un certificat simple auto-signé pour le serveur, valide pour 365
 jours, utilisez la commande <productname>OpenSSL</productname> suivante, en
@@ -2497,7 +2514,7 @@ certificat signé par une autorité de certificats (<acronym>CA</acronym>)
 (habituellement un <acronym>CA</acronym> racine entreprise) devrait être
 utilisé en production.
 </para>
- 
+
 <para>
 Pour créer un certificat serveur dont l'identité peut être validé par des
 clients, créez tout d'abord une demande de signature de certificat


### PR DESCRIPTION
Traduction des nouveautés de la v11b3.
Au passage, remplacé les « huges pages » par des `<foreignphrase>huge pages</foreignphrase>`, ce qui me semble le meilleur compromis pour des termes anglais qu'on est obligés de laisser en VF.
