### PR TITLE
jit.xml  config.xml - 11ß4 - accords

### DIFF
--- a/postgresql/config.xml
+++ b/postgresql/config.xml
@@ -1708,7 +1708,7 @@ include 'nom_fichier'
     <para>
      Quand autovacuum fonctionne, un maximum de
      <xref linkend="guc-autovacuum-max-workers"/> fois cette quantité de
-     mémoire peut être utilisé. Il convient donc de s'assurer de ne pas
+     mémoire peut être utilisée. Il convient donc de s'assurer de ne pas
      configurer la valeur par défaut de façon trop importante. Il pourrait
      être utile de contrôler ceci en configurant <xref
      linkend="guc-autovacuum-work-mem"/> séparément.
@@ -4704,7 +4704,7 @@ SELECT * FROM parent WHERE clef = 2400;</programlisting>
       </term>
       <listitem>
        <para>
-        Détermine si la compilation <acronym>JIT</acronym> peut être utilisé
+        Détermine si la compilation <acronym>JIT</acronym> peut être utilisée
         par <productname>PostgreSQL</productname>, quand elle est disponible
         (voir <xref linkend="jit"/>). La valeur par défaut est
         <literal>off</literal>.

--- a/postgresql/jit.xml
+++ b/postgresql/jit.xml
@@ -119,7 +119,7 @@
    <acronym>JIT</acronym> sera opérée. Deux décisions supplémentaires sont
    encore nécessaires. Premièrement, si le coût estimé est plus important que
    la configuration de <xref linkend="guc-jit-inline-above-cost"/>, les
-   petites fonctions et opérateurs utilisées dans la requête seront intégrés.
+   petites fonctions et opérateurs utilisés dans la requête seront intégrés.
    Ensuite, si le coût est plus important que la valeur de <xref
    linkend="guc-jit-optimize-above-cost"/>, les optimisations coûteuses sont
    appliquées pour améliorer le code généré. Chacune de ses options augmente


### PR DESCRIPTION
Accords

(pour le 3è on suit la règle conservatrice qui masculin qui l'emporte, valable jusque nouvel ordre)