### PR TITLE
installation.xml - traduction et relecture complète

### DIFF
--- a/postgresql/installation.xml
+++ b/postgresql/installation.xml
@@ -76,7 +76,7 @@ su - postgres
       Il est nécessaire d'avoir un compilateur C
       <acronym>ISO</acronym>/<acronym>ANSI</acronym> (au minimum compatible
       avec C89). Une version récente de
-      <productname>GCC</productname> est recommandée mais
+      <productname>GCC</productname> est recommandée, mais
       <productname>PostgreSQL</productname> est connu pour être compilable avec de
       nombreux compilateurs de divers vendeurs.
      </para>
@@ -103,11 +103,11 @@ su - postgres
       utilisée par défaut. Elle permet à <application>psql</application>
       (l'interpréteur de ligne de commandes SQL de PostgreSQL) de se souvenir de
       chaque commande saisie, et permet d'utiliser les touches
-      de flêches pour rappeler et éditer les commandes précédentes. C'est très
+      de flèches pour rappeler et éditer les commandes précédentes. C'est très
       pratique et fortement recommandé. Pour ne pas l'utiliser, il
       faut préciser <option>--without-readline</option> au moment de l'exécution
       de la commande <filename>configure</filename>. Une alternative possible est
-      l'utilisation de la bibliothèqe <filename>libedit</filename> sous license
+      l'utilisation de la bibliothèque <filename>libedit</filename> sous licence
       BSD, développée au début sur <productname>NetBSD</productname>. La
       bibliothèque <filename>libedit</filename> est compatible
       GNU <productname>Readline</productname> et est utilisée si cette dernière
@@ -197,7 +197,7 @@ su - postgres
       <indexterm><primary>libpython</primary></indexterm>
       <filename>libpython</filename> doit l'être aussi sur la plupart des
       plateformes. Ce n'est pas le cas des installations par défaut de
-      <productname>Python</productname> construits à partir des sources mais
+      <productname>Python</productname> construits à partir des sources mais,
       une bibliothèque partagée est disponible dans de nombreuses
       distributions de systèmes d'exploitation. <filename>configure</filename>
       échouera si la construction de <application>PL/Python</application> est
@@ -226,7 +226,7 @@ su - postgres
       permet d'afficher les messages d'un programme dans une langue autre que l'anglais,
       une implantation de l'<acronym>API</acronym>
       <application>Gettext</application> est nécessaire. Certains systèmes d'exploitation
-      l'intégrent (par exemple, <systemitem class="osname">Linux</systemitem>,
+      l'intègrent (par exemple, <systemitem class="osname">Linux</systemitem>,
       <systemitem class="osname">NetBSD</systemitem>,
       <systemitem class="osname">Solaris</systemitem>). Pour les autres systèmes,
       un paquet additionnel peut être téléchargé sur <ulink
@@ -381,10 +381,10 @@ su - postgres
     fichiers dans l'arborescence de compilation pour enregistrer ce qui a été
     trouvé. <filename>configure</filename> peut aussi être exécuté à
     partir d'un répertoire hors de l'arborescence des sources pour
-    conserver l'arborescence de compilation séparé. Cette procédure est aussi
-    appelé  une construction a
+    conserver l'arborescence de compilation séparée. Cette procédure est aussi
+    appelée une construction de type
     <indexterm><primary>VPATH</primary></indexterm><firstterm>VPATH</firstterm>
-    build. Voici comment la faire&nbsp;:
+    Voici comment la faire&nbsp;:
 <screen>
 <userinput>mkdir build_dir</userinput>
 <userinput>cd build_dir</userinput>
@@ -421,7 +421,7 @@ su - postgres
        Pour satisfaire des besoins spécifiques, les sous-répertoires peuvent
        être personnalisés à l'aide des options qui suivent.
        Toutefois, en laissant les options par défaut, l'installation est
-       déplaçable, ce qui signifie que le réperoire peut être déplacé après
+       déplaçable, ce qui signifie que le répertoire peut être déplacé après
        installation. (Cela n'affecte pas les emplacements de
        <literal>man</literal> et <literal>doc</literal>.)
       </para>
