### PR TITLE
pgbench.xml - relecture et corrections mineures

### DIFF
--- a/postgresql/ref/pgbench.xml
+++ b/postgresql/ref/pgbench.xml
@@ -36,7 +36,7 @@
   <title>Description</title>
  <para>
   <application>pgbench</application> est un programme pour réaliser simplement des
-  tests de performances (<foreignphrase>benchmark</foreignphrase>)
+  tests de performance (<foreignphrase>benchmark</foreignphrase>)
   sur <productname>PostgreSQL</productname>.  Il
   exécute la même séquence de commandes SQL en continu, potentiellement
   avec plusieurs sessions concurrentes puis calcule le taux de
@@ -114,7 +114,7 @@ pgbench -i <optional> <replaceable>autres-options</replaceable>
 
   <para>
    Par défaut, avec un facteur d'échelle de 1, les tables contiennent
-   initialement les nombres de lignes suivant&nbsp;:
+   initialement les nombres de lignes suivants&nbsp;:
 <screen>
 table                   # de lignes
 ---------------------------------
@@ -185,9 +185,9 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
         N'effectue qu'une partie des étapes d'initialisation habituelles.
         <replaceable>init_steps</replaceable> spécifie les étapes
         d'initialisation à exécuter, à raison d'un caractère par étape.
-        Chaque étape est appelée dans l'ordre indiquée.
-        Le défaut est <literal>dtgvp</literal>. Voici la liste des différentes
-		étapes&nbsp;:
+        Chaque étape est appelée dans l'ordre indiqué.
+        La valeur par défaut est <literal>dtgvp</literal>. Voici la liste 
+        des différentes étapes disponibles&nbsp;:
 
         <variablelist>
          <varlistentry>
@@ -399,7 +399,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       <listitem>
        <para>
         Nombre de clients simulés, c'est-à-dire le nombre
-        de sessions concurentes sur la base de données.
+        de sessions concurrentes sur la base de données.
         La valeur par défaut est à 1.
        </para>
       </listitem>
@@ -467,7 +467,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
         <application>pgbench</application>.
         Utiliser plus d'un thread peut être utile sur des machines
         possédant plusieurs cœurs.
-        Les clients sont distribués de la manière la plus égale possible
+        Les clients sont distribués de la manière la plus uniforme possible 
         parmi les threads.
         La valeur par défaut est 1.
        </para>
@@ -492,7 +492,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       <listitem>
        <para>
         Les transactions durant plus de <replaceable>limite</replaceable> millisecondes
-        sont comptabilisée et rapportées séparement en tant que
+        sont comptabilisée et rapportées séparément en tant que
         <firstterm>late</firstterm>.
        </para>
        <para>
@@ -618,20 +618,20 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
        <para>
 		Lorsque le bridage est actif, la latence de la transaction rapportée en
         fin de test est calculée à partir des dates de démarrage ordonnancées,
-        c'est-à-dire qu'elle inclue le temps où chaque transaction attend
+        c'est-à-dire qu'elle inclut le temps où chaque transaction attend
         que la précédente se termine.
 		Le temps d'attente est appelé temps de latence d'ordonnancement,
 		et ses valeurs moyenne et maximum sont rapportées séparément.
         La latence de transaction par rapport au temps de démarrage réel,
         c'est-à-dire le temps d'exécution de la transaction
-		dans la base, peut être récupéré en soustrayant le temps de
+		dans la base, peut être récupérée en soustrayant le temps de
 		latence d'ordonnancement à la latence précisée dans les journaux.
        </para>
 
        <para>
         Si l'option <option>--latency-limit</option> est utilisée avec
         l'option  <option>--rate</option>, une transaction peut avoir
-        une telle latence qu'elle serait déja supérieure à limite de
+        une telle latence qu'elle serait déjà supérieure à limite de
         latence lorsque la transaction précédente se termine, car la
         latence est calculée au moment de la date de démarrage planifiée.
         Les transactions concernées ne sont pas envoyées à l'instance,
@@ -790,10 +790,10 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
         <command>pgbench</command> s'exécutera à l'identique s'il y a un client
         par thread et pas de dépendance externe ou par rapport aux données.
         D'un point de vue statistique, reproduire des runs est une mauvaise
-        idée car cela peut masquer la variabilité des performances ou
+        idée, car cela peut masquer la variabilité des performances ou
         améliorer les performances excessivement, par exemple en appelant les
         mêmes pages qu'un run précédent.
-        Cependant, ce peut être d'une grande aide pour débuguer, par exemple
+        Cependant, ce peut être d'une grande aide pour déboguer, par exemple
         pour reproduire un cas tordu provoquant une erreur. À utiliser
         judicieusement.
        </para>
@@ -817,7 +817,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
         le journal.
 		Par exemple, lorsque vous évaluez le nombre de transactions par seconde,
         vous devrez multiplier les nombres en conséquence. (Par exemple,
-        avec un taux d'échantillonage de 0.01, vous n'obtiendrez que 1/100 du
+        avec un taux d'échantillonnage de 0.01, vous n'obtiendrez que 1/100 du
         tps réel).
        </para>
       </listitem>
@@ -912,7 +912,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
    façon aléatoire à partir d'une liste. Cela inclut des scripts internes
    avec l'option <option>-b</option> et des scripts fournis par
    l'utilisateur avec l'option <option>-f</option>. Chaque script peut se
-   voir associé un poids relatif, indiqué après un <literal>@</literal>,
+   voir associer un poids relatif, indiqué après un <literal>@</literal>,
    pour changer sa probabilité d'exécution. Le poids par défaut est
    <literal>1</literal>. Les scripts avec un poids de <literal>0</literal>
    sont ignorés.
