### PR TITLE
Dans "bibliographie", met l'attribut "id" sur <biblioentry> et non <biblioset>.

### DIFF
--- a/postgresql/biblio.xml
+++ b/postgresql/biblio.xml
@@ -240,8 +240,8 @@ ssimkovi@ag.or.at
    <pubdate>1993</pubdate>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ong90" relation="article">
+  <biblioentry id="ong90">
+   <biblioset relation="article">
     <title>A Unified Framework for Version Modeling Using Production Rules in a Database System</title>
     <authorgroup>
      <author>
@@ -264,8 +264,8 @@ ssimkovi@ag.or.at
    </biblioset>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="rowe87" relation="article">
+  <biblioentry id="rowe87">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M87-13.pdf">The <productname>POSTGRES</productname> data model</ulink></title>
     <titleabbrev>Rowe and Stonebraker, 1987</titleabbrev>
     <authorgroup>
@@ -286,8 +286,8 @@ ssimkovi@ag.or.at
    </confgroup>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="seshadri95" relation="article">
+  <biblioentry id="seshadri95">
+   <biblioset relation="article">
     <title><ulink url="http://citeseer.ist.psu.edu/seshadri95generalized.html">Generalized
     Partial Indexes</ulink></title>
     <authorgroup>
@@ -315,8 +315,8 @@ ssimkovi@ag.or.at
    <pagenums>420-7</pagenums>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston86" relation="article">
+  <biblioentry id="ston86">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M85-95.pdf">The design of <productname>POSTGRES</productname></ulink></title>
     <authorgroup>
      <author>
@@ -336,8 +336,8 @@ ssimkovi@ag.or.at
    </confgroup>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston87a" relation="article">
+  <biblioentry id="ston87a">
+   <biblioset relation="article">
     <title>The design of the <productname>POSTGRES</productname> rules system</title>
     <authorgroup>
      <author>
@@ -361,8 +361,8 @@ ssimkovi@ag.or.at
    </confgroup>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston87b" relation="article">
+  <biblioentry id="ston87b">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M87-06.pdf">The design of the <productname>POSTGRES</productname> storage system</ulink></title>
     <authorgroup>
      <author>
@@ -378,8 +378,8 @@ ssimkovi@ag.or.at
    </confgroup>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston89" relation="article">
+  <biblioentry id="ston89">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M89-82.pdf">A commentary on the <productname>POSTGRES</productname> rules system</ulink></title>
     <authorgroup>
      <author>
@@ -402,8 +402,8 @@ ssimkovi@ag.or.at
    </biblioset>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston89b" relation="article">
+  <biblioentry id="ston89b">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M89-17.pdf">The case for partial indexes</ulink></title>
     <authorgroup>
      <author>
@@ -419,8 +419,8 @@ ssimkovi@ag.or.at
    </biblioset>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston90a" relation="article">
+  <biblioentry id="ston90a">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M90-34.pdf">The implementation of <productname>POSTGRES</productname></ulink></title>
     <authorgroup>
      <author>
@@ -446,8 +446,8 @@ ssimkovi@ag.or.at
    </biblioset>
   </biblioentry>
 
-  <biblioentry>
-   <biblioset id="ston90b" relation="article">
+  <biblioentry id="ston90b">
+   <biblioset relation="article">
     <title><ulink url="http://db.cs.berkeley.edu/papers/ERL-M90-36.pdf">On Rules, Procedures, Caching and Views in Database Systems</ulink></title>
     <authorgroup>
      <author>


### PR DESCRIPTION
Similaire à ce qui est fait dans la doc en anglais.
Dans le cas contraire fop1.1 sort des warnings de ce type:
Page xxxvii: Unresolved ID reference "ston90b" found.
Page xxxvii: Unresolved ID reference "ston90a" found.
Page xxxvii: Unresolved ID reference "rowe87" found.
....
et dans le rendu html, [ston90b] etc. sont manquants