@@ -441,10 +441,10 @@ su - postgres
       <para>
        Les fichiers qui dépendent de l'architecture peuvent être installés dans
        un répertoire différent, <replaceable>EXEC-PREFIX</replaceable>, de celui donné
-       par <replaceable>PREFIX</replaceable>. Ce qui peut être utile pour partager
-       les fichiers dépendant de l'architecture entre plusieurs machines.
+       par <replaceable>PREFIX</replaceable>. Cela peut être utile pour partager
+       les fichiers indépendant de l'architecture entre plusieurs machines.
        S'il est omis, <replaceable>EXEC-PREFIX</replaceable> est égal à
-       <replaceable>PREFIX</replaceable> et les fichiers dépendant seront installés
+       <replaceable>PREFIX</replaceable> et les fichiers dépendants seront installés
        sous la même arborescence que les fichiers indépendants de
        l'architecture, ce qui est probablement le but recherché.
       </para>
@@ -604,10 +604,10 @@ su - postgres
      <listitem>
       <para>
        Ajoute <replaceable>STRING</replaceable> au numéro de version de
-       PostgreSQL.  Cela peut être utilisé, par exmeple, pour marquer des
+       PostgreSQL. Cela peut être utilisé, par exemple, pour marquer des
        binaires compilés depuis des instantanés Git ne faisant pas encore
        partie d'une version officielle ou contenant des patchs particuliers
-       avec une chaînes de texte supplémentaire telle qu'un identifiant
+       avec une chaîne de texte supplémentaire telle qu'un identifiant
        <command>git describe</command> ou un numéro de version d'un paquet
        d'une distribution.
       </para>
@@ -619,10 +619,10 @@ su - postgres
      <listitem>
       <para>
        <replaceable>REPERTOIRES</replaceable> est une liste de répertoires séparés par
-       des caractères deux points (:) qui sera ajoutée à la liste de recherche
-       des fichiers d'en-tête. Si vous avez des paquetages optionnels (tels
+       le caractère deux points (<literal>:</literal>) qui sera ajoutée à la liste de recherche
+       des fichiers d'en-tête du compilateur. Si vous avez des paquetages optionnels (tels
        que <application>Readline</application> GNU) installés dans des répertoires non
-       conventionnels, vous pouvez utiliser cette option et certainement
+       conventionnels, vous devez utiliser cette option et probablement aussi 
        l'option <option>--with-libraries</option> correspondante.
       </para>
       <para>
@@ -637,9 +637,9 @@ su - postgres
      <listitem>
       <para>
        <replaceable>REPERTOIRES</replaceable> est une liste de recherche de répertoires
-       de bibliothèques séparés par des caractères deux points (:).
+       de bibliothèques séparés par le caractère deux points (<literal>:</literal>).
        Si des paquets sont installés dans des répertoires non conventionnels,
