### PR TITLE
amcheck.xml : traduction v11bêta3 + relecture

### DIFF
--- a/postgresql/amcheck.xml
+++ b/postgresql/amcheck.xml
@@ -10,31 +10,31 @@
 
  <para>
   Le module <filename>amcheck</filename> fournit des fonctions vous permettant
-  de vérifier la cohérence logique de la structure des relations.  Si la structure
+  de vérifier la cohérence logique de la structure des relations. Si la structure
   semble valide, aucune erreur n'est levée.
  </para>
 
  <para>
-  Les fonctions vérifient diverses <emphasis>propriétés invariables</emphasis>
+  Les fonctions vérifient diverses <emphasis>propriétés invariantes</emphasis>
   dans la structure de la représentation de certains relations. La justesse des
   fonctions permettant l'accès aux données durant les parcours d'index et
-  d'autres opération importantes reposent sur le fait que ces propriétés
-  invariables soient toujours vraies.  Par exemple, certaines fonctions
+  d'autres opérations importantes reposent sur le fait que ces propriétés
+  invariantes sont toujours vraies. Par exemple, certaines fonctions
   vérifient, entre autres choses, que toutes les pages d'index B-Tree ont leurs
   éléments dans un ordre <quote>logique</quote> (par exemple, pour des index
   B-Tree sur un type  <type>text</type>, les lignes de l'index devraient être
-  triées dans l'ordre alphabétique défini par la collation).  Si, quelque soit
-  la raison,  cette propriété invariable spécifique n'est plus vérifiée, il
-  faut s'attendre à ce que des recherches binaires sur la page affectée
+  triées dans l'ordre alphabétique défini par la collation). Si, pour une
+  raison ou une autre, cette propriété invariante spécifique n'est plus vérifiée,
+  il faut s'attendre à ce que des recherches binaires sur la page affectée
   renseignent de manière erronée les parcours d'index, avec pour conséquence
-  des résultats erronnés aux requêtes SQL.
+  des résultats de requêtes SQL erronés.
  </para>
  <para>
-  La vérification est réalisée en utilisant les même précédures que celles
-  utilisées par les parcours d'index eux-même, qui peuvent très bien être du
-  code utilisateur pour une classe d'opérateur.  Par exemple, la vérification
+  La vérification est réalisée en utilisant les même procédures que celles
+  utilisées par les parcours d'index eux-mêmes, qui peuvent très bien être du
+  code utilisateur pour une classe d'opérateur. Par exemple, la vérification
   d'index B-Tree s'appuie sur les comparaisons faites avec une ou plusieurs
-  routines pour la fonction de support 1.  See <xref linkend="xindex-support"/>
+  routines pour la fonction de support 1. Voir <xref linkend="xindex-support"/>
   pour plus de détail sur les fonctions de support des classes d'opérateur.
  </para>
  <para>
@@ -56,8 +56,8 @@
 
     <listitem>
      <para>
-         <function>bt_index_check</function> que sa cible, un index B-Tree,
-      respecte une vériété de propriétés invariables.  Exemple d'utilisation :
+         <function>bt_index_check</function> vérifie que sa cible, un index B-Tree,
+      respecte un éventail de propriétés invariables. Exemple d'utilisation&nbsp;:
 <screen>
 test=# SELECT bt_index_check(index =&gt; c.oid, heapallindexed =&gt; i.indisunique),
                c.relname,
@@ -88,12 +88,12 @@ ORDER BY c.relpages DESC LIMIT 10;
 (10 rows)
 </screen>
       Cet exemple montre une session qui effectue une vérification de chacun
-      des index sur le catalogue dans la base de données <quote>test</quote>.
+      des index du catalogue dans la base de données <quote>test</quote>.
       Seul le détail des 10 plus gros index vérifiés est affiché. La
       vérification de la présence des lignes dans la table ainsi que des
       lignes dans l'index est requis uniquement pour les index d'unicité.
       Puisqu'aucune erreur n'est retournée, tous les index testés semblent
-      être cohérent au niveau logique.  Bien évidemment, cette requête
+      être cohérents au niveau logique. Bien évidemment, cette requête
       pourrait être facilement modifiée pour appeler
       <function>bt_index_check</function> sur chacun des index présents dans
       la base de données pour lesquels la vérification est supportée.
@@ -101,18 +101,18 @@ ORDER BY c.relpages DESC LIMIT 10;
      <para>
       <function>bt_index_check</function> acquiert un
       <literal>AccessShareLock</literal> sur l'index cible ainsi que sur la
-      relation à laquelle il appartient.  Ce niveau de verrouillage est le
+      relation à laquelle il appartient. Ce niveau de verrouillage est le
       même que celui acquis sur les relations lors d'une simple requête
       <literal>SELECT</literal>. <function>bt_index_check</function> ne
       vérifie pas les propriétés invariantes qui englobent les relations
       enfant/parent, mais vérifiera la présence de toutes les lignes de la
       table et des lignes d'index à l'intérieur de l'index quand
       <parameter>heapallindexed</parameter> vaut <literal>true</literal>.
-      Quand un test léger, de routine, pour détecter des problèmes de
-      corruption est nécessaire sur un environnement de production, utiliser
-      <function>bt_index_check</function> offre généfalement le meilleur
-      compromis entre la minutie de la vérification et l'impact limité sur les
-      performances de l'application ainsi que sa disponibilité.
+      Quand il faut lancer un test de recherche de corruption,
+      de routine et pas trop lourd, sur un environnement de production,
+      l'utilisation de <function>bt_index_check</function> offre généfalement
+      le meilleur compromis entre vérification minutieuse et impact
+      limité sur les performances et la disponibilité de l'application.
      </para>
     </listitem>
    </varlistentry>
@@ -136,7 +136,7 @@ ORDER BY c.relpages DESC LIMIT 10;
       <function>bt_index_parent_check</function> sont un sur-ensemble des
       vérifications réalisées par <function>bt_index_check</function>.
       On peut voir <function>bt_index_parent_check</function> comme une version
-      plus minitieuse de <function>bt_index_check</function> :
+      plus minutieuse de <function>bt_index_check</function>&bnsp;:
       contrairement à <function>bt_index_check</function>,
       <function>bt_index_parent_check</function> vérifie également les
       propriétés invariantes qui englobent les relations parent/enfant.
@@ -146,24 +146,24 @@ ORDER BY c.relpages DESC LIMIT 10;
      </para>
      <para>
       Un verrou de type <literal>ShareLock</literal> est requis sur l'index
-      ciblé par <function>bt_index_parent_check</function> (un verrou de type
+      ciblé par <function>bt_index_parent_check</function> (un
       <literal>ShareLock</literal> est également acquis sur la relation
-      associée).  Ces verrous empêchent des modifications concurrentes par des
-      commandes <command>INSERT</command>, <command>UPDATE</command>, et
-      <command>DELETE</command>  Les verrous empêchent également la relation
+      associée). Ces verrous empêchent des modifications concurrentes par des
+      commandes <command>INSERT</command>, <command>UPDATE</command> et
+      <command>DELETE</command>. Les verrous empêchent également la relation
       associée d'être traitée de manière concurrente par
-      <command>VACUUM</command>, ainsi que toute autre commande qui n'est pas
-      un ordre DML.  Il est à noter que cette fonction conserve les verrous
-      uniquement durant son exécution et non pas durant l'intégralité de la
+      <command>VACUUM</command>, ainsi que toute autre commande d'administration.
+      Il est à noter que cette fonction ne conserve les verrous
+      uniquement que durant son exécution et non pas durant l'intégralité de la
       transaction.
      </para>
      <para>
-      La vérification supplémentaire de
+      La vérification supplémentaire qu'opère
       <function>bt_index_parent_check</function> est plus apte à détecter
-      différents cas pathologiques.  Ces cas peuvent impliquer une classe
+      différents cas pathologiques. Ces cas peuvent impliquer une classe
       d'opérateur B-Tree implémentée de manière incorrecte utilisée pout
       l'index vérifié, ou, hypothétiquement, des bugs non encore découverts
-      dans le code de la méthode d'accès assocée à cet index B-Tree.  Il est à
+      dans le code de la méthode d'accès associée à cet index B-Tree. Il est à
       noter que <function>bt_index_parent_check</function> ne peut pas être
       utilisé lorsque le mode Hot Standby est activé (c'est-à-dire, sur un
       serveur secondaire disponible en lecture seule), contrairement à
@@ -175,42 +175,43 @@ ORDER BY c.relpages DESC LIMIT 10;
  </sect2>
 
  <sect2>
-  <title>Optional <parameter>heapallindexed</parameter> verification</title>
+  <title>Vérification optionnelle <parameter>heapallindexed</parameter>
+  </title>
  <para>
-  When the <parameter>heapallindexed</parameter> argument to
-  verification functions is <literal>true</literal>, an additional
-  phase of verification is performed against the table associated with
-  the target index relation.  This consists of a <quote>dummy</quote>
-  <command>CREATE INDEX</command> operation, which checks for the
-  presence of all hypothetical new index tuples against a temporary,
-  in-memory summarizing structure (this is built when needed during
-  the basic first phase of verification).  The summarizing structure
-  <quote>fingerprints</quote> every tuple found within the target
-  index.  The high level principle behind
-  <parameter>heapallindexed</parameter> verification is that a new
-  index that is equivalent to the existing, target index must only
-  have entries that can be found in the existing structure.
+  Quand l'argument <parameter>heapallindexed</parameter> des fonctions de
+  vérification est à <literal>true</literal>, une phase de vérification
+  supplémentaire est opérée sur la table associée à l'index cible.
+  Elle consiste en une opération <command>CREATE INDEX</command>
+  <quote>bidon</quote> qui vérifie la présence de tous les nouveaux
+  enregistrements hypothétiques d'index dans une structure de
+  récapitulation temporaire et en mémoire (elle est construire au besoin
+  durant la première phase de la vérification). Cette structure de
+  récapitulation prend l'<quote>empreinte digitale</quote> de chaque
+  enregistrement rencontré dans l'index cible. Le principe directeur
+  derrière la vérification <parameter>heapallindexed</parameter> est qu'un
+  nouvel index équivalent à l'index cible existant ne doit avoir que des entrées
+  que l'on peut trouver dans la structure existante.
+ </para>
+
+ <para>
+  La phase <parameter>heapallindexed</parameter> supplémentaire a un coût
+  significatif&nbsp;: typiquement, la vérification peut être plusieurs fois
+  plus longue. Cependant il n'y a pas de changement quant aux verrous acquis
+  au niveau quand on opère une vérification <parameter>heapallindexed
+  </parameter> est faite.
  </para>
  <para>
-  The additional <parameter>heapallindexed</parameter> phase adds
-  significant overhead: verification will typically take several times
-  longer.  However, there is no change to the relation-level locks
-  acquired when <parameter>heapallindexed</parameter> verification is
-  performed.
- </para>
- <para>
-  The summarizing structure is bound in size by
-  <varname>maintenance_work_mem</varname>.  In order to ensure that
-  there is no more than a 2% probability of failure to detect an
-  inconsistency for each heap tuple that should be represented in the
-  index, approximately 2 bytes of memory are needed per tuple.  As
-  less memory is made available per tuple, the probability of missing
-  an inconsistency slowly increases.  This approach limits the
-  overhead of verification significantly, while only slightly reducing
-  the probability of detecting a problem, especially for installations
-  where verification is treated as a routine maintenance task.  Any
-  single absent or malformed tuple has a new opportunity to be
-  detected with each new verification attempt.
+  La structure de récapitulation est limitée en taille par
+  <varname>maintenance_work_mem</varname>. Pour s'assurer que la probabilité de
+  rater une inconsistance ne dépasse 2&nbsp;% pour chaque enregistrement qui
+  devrait être dans l'index, il faut environ 2 octets de mémoire par
+  enregistrement. Quand moins de mémoire est disponible par enregistrement,
+  la probabilité de manquer une inconsistence augmente lentement. Cette
+  approche limite significativement le coût de la vérification, tout en
+  réduisant légèrement la probabilité de détecter un problème, particulièrement
+  sur les installations où la vérification est traitée comme un opération de
+  maintenance de routine. Tout enregistrement absent ou déformé a une nouvelles
+  chance d'être détecté avec chaque lancement de la vérification.
  </para>
 
  </sect2>
@@ -222,36 +223,36 @@ ORDER BY c.relpages DESC LIMIT 10;
   <filename>amcheck</filename> peut être efficace pour détecter différents
   types de modes d'échec que les <link
       linkend="app-initdb-data-checksums"><application>sommes de contrôle de
-  page </application></link> n'arriveront jamais à détecter.  Cela inclut :
+  page </application></link> n'arriveront jamais à détecter. Cela inclut&nbsp;:
 
   <itemizedlist>
    <listitem>
     <para>
-     Les incohérences structurelles causée par des implémentations incorrectes
+     Les incohérences dans la structure causées par des implémentations incorrectes
      de classe d"opérateur.
     </para>
     <para>
      Cela inclue également des problèmes causés par le changement des règles de
-     comparaison des collations du système d'exploitation.  Les comparaisons
+     comparaison des collations du système d'exploitation. Les comparaisons
      des données d'un type ayant une collation comme <type>text</type> doivent
      être immuables (tout comme toutes les autres comparaisons utilisées pour
      les parcours d'index B-Tree doivent être immuables), ce qui implique que
-     les règles de collation du système d'exploitation ne dois jamais changer.
+     les règles de collation du système d'exploitation ne doivent jamais changer.
      Bien que cela soit rare, des mises à jour des règles des collations du
-     système d'exploitation peuvent causer ces problèmes.  Plus généralement,
+     système d'exploitation peuvent causer ces problèmes. Plus généralement,
      une incohérence dans l'ordre de collation entre un serveur primaire et son
      réplicat est impliqué, peut-être parce que la version
-     <emphasis>major</emphasis> du système d'exploitation utilisée était
-     incohérente.  De telles incohérences ne surviendront généralement que sur
-     des serveur secondaires, et ne pourront par conséquent être détectées que
-     sur des serveurs secondaires.
+     <emphasis>majeure</emphasis> du système d'exploitation utilisée est
+     incohérente. De telles incohérences ne surviendront généralement que sur
+     des serveurs secondaires, et ne pourront par conséquent être détectées que
+     là.
     </para>
     <para>
-     Si un tel problème survient, il se peut que cela n'affecte par
-     individuellement chaque index qui utilise le tri d'une collation affectée,
-     tout simplement car les valeurs <emphasis>indexée</emphasis> pourraient
+     Si un tel problème survient, il se peut que cela n'affecte pas
+     chaque index qui utilise le tri d'une collation affectée,
+     tout simplement car les valeurs <emphasis>indexées</emphasis> pourraient
      avoir le même ordre de tri absolu indépendamment des incohérences
-     comportementales.  Voir
+     comportementales. Voir
      <xref linkend="locale"/> et <xref linkend="collation"/> pour plus de
      détails sur comment <productname>PostgreSQL</productname> utilise les
      locales et collations du système d'exploitation.
@@ -259,65 +260,66 @@ ORDER BY c.relpages DESC LIMIT 10;
    </listitem>
    <listitem>
     <para>
-     Des incohérences dans la structure entre les index et les tables indexées
-     (lors que la vérification <parameter>heapallindexed</parameter> est
+     Les incohérences dans la structure entre les index et les tables indexées
+     (lorsque la vérification <parameter>heapallindexed</parameter> est
      réalisée).
     </para>
     <para>
      Il n'y a pas de vérification avec la table initiale en temps normal. Les
-     symptômes d'une corrution de la table peuvent être subtils.
+     symptômes d'une corruption de la table peuvent être subtils.
     </para>
    </listitem>
    <listitem>
      <para>
-     Une corruption causée par un hypothétique bug non encore découvert dans
-     l'implémentation associée à la méthode d'accès, au code effectuant le
-     tri ou à la gestion transactionnelle.
+     La corruption causée par un hypothétique bug non encore découvert dans
+     le code de la méthode d'accès dans PostgreSQL, dans le code effectuant le
+     tri ou le code de gestion transactionnelle.
     </para>
     <para>
      La vérification automatique de l'intégrité structurelle des index joue un
-     rôle sur les principaux tests des fonctionnalités nouvelles ou proposées
-     dans <productname>PostgreSQL</productname> qui pourraient possiblement
-     autoriser l'introduction d'incohérence logiques. La vérification de la
+     rôle dans les tests généraux des fonctionnalités de
+     <productname>PostgreSQL</productname>, nouvelles ou proposées,
+     qui pourraient possiblement permettre l'introduction d'incohérences
+     logiques. La vérification de la
      structure de la table et des informations de visibilité et de statut des
      transactions associées joue un rôle similaire. Une stratégie de test
      évidente est d'appeler les fonctions d'<filename>amcheck</filename> de
      manière continue en même temps que les tests de régression standard sont
-     lancés.  Voir <xref
-     linkend="regress-run"/> pour plus de détail sur commencer lancer les
+     lancés. Voir <xref
+     linkend="regress-run"/> pour plus de détails sur commencer lancer les
     tests.
     </para>
    </listitem>
    <listitem>
     <para>
-     Les défauts du système de fichiers ou du sous système de stockage quand
-     les vérifications des sommes de contrôles ne sont pas activées.
+     Les failles dans le système de fichiers ou dans le sous-système de stockage
+     quand les sommes de contrôles ne sont pas activées.
     </para>
     <para>
-     Il est à noter que <filename>amcheck</filename> examine les pages telles
-     que représentées dans des tampons en mémoire partagée au moment de la
-     vérification s'il y a seulement un accès en mémoire partagée lors de
-     l'accès au bloc.  Par conséquent, <filename>amcheck</filename> n'examine
+     Il est à noter que <filename>amcheck</filename> n'examine une page que
+     telle qu'elle se présente dans un tampon en mémoire partagée lors de la
+     vérification, et qu'en accédant au bloc dans la mémoire partagée.
+     Par conséquent, <filename>amcheck</filename> n'examine
      pas forcément les données lues depuis le système de fichiers au moment de
-     la vérification.  De plus, quand les sommes de contrôles sont activées,
+     la vérification. Notez que si les sommes de contrôles sont activées,
      <filename>amcheck</filename> peut lever une erreur de somme de contrôle
-     incorrecte quand un block corrompu est lu vers un tampon.
+     incorrecte quand un bloc corrompu est lu vers un tampon.
     </para>
    </listitem>
    <listitem>
     <para>
-     Les corruptions causée par une mémoire RAM défaillante, et plus largement
-     le sous système mémoire ainsi que le système d'exploitation.
+     Les corruptions causée par une RAM défaillante, et plus largement
+     le sous-système mémoire et le système d'exploitation.
     </para>
     <para>
      <productname>PostgreSQL</productname> ne protège pas contre les erreurs
-     mémoire corrigibles et il est supposé que vous utilisez de la mémoire RAM
-     utilisant le standard de l'instrie Error Correcting Codes (ECC) ou une
-     meilleure protection.  Cependant, la mémoire ECC est typiquement immunisée
-     uniquement contre les erreurs d'un seul bit, et il ne faut pas partir du
-     principe que ce type de mémoire fournit une protection
-     <emphasis>absolue</emphasis> contre les défaillances résultant en une
-     corruption mémoire.
+     mémoire corrigibles, et il est supposé que vous utilisez de la mémoire RAM
+     de standard industriel ECC (<foreignphrase>Error Correcting Codes
+ </foreignphrase>) ou avec une meilleure protection. Cependant, la mémoire ECC
+     n'est typiquement immunisée que contre les erreurs d'un seul bit, et il
+     ne faut pas partir du principe que ce type de mémoire fournit une protection
+     <emphasis>absolue</emphasis> contre les défaillances provoquant une
+     corruption de la mémoire.
     </para>
     <para>
      Quand la vérification <parameter>heapallindexed</parameter> est réalisée,
@@ -328,7 +330,7 @@ ORDER BY c.relpages DESC LIMIT 10;
    </listitem>
   </itemizedlist>
   De manière générale, <filename>amcheck</filename> ne peut que prouver la
-  présence d'une corruption; il ne peut pas en prouver l'absence.
+  présence d'une corruption&nbsp;; il ne peut pas en prouver l'absence.
  </para>
 
  </sect2>
@@ -344,12 +346,11 @@ ORDER BY c.relpages DESC LIMIT 10;
  </para>
  <para>
   Il n'y a pas de méthode générale pour réparer les problèmes que
-  <filename>amcheck</filename> détecte.  Une explication de la cause principale
-  menant à ce que la propriété invariable soit violée devrait être étudiée.
-  <xref linkend="pageinspect"/> pourrait jouer un rôle utile dans le
-  diagnostique de la corruption qu'<filename>amcheck</filename> détecte.  Un
-  <command>REINDEX</command> pourrait ne pas être efficace pour réparer la
-  corruption.
+  <filename>amcheck</filename> détecte. Une explication de la cause principale
+  menant à ce que la propriété invariante soit violée devrait être étudiée.
+  <xref linkend="pageinspect"/> peut jouer un rôle utile dans le
+  diagnostic de la corruption qu'<filename>amcheck</filename> détecte. Un
+  <command>REINDEX</command> peut échouer à réparer la corruption.
  </para>
 
  </sect2>


### PR DESCRIPTION
Traduction du texte nouveau en v11ß3

Relecture complète, avec correction d'erreurs de frappe, quelques espaces en trop et &nbsp; manquants, et quelques tentatives d'allègement de formulation.

J'ai remplacé "invariable" par "invariant", le premier m'évoquant trop la grammaire et le second plus les maths.