### PR TITLE
Ajoute les appels manquants &alterRule et &dropRule pour la liste des commandes SQL

### DIFF
--- a/postgresql/reference.xml
+++ b/postgresql/reference.xml
@@ -63,6 +63,7 @@
   &alterPublication;
   &alterRole;
   &alterRoutine;
+  &alterRule;
   &alterSchema;
   &alterSequence;
   &alterServer;
@@ -109,8 +110,8 @@
   &createOperator;
   &createOperatorClass;
   &createOperatorFamily;
-  &createProcedure;
   &createPolicy;
+  &createProcedure;
   &createPublication;
   &createRole;
   &createRule;
@@ -144,8 +145,8 @@
   &dropConversion;
   &dropDatabase;
   &dropDomain;
-  &dropExtension;
   &dropEventTrigger;
+  &dropExtension;
   &dropForeignDataWrapper;
   &dropForeignTable;
   &dropFunction;
@@ -162,6 +163,7 @@
   &dropPublication;
   &dropRole;
   &dropRoutine;
+  &dropRule;
   &dropSchema;
   &dropSequence;
   &dropServer;
@@ -256,10 +258,10 @@
   &pgbench;
   &pgConfig;
   &pgDump;
-  &pgReceivewal;
-  &pgRecvlogical;
   &pgDumpall;
   &pgIsready;
+  &pgReceivewal;
+  &pgRecvlogical;
   &pgRestore;
   &psqlRef;
   &reindexdb;


### PR DESCRIPTION
Ces commandes ont été oubliées dans les modifs v11 du commit 439e400.
Probablement une erreur de manip en ajoutant alterRoutine et dropRoutine.
Trouvé par fop 1.1 qui émet des warnings sur `<link linkend="...">`
quand l'ID de destination n'existe pas.

Remet aussi dans l'ordre alphabétique les quelques entrées qui n'y étaient
pas pour simplifier la comparaison avec la doc en anglais.