-       il peut s'avérer nécessaire d'utiliser cette option (et l'option correspondante
+       il peut s'avérer nécessaire d'utiliser cette option (ainsi que l'option correspondante
        <option>--with-includes</option>).
       </para>
       <para>
@@ -653,10 +653,10 @@ su - postgres
      <listitem>
       <para>
        Permet de mettre en place le support des langues natives
-       (<acronym>NLS</acronym>). C'est la possibilité d'afficher les messages
-       des programmes dans une langue autre que l'anglais.
-       <replaceable>LANGUES</replaceable> est une liste, optionnelle, des codes
-       des langues que vous voulez supporter séparés par un espace. Par
+       (<acronym>NLS</acronym>). C'est la capacité d'afficher les messages
+       d'un programme dans une langue autre que l'anglais.
+       <replaceable>LANGUES</replaceable> est une liste optionnelle des codes
+       de langue que vous voulez supporter séparés par un espace. Par
        exemple, <literal>--enable-nls='de fr'</literal> (l'intersection entre la
        liste et l'ensemble des langues traduites actuellement sera calculée
        automatiquement). En l'absence de liste, toutes les
@@ -676,10 +676,10 @@ su - postgres
       <para>
        Positionne <replaceable>NUMERO</replaceable> comme numéro de port par défaut
        pour le serveur et les clients. La valeur par défaut est 5432. Le port
-       peut toujours être changé ultérieurement mais, précisé ici,
+       peut toujours être modifié ultérieurement mais, s'il est précisé ici,
        les exécutables du serveur et des clients auront la même valeur
        par défaut, ce qui est vraiment très pratique. Habituellement, la
-       seule bonne raison de choisir une valeur autre que celle par défaut
+       seule bonne raison de choisir une autre valeur que celle par défaut
        est l'exécution de plusieurs serveurs
        <productname>PostgreSQL</productname> sur la même machine.
       </para>
@@ -721,8 +721,8 @@ su - postgres
        Tcl installe les fichiers <filename>tclConfig.sh</filename>, contenant
        certaines informations de configuration nécessaires pour compiler le
        module d'interfaçage avec Tcl. Ce fichier est trouvé automatiquement
-       mais, si pour utiliser une version différente de Tcl, il faut indiquer le répertoire où
-       le trouver.
+       mais pour utiliser une version différente de Tcl, il faut indiquer le répertoire dans lequel il
+       se trouve.
       </para>
      </listitem>
     </varlistentry>
@@ -731,14 +731,14 @@ su - postgres
      <term><option>--with-gssapi</option></term>
      <listitem>
       <para>
-       Construire avec le support de l'authentification GSSAPI. Sur de
+       Permet la compilation avec le support de l'authentification GSSAPI. Sur de
        nombreux systèmes, GSSAPI (qui fait habituellement partie d'une
        installation Kerberos) n'est pas installé dans un emplacement
        recherché par défaut (c'est-à-dire <filename>/usr/include</filename>,
        <filename>/usr/lib</filename>), donc vous devez utiliser les options
        <option>--with-includes</option> et <option>--with-libraries</option>
        en plus de cette option. <filename>configure</filename> vérifiera les
-       fichiers d'en-têtes nécessaires et les bibliothèques pour s'assurer
+       fichiers d'en-tête et les bibliothèques nécessaires pour s'assurer
        que votre installation GSSAPI est suffisante avant de continuer.
       </para>
      </listitem>
@@ -761,33 +761,33 @@ su - postgres
      <term><option>--with-llvm</option></term>
      <listitem>
       <para>
-       Build with support for <productname>LLVM</productname> based
-       <acronym>JIT</acronym> compilation<phrase
+       Permet la compilation avec le support de <acronym>JIT</acronym> basée sur 
+       <productname>LLVM</productname><phrase
        condition="standalone-ignore"> (see <xref
-       linkend="jit"/>)</phrase>.  This
-       requires the <productname>LLVM</productname> library to be installed.
-       The minimum required version of <productname>LLVM</productname> is
-       currently 3.9.
+       linkend="jit"/>)</phrase>.  Ceci 
+       nécessite l'installation de la bibliothèque <productname>LLVM</productname>. La version 
+       minimale requise de <productname>LLVM</productname> est 
+       actuellement la 3.9.
       </para>
       <para>
        <command>llvm-config</command><indexterm><primary>llvm-config</primary></indexterm>
-       will be used to find the required compilation options.
-       <command>llvm-config</command>, and then
-       <command>llvm-config-$major-$minor</command> for all supported
-       versions, will be searched on <envar>PATH</envar>. If that would not
-       yield the correct binary, use <envar>LLVM_CONFIG</envar> to specify a
-       path to the correct <command>llvm-config</command>. For example
+       sera utilisé pour trouver les options de compilation requises.
+       <command>llvm-config</command>, puis 
+       <command>llvm-config-$major-$minor</command> pour toutes les version supportées,
+       seront recherché dans <envar>PATH</envar>. Dans le cas où les bons 
+       binaires ne sont pas trouvés, il faut utiliser la variable <envar>LLVM_CONFIG</envar> afin de spécifier le 
+       chemin à <command>llvm-config</command>. Exemple&nbsp;:
 <programlisting>
 ./configure ... --with-llvm LLVM_CONFIG='/path/to/llvm/bin/llvm-config'
 </programlisting>
       </para>
 
       <para>