@@ -949,9 +949,9 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
 
   <para>
    Si vous sélectionnez le script interne <literal>simple-update</literal> (ou
-   <option>-N</option>), les étapes 4 et 5 ne sont pas inclus dans la
+   <option>-N</option>), les étapes 4 et 5 ne sont pas incluses dans la
    transaction. Ceci évitera des contentions au niveau des mises à jour sur
-   ces tables mais le test ressemblera encore moins à TPC-B.
+   ces tables, mais le test ressemblera encore moins à TPC-B.
   </para>
 
   <para>
@@ -965,7 +965,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
 
   <para>
    <application>pgbench</application> est capable d'utiliser des
-   scénarios de test de performances personnalisés, en remplaçant le
+   scénarios de test de performance personnalisés, en remplaçant le
    script de transactions par défaut (décrit ci-dessus) par un script de
    transactions lu depuis un fichier spécifié avec l'option
    (<option>-f</option>).
@@ -983,7 +983,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
 
   <note>
    <para>
-    Avant <productname>PostgreSQL</productname> 9.6, les commandes SQL compris
+    Avant <productname>PostgreSQL</productname> 9.6, les commandes SQL comprises
     dans les fichiers scripts étaient terminées par un retour à la ligne.
     Elles ne pouvaient donc pas être écrites sur plusieurs lignes. Maintenant,
     un point-virgule est <emphasis>requis</emphasis> pour séparer des
@@ -1030,7 +1030,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       <row>
        <entry><literal>client_id</literal></entry>
        <entry>nombre unique permettant d'identifier la session client
-       (commence à zero)</entry>
+       (commence à zéro)</entry>
       </row>
 
       <row>
@@ -1046,7 +1046,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
 
       <row>
        <entry><literal>scale</literal></entry>
-       <entry>facteur d'echelle courant</entry>
+       <entry>facteur d'échelle courant</entry>
       </row>
      </tbody>
     </tgroup>
@@ -1178,7 +1178,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       <literal>:</literal><replaceable>nom_variable</replaceable> à une variable.
       Si vous voulez utiliser un <replaceable>argument</replaceable> commençant
       avec un symbole deux-points, écrivez un deux-points supplémentaire au
-      début de <replaceable>argument</replaceable>.
+      début de l'<replaceable>argument</replaceable>.
      </para>
 
      <para>
@@ -1606,7 +1606,7 @@ f(x) = exp(-parameter * (x - min) / (max - min + 1)) / (1 - exp(-parameter))
 f(x) = PHI(2.0 * parameter * (x - mu) / (max - min + 1)) /
        (2.0 * PHI(parameter) - 1)
 </literallayout>
-      alors la valeur value <replaceable>i</replaceable> entre
+      alors la valeur <replaceable>i</replaceable> entre
       <replaceable>min</replaceable> et <replaceable>max</replaceable>
       (inclus) est sélectionnée avec une probabilité&nbsp;:
       <literal>f(i + 0.5) - f(i - 0.5)</literal>. Intuitivement, plus
@@ -1701,7 +1701,7 @@ f(x) = PHI(2.0 * parameter * (x - mu) / (max - min + 1)) /
    des lignes différentes, sélectionnées aléatoirement.
    (Cet exemple montre aussi pourquoi il est important que chaque session
    cliente ait ses propres variables &mdash; sinon elles n'affecteront
-   pas les différentes lignes de façon indépendantes.
+   pas les différentes lignes de façon indépendante.
   </para>
 
  </refsect2>
@@ -1784,14 +1784,14 @@ f(x) = PHI(2.0 * parameter * (x - mu) / (max - min + 1)) /
 </screen>
    Dans cet exemple, la transaction 82 a été en retard, elle affiche une
    latence (6,173&nbsp;ms) supérieure à la limite de 5&nbsp;ms.
-   Les deux transactions suivantes ont été ignorées car elles avaient
+   Les deux transactions suivantes ont été ignorées, car elles avaient
    déjà en retard avant même d'avoir commencé.
   </para>
 
   <para>
    Dans le cas d'un test long sur du matériel qui peut
    supporter un grand nombre de transactions, les journaux
-   peut devenir très volumineux.
+   peuvent devenir très volumineux.
    L'option <option>--sampling-rate</option> peut être utilisée pour
    journaliser seulement un extrait aléatoire des transactions
    effectuées.
@@ -1964,7 +1964,7 @@ tps = 622.977698 (excluding connections establishing)
    Une limitation de <application>pgbench</application> est qu'il peut
    lui-même devenir le goulet d'étranglement lorsqu'on essaye de tester avec
    un grand nombre de sessions clientes.
-   Cela peut être attenué en utilisant <application>pgbench</application>
+   Cela peut être atténué en utilisant <application>pgbench</application>
    depuis une machine différente du serveur de base
    de données, bien qu'une faible latence sur le réseau soit dans ce cas
    essentielle.
@@ -1979,7 +1979,7 @@ tps = 622.977698 (excluding connections establishing)
 
   <para>
     Si des utilisateurs non dignes de confiance ont accès à une base de
-    données qui a adopté une <link linkend="ddl-schemas-patterns">méthode
+    données qui n'a pas adopté une <link linkend="ddl-schemas-patterns">méthode
     sécurisée d'utilisation des schémas</link>, il ne faut pas exécuter
     <application>pgbench</application> dans cette base.
     <application>pgbench</application> utilise des noms non qualifiés et ne


### PR DESCRIPTION
- Corrections d'orthographe
- Une négation non prise en compte dans la traduction ajouté (cf fin du fichier partie sécurité).