-       <productname>LLVM</productname> support requires a compatible
-       <command>clang</command> compiler (specified, if necessary, using the
-       <envar>CLANG</envar> environment variable), and a working C++
-       compiler (specified, if necessary, using the <envar>CXX</envar>
-       environment variable).
+       Le support de <productname>LLVM</productname> nécessite un compilateur 
+       <command>clang</command> compatible (qui peut être spécifié, si nécessaire, en utilisant la variable d'environnement 
+       <envar>CLANG</envar>, et un compilateur C++
+       fonctionnel (qui peut être spécifié, si nécessaire, en utilisant la variable d'environnement 
+       <envar>CXX</envar>).
       </para>
      </listitem>
     </varlistentry>
@@ -1057,7 +1057,7 @@ su - postgres
      <term><option>--with-segsize=<replaceable>TAILLESEG</replaceable></option></term>
      <listitem>
       <para>
-       Indique la <firstterm>taille d'un segment</firstterm>, en gigaoctets.
+       Indique la <firstterm>taille d'un segment</firstterm>, en gigaoctets. La valeur par défaut est de 1 gigaoctet, valeur considérée comme sûre pour toutes les plateformes prises en charge.
        Les grandes tables sont divisées en plusieurs fichiers du système
        d'exploitation, chacun de taille égale à la taille de segment.
        Cela évite les problèmes avec les limites de tailles de fichiers qui
@@ -1073,7 +1073,7 @@ su - postgres
        tels que <application>tar</application>, pourraient aussi limiter la
        taille maximum utilisable pour un fichier.
        Il est recommandé, même si pas vraiment nécessaire, que cette valeur
-       soit un multiple de 2.
+       soit une puissance de 2.
        Notez que changer cette valeur impose de faire un initdb.
       </para>
      </listitem>
@@ -1086,7 +1086,7 @@ su - postgres
        Indique la <firstterm>taille d'un bloc</firstterm>, en kilooctets. C'est
        l'unité de stockage et d'entrée/sortie dans les tables. La valeur
        par défaut, 8 kilooctets, est appropriée pour la plupart des cas&nbsp;;
-       mais d'autres valeurs peuvent être utilises dans des cas spéciaux.
+       mais d'autres valeurs peuvent être utilisées dans des cas particuliers.
        Cette valeur doit être une puissance de 2 entre 1 et 32 (kilooctets).
        Notez que changer cette valeur impose de faire un initdb.
       </para>
@@ -1100,8 +1100,8 @@ su - postgres
        Indique la <firstterm>taille d'un bloc WAL</firstterm>, en kilooctets. C'est
        l'unité de stockage et d'entrée/sortie dans le journal des transactions. La valeur
        par défaut, 8 kilooctets, est appropriée pour la plupart des cas&nbsp;;
-       mais d'autres valeurs peuvent être utilises dans des cas spéciaux.
-       La valeur doit être une puissance de 2 entre 1 et 1024 (kilooctets).
+       mais d'autres valeurs peuvent être utilises dans des cas particuliers.
+       La valeur doit être une puissance de 2 comprise entre 1 et 64 (kilooctets).
       </para>
      </listitem>
     </varlistentry>
@@ -1147,10 +1147,10 @@ su - postgres
      <term><option>--disable-thread-safety</option></term>
      <listitem>
       <para>
-       Désactive la sûreté des threads pour les bibliothèques clients. Ceci
+       Désactive la sécurité des threads pour les bibliothèques clients. Ceci
        empêche les threads concurrents dans les programmes
        <application>libpq</application> et <application>ECPG</application>
-       de contrôler avec sûreté leur pointeurs de connexion privés.
+       de contrôler en toute sécurité leurs pointeurs de connexion privés.
       </para>
      </listitem>
     </varlistentry>
@@ -1173,7 +1173,7 @@ su - postgres
        redondant de l'installer une nouvelle fois. Quand cette option est
        utilisée, la base des fuseaux horaires, fournie par le système, dans
        <replaceable>RÉPERTOIRE</replaceable> est utilisée à la place de celle
-       inclus dans la distribution des sources de PostgreSQL.
+       incluse dans la distribution des sources de PostgreSQL.
        <replaceable>RÉPERTOIRE</replaceable> doit être indiqué avec un chemin
        absolu. <filename>/usr/share/zoneinfo</filename> est un répertoire
        très probable sur certains systèmes d'exploitation. Notez que la routine
@@ -1194,7 +1194,7 @@ su - postgres
        horaires changent. Un autre avantage est que PostgreSQL peut être
        cross-compilé<indexterm><primary>cross compilation</primary></indexterm>
        plus simplement si les fichiers des fuseaux horaires n'ont pas besoin
-       d'être construit lors de l'installation.
+       d'être construits lors de l'installation.
       </para>
      </listitem>
     </varlistentry>
@@ -1256,7 +1256,7 @@ su - postgres
        sont compilés pour qu'elles puissent être profilées. À la sortie du
        processus serveur, un sous-répertoire sera créé pour contenir le
        fichier <filename>gmon.out</filename> à utiliser pour le profilage.
-       Cette option est à utiliser seulement avec GCC lors d'un développement.
+       Cette option est à utiliser uniquement avec GCC lors d'un développement.
       </para>
      </listitem>
     </varlistentry>
@@ -1362,7 +1362,7 @@ su - postgres
     </para>
 
     <para>
-    Voici une liste des variables importantes qui sont configurables de cete
+    Voici une liste des variables importantes qui sont configurables de cette
     façon&nbsp;:
     </para>
 
@@ -1399,8 +1399,8 @@ su - postgres
        <term><envar>CLANG</envar></term>
        <listitem>
         <para>
-         path to <command>clang</command> program used to process source code
-         for inlining when compiling with <literal>--with-llvm</literal>
+         chemin vers le programme <command>clang</command> utilisé pour l'optimisation inlining du code source 
+         lors de la compilation avec <literal>--with-llvm</literal>
         </para>
        </listitem>
       </varlistentry>
@@ -1534,7 +1534,7 @@ su - postgres
          chemin complet vers l'interpréteur Python. Il sera utilisé pour
          déterminer les dépendances pour la construction de PL/Python. De
          plus, si Python 2 ou 3 est spécifié ici (ou implicitement choisi), il
-         détermine la variante de PL/Python qui devient disponible. Voir
+         détermine la variante de PL/Python qui devient disponible.
          Voir <xref linkend="regress-tap"/>
          pour plus d'informations.
         </para>
@@ -1562,7 +1562,7 @@ su - postgres
     </para>
 
     <para>
-    Voici une liste des variables importantes qui sont configurables de cete
+    Voici une liste des variables importantes qui sont configurables de cette
     façon&nbsp;:
     </para>
 
@@ -1727,12 +1727,12 @@ su - postgres
     </para>
 
     <para>
-     Parfois, il est utile d'ajouter des options de compilation à l'ensemble
+     Il est parfois utile d'ajouter des options de compilation à l'ensemble
      choisi par <filename>configure</filename> après coup. Un exemple parlant
      concerne l'option <option>-Werror</option> de
      <application>gcc</application> qui ne peut pas être incluse dans la
      variable <envar>CFLAGS</envar> passée à <filename>configure</filename>,
-     car il cassera un ggrand nombre de tests internes de
+     car il cassera un grand nombre de tests internes de
      <filename>configure</filename>. Pour ajouter de telles options, incluez-
      les dans la variable d'environnement <envar>COPT</envar> lors de
      l'exécution de <filename>gmake</filename>. Le contenu de
@@ -1755,7 +1755,7 @@ su - postgres
       d'utiliser les options <option>--enable-cassert</option> (qui active
       un grand nombre de vérifications d'erreur à l'exécution) et
        <option>--enable-debug</option> (qui améliore l'utilité des outils
-       de débuggage) de configure.
+       de débogage) de configure.
      </para>
 
      <para>
@@ -1764,8 +1764,8 @@ su - postgres
       toute optimisation (<option>-O0</option>) désactive aussi certains
       messages importants du compilateur (comme l'utilisation de variables
       non initialisées). Néanmoins, les niveaux d'optimisations peuvent
-      compliquer le débuggage parce que faire du pas à pas sur le code
-      compilé ne correspondra pas forcément aux lignes de code une à une.
+      compliquer le débuggage parce que faire du pas-à-pas sur le code
+      compilé ne correspondra pas forcément aux lignes de code une-à-une.
       Si vous avez du mal à débugger du code optimisé, recompilez les fichiers
       intéressants avec <option>-O0</option>. Une façon simple de le faire est
       de passer une option à <application>make</application>:
@@ -1853,7 +1853,7 @@ PostgreSQL, contrib, and documentation successfully made. Ready to install.
     l'<xref linkend="configure"/>. Assurez-vous d'avoir les droits appropriés
     pour écrire dans ces répertoires. Normalement, vous avez besoin d'être
     superutilisateur pour cette étape. Une alternative consiste à créer les
-    répertoires cibles à l'avance et à leur donner les droits appropriées.
+    répertoires cibles à l'avance et à leur donner les droits appropriés.
    </para>
 
    <para>
@@ -1887,10 +1887,10 @@ PostgreSQL, contrib, and documentation successfully made. Ready to install.
   <para>
    L'installation standard fournit seulement les fichiers en-têtes nécessaires
    pour le développement d'applications clientes ainsi que pour le développement
-   de programmes côté serveur comme des fonction personnelles ou des
+   de programmes côté serveur comme des fonctions personnelles ou des
    types de données écrits en C (avant <productname>PostgreSQL</productname> 8.0, une
    commande <literal>make install-all-headers</literal> séparée était nécessaire pour
-   ce dernier point mais cette étape a été intégrée à l'installation standard).
+   ce dernier point, mais cette étape a été intégrée à l'installation standard).
   </para>
 
   <formalpara>
@@ -2089,9 +2089,9 @@ export MANPATH</programlisting>
    Une plateforme (c'est-à-dire une combinaison d'un processeur et d'un système
    d'exploitation) est considérée supportée par la communauté de développeur de
    <productname>PostgreSQL</productname> si le code permet le fonctionnement
-   sur cette plateforme et que la construction et les tests de regréssion
+   sur cette plateforme et que la construction et les tests de régression
    ont été récemment vérifiés sur cette plateforme. Actuellement, la plupart
-   des tests de compatibilité de plateforme se fait automatiquement par des
+   des tests de compatibilité de plateforme se font automatiquement par des
    machines de tests dans la <ulink
    url="https://buildfarm.postgresql.org/">ferme de construction de
    PostgreSQL</ulink>. Si vous êtes intéressés par l'utilisation de
@@ -2110,14 +2110,14 @@ export MANPATH</programlisting>
    architectures n'ont pas été testées récemment à notre connaissance. Il est
    souvent possible de construire <productname>PostgreSQL</productname> sur
    un type de processeur non supporté en précisant
-   <option>--disable-spinlocks</option>. Cependant, les performance en
+   <option>--disable-spinlocks</option>. Cependant, les performances en
    souffriront.
   </para>
 
   <para>
    <productname>PostgreSQL</productname> doit fonctionner sur les systèmes
    d'exploitation suivants&nbsp;: Linux (toutes les distributions récentes),
-   Windows (Win2000 SP4 et ultérieure), FreeBSD, OpenBSD, NetBSD, macOS,
+   Windows (Win2000 SP4 et ultérieures), FreeBSD, OpenBSD, NetBSD, macOS,
    AIX, HP/UX et Solaris. D'autres systèmes style
    Unix peuvent aussi fonctionner mais n'ont pas été récemment testés. Dans
    la plupart des cas, toutes les architectures processeurs supportées par
@@ -2231,7 +2231,7 @@ export MANPATH</programlisting>
      Vous voudrez utiliser une version de GCC supérieure à 3.3.2, en particulier
      si vous utilisez une version pré-packagée. Nous avons eu de bons résultats
      avec la 4.0.1. Les problèmes avec les versions précédentes semblent être
-     davantage liées à la façon dont IBM a packagé GCC qu'à des problèmes
+     davantage liés à la façon dont IBM a packagé GCC qu'à des problèmes
      réels, avec GCC, ce qui fait que si vous compilez GCC vous-même, vous
      pourriez réussir avec une version plus ancienne de GCC.
     </para>
@@ -2271,7 +2271,7 @@ export MANPATH</programlisting>
      dans <filename>pg_hba.conf</filename>, etc. Les anciennes versions d'AIX
      ont quelques bogues dans cette fonction. Si vous avez des problèmes relatifs
      à ces paramètres, la mise à jour vers le niveau de correctif AIX approprié
-     indiqué ci-dessus pourrait se charger de cela.
+     indiqué ci-dessus devrait résoudre cela.
     </para>
 
     <!-- https://archives.postgresql.org/message-id/6064jt6cfm.fsf_-_@dba2.int.libertyrms.com -->
@@ -2411,10 +2411,10 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
      <literal>LDFLAGS="-Wl,-bbigtoc"</literal> à <command>configure</command>.
      (Les options pour <command>xlc</command> pourraient différer.) Si vous omettez
      les exports de <envar>OBJECT_MODE</envar>, votre compilation échouera avec
-     des erreurs de l'éditeur de liens. Quand <envar>OBJECT_MODE</envar> est
+     des erreurs de l'éditeur de liens. Lorsque <envar>OBJECT_MODE</envar> est
      positionné, il indique aux outils de compilation d'AIX comme
      <command>ar</command>, <command>as</command> et
-     <command>ld</command> quel types de fichiers manipuler par défaut.
+     <command>ld</command> quel types de fichiers à manipuler par défaut.
     </para>
 
     <para>
@@ -2570,7 +2570,7 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
        peuvent générer des échecs de tests de régression aléatoires en raison
        d'un dépassement de capacité de la file d'attente de <function>listen()</function>
        qui cause des erreurs de connexion refusée ou des blocages. Vous pouvez
-       limiter le nombre de connexion en utilisant la variable de make
+       limiter le nombre de connexions en utilisant la variable de make
        <varname>MAX_CONNECTIONS</varname> comme ceci&nbsp;:
        <programlisting>
 make MAX_CONNECTIONS=5 check
@@ -2688,7 +2688,7 @@ make MAX_CONNECTIONS=5 check
 
    <para>
     PostgreSQL pour Windows peut être compilé en utilisant MinGW, un environnement
-    de compilation similaire à Unix pour les systèmes d'exploitation
+    de compilation similaire à celui disponible sous Unix pour les systèmes d'exploitation
     Microsoft, ou en utilisant la suite de compilation
     <productname>Visual C++</productname> de Microsoft.
     La variante de compilation MinGW utilise le système de compilation normal
@@ -2700,12 +2700,12 @@ make MAX_CONNECTIONS=5 check
    </para>
 
    <para>
-    Le port natif Windows requiert un système Microsoft 200 ou ultérieurs,
-    32 bits ou 64 bits. Les systèmes plus anciens n'ont pas l'infrastructure
+    Le port natif Windows requiert une version 32 ou 64 bits de Windows 2000 ou ultérieurs.
+    Les systèmes d'exploitation antérieurs n'ont pas l'infrastructure
     nécessaire (mais Cygwin peut être utilisé pour ceux-ci). MinGW, le système
     de compilation similaire à Unix, et MSYS, une suite d'outils Unix nécessaires
     pour exécuter des scripts shell tels que <command>configure</command>, peuvent
-    être téléchargés de <ulink url="http://www.mingw.org/"></ulink>. Aucun
+    être téléchargés à partir de <ulink url="http://www.mingw.org/"></ulink>. Aucun
     de ces outils n'est nécessaire pour exécuter les binaires générés&nbsp;;
     ils ne sont nécessaires que pour créer les binaires.
    </para>
@@ -2732,10 +2732,10 @@ make MAX_CONNECTIONS=5 check
      <productname>minidumps</productname> qui peuvent être utilisés pour dépister la cause du plantage&nbsp;;
      ils sont semblables aux core dumps d'Unix. Vous pouvez lire ces dumps avec
      <productname>Windows Debugger Tools</productname> ou avec
-     <productname>Visual Studio</productname>. Pour permettre la génération des dumps sous Windows, crééz un
+     <productname>Visual Studio</productname>. Pour permettre la génération des dumps sous Windows, créez un
      sous-répertoire nommé <filename>crashdumps</filename>
      dans le répertoire des données du cluster. Ainsi les dumps seront écrits dans ce répertoire
-     avec un nom unique généré à partir de l'identifiant du process planté et le moment du plantage.
+     avec un nom unique généré à partir de l'identifiant du processus planté et du moment du plantage.
     </para>
    </sect3>
   </sect2>


### PR DESCRIPTION
- Traduction des ajouts de la version 11 beta 3
- Corrections orthographiques
- Correction erreur de valeur max de "--with-wal-blocksize" : passage de 1024 à 64
- Ajout d'une phrase absente de la traduction "The default segment size, 1 gigabyte, is safe on all supported platforms."