### PR TITLE
ddl.xml : traduction v12 vs HEAD du 18/6

### DIFF
--- a/postgresql/ddl.xml
+++ b/postgresql/ddl.xml
@@ -240,27 +240,29 @@ DROP TABLE produits;</programlisting>
  </sect1>
 
  <sect1 id="ddl-generated-columns">
-  <title>Generated Columns</title>
+  <title>Colonnes générées</title>
 
   <indexterm zone="ddl-generated-columns">
    <primary>generated column</primary>
   </indexterm>
 
   <para>
-   A generated column is a special column that is always computed from other
-   columns.  Thus, it is for columns what a view is for tables.  There are two
-   kinds of generated columns: stored and virtual.  A stored generated column
-   is computed when it is written (inserted or updated) and occupies storage
-   as if it were a normal column.  A virtual generated column occupies no
-   storage and is computed when it is read.  Thus, a virtual generated column
-   is similar to a view and a stored generated column is similar to a
-   materialized view (except that it is always updated automatically).
-   PostgreSQL currently implements only stored generated columns.
+   Une colonne générée est une colonne spéciale, toujours calculée à partir
+   d'autres colonnes. Elle est donc aux colonnes ce qu'une vue est aux tables.
+   Il y a deux types de colonnes générées&nbsp;: stockée et virtuelle.
+   Une colonne générée stockée est calculée quand elle est écrite (insérée ou mise à jour)
+   et occupe de l'espace de stockage comme si elle était une colonne normale.
+   Une colonne virtuelle générée n'occupe pas d'espace et est calculée à la lecture.
+   Une colonne générée virtuelle est donc équivalente à une vue, et une colonne
+   générée stockée à une vue matérialisée (sauf qu'elle sera toujours mise à jour
+   automatiquement).
+   PostgreSQL n'implémente actuellement que les colonnes générées stockées.
   </para>
 
   <para>
-   To create a generated column, use the <literal>GENERATED ALWAYS
-   AS</literal> clause in <command>CREATE TABLE</command>, for example:
+   Pour créer une colonne générée, utilisez la clause
+   <literal>GENERATED ALWAYS AS</literal> de la commande
+    <command>CREATE TABLE</command>, par exemple&nbsp;:
 <programlisting>
 CREATE TABLE people (
     ...,
@@ -268,89 +270,93 @@ CREATE TABLE people (
     height_in numeric <emphasis>GENERATED ALWAYS AS (height_cm * 2.54) STORED</emphasis>
 );
 </programlisting>
-   The keyword <literal>STORED</literal> must be specified to choose the
-   stored kind of generated column.  See <xref linkend="sql-createtable"/> for
-   more details.
+   Le mot-clé <literal>STORED</literal> doit être spécifié pour choisir le
+   type de colonne générée. Voir <xref linkend="sql-createtable"/> pour plus de
+   détails.
   </para>
 
   <para>
-   A generated column cannot be written to directly.  In
-   <command>INSERT</command> or <command>UPDATE</command> commands, a value
-   cannot be specified for a generated column, but the keyword
-   <literal>DEFAULT</literal> may be specified.
+   On ne peut écrire directement dans une colonne générée.
+   Une valeur ne peut pas y être affectée dans les commandes
+   <command>INSERT</command> ou <command>UPDATE</command>, mais le
+   mot-clé <literal>DEFAULT</literal> peut l'être.
   </para>
 
   <para>
-   Consider the differences between a column with a default and a generated
-   column.  The column default is evaluated once when the row is first
-   inserted if no other value was provided; a generated column is updated
-   whenever the row changes and cannot be overridden.  A column default may
-   not refer to other columns of the table; a generation expression would
-   normally do so.  A column default can use volatile functions, for example
-   <literal>random()</literal> or functions referring to the current time;
-   this is not allowed for generated columns.
+   Voyons les différences entre une colonne avec une valeur par défaut et
+   une colonne générée. La colonne par défaut est calculée une seule fois
+   à la première insertion de la ligne si aucune autre valeur n'est fournie&nbsp;;
+   une colonne générée est mise à jour à chaque fois que la ligne change et on
+   ne peut y déroger. Une colonne par défaut ne peut se référer à d'autres
+   colonnes de la table&nbsp;; mais c'est ce que fait normalement une
+   expression générée. Une colonne par défaut peut utiliser des fonctions
+   volatiles, par exemple <literal>random()</literal> ou des fonctions se
+   référant au temps actuel&nbsp;; ce n'est pas permis pour les colonnes
+   générées.
   </para>
 
   <para>
-   Several restrictions apply to the definition of generated columns and
-   tables involving generated columns:
+   Il existe plusieurs restrictions dans la définition des colonnes générées
+   et des tables qui les utilisent&nbsp;:
 
    <itemizedlist>
     <listitem>
      <para>
-      The generation expression can only use immutable functions and cannot
-      use subqueries or reference anything other than the current row in any
-      way.
+      L'expression pour générer les valeurs ne peut utiliser que des fonctions
+      immutables, ne peut utiliser de sous-requêtes, ni référencer d'aucune
+      manière quoi que ce soit hors de la ligne en cours.
      </para>
     </listitem>
     <listitem>
      <para>
-      A generation expression cannot reference another generated column.
+      Une expression ne peut référencer une autre colonne générée.
      </para>
     </listitem>
     <listitem>
      <para>
-      A generation expression cannot reference a system column, except
+      Une expression ne peut référencer une colonne système, sauf
       <varname>tableoid</varname>.
      </para>
     </listitem>
     <listitem>
      <para>
-      A generated column cannot have a column default or an identity definition.
+      Une colonne générée ne peut avoir une valeur par défaut ou être
+      définie comme colonne identité.
      </para>
     </listitem>
     <listitem>
      <para>
-      A generated column cannot be part of a partition key.
+      Une colonne générée ne peut faire partie d'une clé de partitionnement.
      </para>
     </listitem>
     <listitem>
      <para>
-      Foreign tables can have generated columns.  See <xref
-      linkend="sql-createforeigntable"/> for details.
+      Les tables étrangères peuvent porter des colonnes générées.
+      Voir <xref linkend="sql-createforeigntable"/> pour les détails.
      </para>
     </listitem>
    </itemizedlist>
   </para>
 
   <para>
-   Additional considerations apply to the use of generated columns.
+   D'autres considérations s'appliquent à l'utilisation des colonnes générées.
    <itemizedlist>
     <listitem>
      <para>
-      Generated columns maintain access privileges separately from their
-      underlying base columns.  So, it is possible to arrange it so that a
-      particular role can read from a generated column but not from the
-      underlying base columns.
+      Les colonnes générées maintiennent les privilèges d'accès séparément
+      des colonnes sur lesquelles elles sont basées. On peut donc s'arranger
+      pour qu'un rôle défini puisse lire une colonne générée mais pas la
+      colonne de base sous-jacente.
      </para>
     </listitem>
     <listitem>
      <para>
-      Generated columns are, conceptually, updated after
-      <literal>BEFORE</literal> triggers have run.  Therefore, changes made to
-      base columns in a <literal>BEFORE</literal> trigger will be reflected in
-      generated columns.  But conversely, it is not allowed to access
-      generated columns in <literal>BEFORE</literal> triggers.
+      Conceptuellement, les colonnes générées sont mises à jour après le
+      déclenchement des triggers <literal>BEFORE</literal>.
+      Les changements dans les colonnes de base au sein d'un trigger
+      <literal>BEFORE</literal> seront donc répercutés dans les colonnes générées.
+      Mais à l'inverse il n'est pas permis d'accéder aux colonnes générées
+      dans les triggers <literal>BEFORE</literal>.
      </para>
     </listitem>
    </itemizedlist>
@@ -528,54 +534,60 @@ CREATE TABLE people (
 
    <note>
     <para>
-     <productname>PostgreSQL</productname> does not support
-     <literal>CHECK</literal> constraints that reference table data other than
-     the new or updated row being checked.  While a <literal>CHECK</literal>
-     constraint that violates this rule may appear to work in simple
-     tests, it cannot guarantee that the database will not reach a state
-     in which the constraint condition is false (due to subsequent changes
-     of the other row(s) involved).  This would cause a database dump and
-     reload to fail.  The reload could fail even when the complete
-     database state is consistent with the constraint, due to rows not
-     being loaded in an order that will satisfy the constraint.  If
-     possible, use <literal>UNIQUE</literal>, <literal>EXCLUDE</literal>,
-     or <literal>FOREIGN KEY</literal> constraints to express
-     cross-row and cross-table restrictions.
+     <productname>PostgreSQL</productname> ne supporte pas les contraintes
+     <literal>CHECK</literal> référençant des données situées ailleurs
+     que dans la ligne vérifiée, nouvelle ou mise à jour.
+     Bien qu'une contrainte <literal>CHECK</literal> violant cette règle
+     puisse sembler fonctionner dans des tests simples, on ne peut garantir
+     que la base de données n'atteindra pas un état dans lequel la
+     condition de contrainte serait fausse (suite à des changements sur
+     d'autres lignes impliquées). Cela entraînerait l'échec d'une restauration
+     de sauvegarde logique. Elle échouerait même si l'état de la
+     base entière était cohérent avec la contrainte, à cause des lignes non
+     encore chargées dans un ordre qui satisferait la contrainte. Si
+     possible, utilisez les contraintes <literal>UNIQUE</literal>,
+     <literal>EXCLUDE</literal> ou <literal>FOREIGN KEY</literal>
+     pour exprimer des restrictions entre lignes ou entre tables.
     </para>
 
     <para>
-     If what you desire is a one-time check against other rows at row
-     insertion, rather than a continuously-maintained consistency
-     guarantee, a custom <link linkend="triggers">trigger</link> can be used
-     to implement that.  (This approach avoids the dump/reload problem because
-     <application>pg_dump</application> does not reinstall triggers until after
-     reloading data, so that the check will not be enforced during a
-     dump/reload.)
+     Si vous recherchez une vérification uniquement à l'insertion de la ligne
+     par rapport à d'autres lignes, et non une garantie de cohérence
+     à maintenir en permanence, vous pouvez utiliser un
+     <link linkend="triggers">trigger</link> personnalisé. (Cette approche
+     évite le problème de la restauration logique car
+     <application>pg_dump</application> ne réinstalle pas les triggers
+     avant d'avoir fini de recharger les données&nbsp;; ainsi la vérification
+     ne sera pas appliquée à la restauration.)
     </para>
    </note>
 
    <note>
     <para>
-     <productname>PostgreSQL</productname> assumes that
-     <literal>CHECK</literal> constraints' conditions are immutable, that
-     is, they will always give the same result for the same input row.
-     This assumption is what justifies examining <literal>CHECK</literal>
-     constraints only when rows are inserted or updated, and not at other
-     times.  (The warning above about not referencing other table data is
-     really a special case of this restriction.)
+     <productname>PostgreSQL</productname>
+     suppose que les conditions des contraintes <literal>CHECK</literal>
+     sont immutables, c'est-à-dire qu'elles donneront toujours le même
+     résultat pour la même ligne en entrée. Ainsi on s'autorise à n'examiner
+     les contraintes <literal>CHECK</literal> qu'à l'insertion ou la
+     suppression des lignes, et pas à d'autres moments. (L'avertissement
+     ci-dessus sur la référence aux données d'autres tables n'est qu'un cas
+     particulier de cette restriction.)
     </para>
 
     <para>
-     An example of a common way to break this assumption is to reference a
-     user-defined function in a <literal>CHECK</literal> expression, and
-     then change the behavior of that
-     function.  <productname>PostgreSQL</productname> does not disallow
-     that, but it will not notice if there are rows in the table that now
-     violate the <literal>CHECK</literal> constraint. That would cause a
-     subsequent database dump and reload to fail.
-     The recommended way to handle such a change is to drop the constraint
-     (using <command>ALTER TABLE</command>), adjust the function definition,
-     and re-add the constraint, thereby rechecking it against all table rows.
+     Un exemple d'une manière courante de passer outre cette supposition
+     est de faire référence à une fonction utilisateur dans l'expression
+     d'un <literal>CHECK</literal>, puis de changer le comportement
+     de cette fonction.
+     <productname>PostgreSQL</productname> ne l'interdit pas, mais il
+     ne remarquera pas qu'il y a des lignes dans la table qui violent à présent la
+     contrainte <literal>CHECK</literal>. Cela provoquerait l'échec d'une
+     sauvegarde/restauration logique subséquente.
+     La manière recommandée pour traiter un tel changement est de
+     supprimer la contrainte (avec <command>ALTER TABLE</command>),
+     d'ajuster la définition de la fonction et de ré-appliquer la
+     contrainte, la revalidant ainsi sur toutes les lignes de la
+     table.
     </para>
    </note>
   </sect2>
@@ -1115,11 +1127,11 @@ CREATE TABLE cercles (
         </indexterm>
 
         <para>
-         L' OID de la table contenant la ligne. Cette colonne est
+         L'OID de la table contenant la ligne. Cette colonne est
          particulièrement utile pour les requêtes qui utilisent des hiérarchies
          d'héritage (voir <xref linkend="ddl-inherit"/>). Il est, en effet,
          difficile, en son absence, de savoir de quelle table provient une ligne.
-         <structfield>tableoid</structfield> 
+         <structfield>tableoid</structfield>
          peut être joint à la colonne <structfield>oid</structfield> de
          <structname>pg_class</structname> pour obtenir le nom de la table.
         </para>
@@ -1552,7 +1564,7 @@ ALTER TABLE produits ADD FOREIGN KEY (id_groupe_produit) REFERENCES groupes_prod
 ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_propriétaire</replaceable>;
 </programlisting>
    Les superutilisateurs peuvent toujours le
-   faire. Les rôles ordinaires peuvent seulement le faire s'ils sont le
+   faire. Les rôles ordinaires ne peuvent le faire que s'ils sont le
    propriétaire actuel de l'objet (ou un membre du rôle propriétaire) et un
    membre du nouveau rôle propriétaire.
   </para>
@@ -1604,22 +1616,23 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
   </para>
 
   <para>
-   The available privileges are:
+   Les privilèges disponibles sont&nbsp;:
 
    <variablelist>
     <varlistentry>
      <term><literal>SELECT</literal></term>
      <listitem>
       <para>
-       Allows <xref linkend="sql-select"/> from
-       any column, or specific column(s), of a table, view, materialized
-       view, or other table-like object.
-       Also allows use of <xref linkend="sql-copy"/> TO.
-       This privilege is also needed to reference existing column values in
-       <xref linkend="sql-update"/> or <xref linkend="sql-delete"/>.
-       For sequences, this privilege also allows use of the
-       <function>currval</function> function.
-       For large objects, this privilege allows the object to be read.
+       Autorise <xref linkend="sql-select"/> de n'importe quelle colonne,
+       ou colonnes, désignée(s) d'une table, vue, vue matérialisée ou
+       tout autre objet utilisable comme une table.
+       Permet aussi l'utilisation de <xref linkend="sql-copy"/> TO.
+       Ce privilège est aussi nécessaire pour référencer les valeurs
+       actuelles d'une colonne dans <xref linkend="sql-update"/> ou
+       <xref linkend="sql-delete"/>.
+       Pour les séquences, ce privilège permet aussi d'utiliser la
+       fonction <function>currval</function>.
+       Pour les large objects, ce privilège permet de lire l'objet.
       </para>
      </listitem>
     </varlistentry>
@@ -1628,11 +1641,12 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>INSERT</literal></term>
      <listitem>
       <para>
-       Allows <xref linkend="sql-insert"/> of a new row into a table, view,
-       etc.  Can be granted on specific column(s), in which case
-       only those columns may be assigned to in the <command>INSERT</command>
-       command (other columns will therefore receive default values).
-       Also allows use of <xref linkend="sql-copy"/> FROM.
+       Permet l'<xref linkend="sql-insert"/> d'une nouvelle ligne dans
+       une table, vue, etc. Peut être accordé sur des colonnes spécifiques,
+       auquel cas seules ces colonnes pourront être affectées dans
+       l'ordre <command>INSERT</command> (les autres commandes recevront
+       alors les valeurs par défaut).
+       Permet aussi d'utiliser <xref linkend="sql-copy"/> FROM.
       </para>
      </listitem>
     </varlistentry>
@@ -1641,20 +1655,19 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>UPDATE</literal></term>
      <listitem>
       <para>
-       Allows <xref linkend="sql-update"/> of any
-       column, or specific column(s), of a table, view, etc.
-       (In practice, any nontrivial <command>UPDATE</command> command will
-       require <literal>SELECT</literal> privilege as well, since it must
-       reference table columns to determine which rows to update, and/or to
-       compute new values for columns.)
+       Autorise l'<xref linkend="sql-update"/> de n'importe quelle colonne,
+       ou colonnes, désignée(s) d'une table, vue, etc.
+       (En pratique, toute commande <command>UPDATE</command> non triviale
+       requerra aussi le privilège <literal>SELECT</literal> puisqu'il faut
+       se référer aux colonnes de la table pour déterminer quelles lignes
+       mettre à jour et/ou calculer les nouvelles valeurs des colonnes.)
        <literal>SELECT ... FOR UPDATE</literal>
-       and <literal>SELECT ... FOR SHARE</literal>
-       also require this privilege on at least one column, in addition to the
-       <literal>SELECT</literal> privilege.  For sequences, this
-       privilege allows use of the <function>nextval</function> and
-       <function>setval</function> functions.
-       For large objects, this privilege allows writing or truncating the
-       object.
+       et <literal>SELECT ... FOR SHARE</literal> requièrent aussi ce
+       privilège sur au moins une colonne, en plus du privilège <literal>SELECT</literal>.
+       Pour les séquences, ce privilège autorise l'usage des fonctions
+       <function>nextval</function> et <function>setval</function>.
+       Pour les large objects, ce privilège permet d'écrire dans l'objet
+       ou de le tronquer.
       </para>
      </listitem>
     </varlistentry>
@@ -1663,10 +1676,11 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>DELETE</literal></term>
      <listitem>
       <para>
-       Allows <xref linkend="sql-delete"/> of a row from a table, view, etc.
-       (In practice, any nontrivial <command>DELETE</command> command will
-       require <literal>SELECT</literal> privilege as well, since it must
-       reference table columns to determine which rows to delete.)
+       Permet le <xref linkend="sql-delete"/> d'une ligne dans une table, vue,
+       etc. (En pratique, toute commande <command>DELETE</command> non
+       triviale requerra aussi le privilège <literal>SELECT</literal>,
+       puisqu'il faut lire les colonnes de la table pour déterminer quelles
+       lignes supprimer.)
       </para>
      </listitem>
     </varlistentry>
@@ -1675,7 +1689,7 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>TRUNCATE</literal></term>
      <listitem>
       <para>
-       Allows <xref linkend="sql-truncate"/> on a table, view, etc.
+       Permet <xref linkend="sql-truncate"/> sur une table, vue, etc.
       </para>
      </listitem>
     </varlistentry>
@@ -1684,8 +1698,8 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>REFERENCES</literal></term>
      <listitem>
       <para>
-       Allows creation of a foreign key constraint referencing a
-       table, or specific column(s) of a table.
+       Permet la création de clés étrangères référençant une table, ou des
+       colonnes spécifiques d'une table.
       </para>
      </listitem>
     </varlistentry>
@@ -1694,7 +1708,7 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>TRIGGER</literal></term>
      <listitem>
       <para>
-       Allows creation of a trigger on a table, view, etc.
+       Permet la création d'un trigger sur une table, vue, etc.
       </para>
      </listitem>
     </varlistentry>
@@ -1703,20 +1717,21 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>CREATE</literal></term>
      <listitem>
       <para>
-       For databases, allows new schemas and publications to be created within
-       the database.
+       Pour les bases de données, autorise la création de nouveaux schémas
+       et publications dans la base.
       </para>
       <para>
-       For schemas, allows new objects to be created within the schema.
-       To rename an existing object, you must own the
-       object <emphasis>and</emphasis> have this privilege for the containing
-       schema.
+       Pour les schémas, autorise la création de nouveaux objets dans le
+       schéma.
+       Pour renommer un objet existant, vous devez posséder l'objet
+       <emphasis>et</emphasis> posséder ce privilège pour le schéma de
+       l'objet.
       </para>
       <para>
-       For tablespaces, allows tables, indexes, and temporary files to be
-       created within the tablespace, and allows databases to be created that
-       have the tablespace as their default tablespace.  (Note that revoking
-       this privilege will not alter the placement of existing objects.)
+       Pour les tablespaces, permet de créer des tables, index et fichiers
+       temporaires dans le tablespace, et de créer des bases de données
+       ayant ce tablespace comme tablespace par défaut. (Notez que révoquer
+       ce privilège ne modifiera pas l'emplacement des objets.)
       </para>
      </listitem>
     </varlistentry>
@@ -1725,9 +1740,10 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>CONNECT</literal></term>
      <listitem>
       <para>
-       Allows the grantee to connect to the database.  This
-       privilege is checked at connection startup (in addition to checking
-       any restrictions imposed by <filename>pg_hba.conf</filename>).
+       Permet au bénéficiaire de ce privilège de se connecter à la
+       base de données. Ce privilège est vérifié au démarrage de la connexion
+       (en plus de la vérification de toute restriction imposée par
+       <filename>pg_hba.conf</filename>).
       </para>
      </listitem>
     </varlistentry>
@@ -1736,7 +1752,7 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>TEMPORARY</literal></term>
      <listitem>
       <para>
-       Allows temporary tables to be created while using the database.
+       Permet aux tables temporaires d'être créées dans la base de données.
       </para>
      </listitem>
     </varlistentry>
@@ -1745,9 +1761,9 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>EXECUTE</literal></term>
      <listitem>
       <para>
-       Allows calling a function or procedure, including use of
-       any operators that are implemented on top of the function.  This is the
-       only type of privilege that is applicable to functions and procedures.
+       Permet d'appeler une fonction ou procédure, y compris en utilisant des
+       opérateurs implémentés par-dessus la fonction. C'est le seul type de
+       privilège applicable aux fonctions et procédures.
       </para>
      </listitem>
     </varlistentry>
@@ -1756,95 +1772,100 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <term><literal>USAGE</literal></term>
      <listitem>
       <para>
-       For procedural languages, allows use of the language for
-       the creation of functions in that language.  This is the only type
-       of privilege that is applicable to procedural languages.
+       Pour les langages procéduraux, permet d'utiliser le langage pour la
+       création de fonctions. C'est le seul type de privilège applicable
+       aux langages procéduraux.
       </para>
       <para>
-       For schemas, allows access to objects contained in the
-       schema (assuming that the objects' own privilege requirements are
-       also met).  Essentially this allows the grantee to <quote>look up</quote>
-       objects within the schema.  Without this permission, it is still
-       possible to see the object names, e.g. by querying system catalogs.
-       Also, after revoking this permission, existing sessions might have
-       statements that have previously performed this lookup, so this is not
-       a completely secure way to prevent object access.
+       Pour les schémas, permet l'accès aux objets contenus dans le schéma
+       (à supposer que les privilèges d'accès requis par les objets soient aussi
+       repsectés).
+       Cela autorise essentiellement le bénéficiaire à <quote>rechercher/quote>
+       des objets dans le schéma. Sans cette permission, il reste possible de
+       voir les noms des objets, par exemple en consultant les catalogues
+       système.
+       Après révocation de ce privilège, les sessions existantes peuvent avoir
+       des ordres ayant précédemment effectué cette recherche, donc ce n'est pas
+       une manière totalement sûre d'interdire l'accès à un objet.
       </para>
       <para>
-       For sequences, allows use of the
-       <function>currval</function> and <function>nextval</function> functions.
+       Pour les séquences, permet l'utilisation des fonctions
+       <function>currval</function> et <function>nextval</function>.
       </para>
       <para>
-       For types and domains, allows use of the type or domain in the
-       creation of tables, functions, and other schema objects.  (Note that
-       this privilege does not control all <quote>usage</quote> of the
-       type, such as values of the type appearing in queries.  It only
-       prevents objects from being created that depend on the type.  The
-       main purpose of this privilege is controlling which users can create
-       dependencies on a type, which could prevent the owner from changing
-       the type later.)
+       Pour les types et domaines, permet l'utilisation du type ou domaine
+       dans la création de tables, fonctions et autres objets. (Notez que ce
+       privilège ne contrôle pas l'<quote>utilisation</quote> de ce type,
+       comme les valeurs apparaissant dans les requêtes. Il se limite à
+       interdire la création d'objets qui dépendent de ce type. Le but
+       principal de ce privilège est de contrôler quels utilisateurs
+       peuvent créer des dépendances envers un type, qui pourraient
+       empêcher le propriétaire de modifier le type plus tard.)
       </para>
       <para>
-       For foreign-data wrappers, allows creation of new servers using the
-       foreign-data wrapper.
+       Pour les foreign data wrappers, permet la création de nouveaux
+       serveurs avec ce wrapper.
       </para>
       <para>
-       For foreign servers, allows creation of foreign tables using the
-       server.  Grantees may also create, alter, or drop their own user
-       mappings associated with that server.
+       Pour les serveurs étrangers (<foreignphrase>foreign servers</foreignphrase>),
+       permet la création de tables étrangères utilisant le serveur.
+       Les bénéficiaires du privilège peuvent créer, modifier, supprimer leurs
+       propres correspondances d'utilisateurs (<foreignphrase>user mappings</foreignphrase>)
+       associées à ce serveur.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
 
-   The privileges required by other commands are listed on the
-   reference page of the respective command.
+   Les privilèges requis par d'autres commandes sont listés sur la page de
+   référence de la commande.
   </para>
 
   <para>
-   PostgreSQL grants privileges on some types of objects to
-   <literal>PUBLIC</literal> by default when the objects are created.
-   No privileges are granted to <literal>PUBLIC</literal> by default on
+   Par défaut, PostgreSQL accorde des privilèges sur certains types d'objets
+   à <literal>PUBLIC</literal> dès la création des objets.
+   Aucun privilège n'est accordé à <literal>PUBLIC</literal> par défaut sur les
    tables,
-   table columns,
-   sequences,
+   colonnes de table,
+   séquences,
    foreign data wrappers,
-   foreign servers,
+   serveurs étrangers,
    large objects,
-   schemas,
-   or tablespaces.
-   For other types of objects, the default privileges
-   granted to <literal>PUBLIC</literal> are as follows:
-   <literal>CONNECT</literal> and <literal>TEMPORARY</literal> (create
-   temporary tables) privileges for databases;
-   <literal>EXECUTE</literal> privilege for functions and procedures; and
-   <literal>USAGE</literal> privilege for languages and data types
-   (including domains).
-   The object owner can, of course, <command>REVOKE</command>
-   both default and expressly granted privileges. (For maximum
-   security, issue the <command>REVOKE</command> in the same transaction that
-   creates the object; then there is no window in which another user
-   can use the object.)
-   Also, these default privilege settings can be overridden using the
-   <xref linkend="sql-alterdefaultprivileges"/> command.
+   schémas
+   et tablespaces.
+   Pour les autres types d'objets, les privilèges par défaut accordés à
+   <literal>PUBLIC</literal> sont les suivants&nbsp;:
+   sur les bases de données&nbsp;: les privilèges
+   <literal>CONNECT</literal> et <literal>TEMPORARY</literal>
+   (création de table temporaire)&nbsp;;
+   sur les fonctions et procédures&nbsp;: le privilège <literal>EXECUTE</literal> &nbsp;;
+   et sur les langages et types de données (y compris les domaines)&nbsp;:
+   le privilège  <literal>USAGE</literal>.
+   Bien sûr, le propriétaire de l'objet peut <command>REVOKE</command> les
+   privilèges par défaut comme ceux expressément accordés. (Pour une sécurité
+   maximum, ordonnez <command>REVOKE</command> dans la même transaction que
+   celle qui crée l'objet&nbsp;; il n'y a alors aucune fenêtre où un autre
+   utilisateur peut utiliser l'objet.)
+   Ces privilèges par défaut peuvent aussi être remplacés avec la commande
+   <xref linkend="sql-alterdefaultprivileges"/>.
   </para>
 
   <para>
-   <xref linkend="privilege-abbrevs-table"/> shows the one-letter
-   abbreviations that are used for these privilege types in
-   <firstterm>ACL</firstterm> (Access Control List) values.
-   You will see these letters in the output of the <xref linkend="app-psql"/>
-   commands listed below, or when looking at ACL columns of system catalogs.
+   <xref linkend="privilege-abbrevs-table"/> liste les abréviations à une
+   lettre utilisées pour les types de privilèges dans les valeurs des
+   <firstterm>ACL</firstterm> (listes de contrôle d'accès).
+   Vous verrez ces lettres dans la sortie des commandes <xref linkend="app-psql"/>
+   plus bas, ou en consultant les colonnes ACL des catalogues système.
   </para>
 
   <table id="privilege-abbrevs-table">
-   <title>ACL Privilege Abbreviations</title>
+   <title>Abréviations des privilèges dans les ACL</title>
    <tgroup cols="3">
     <thead>
      <row>
-      <entry>Privilege</entry>
-      <entry>Abbreviation</entry>
-      <entry>Applicable Object Types</entry>
+      <entry>Privilège</entry>
+      <entry>Abréviation</entry>
+      <entry>Types d'objets concernés</entry>
      </row>
     </thead>
     <tbody>
@@ -1854,14 +1875,14 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
       <entry>
        <literal>LARGE OBJECT</literal>,
        <literal>SEQUENCE</literal>,
-       <literal>TABLE</literal> (and table-like objects),
-       table column
+       <literal>TABLE</literal> (et objets similaires à des tables),
+       colonne de table
       </entry>
      </row>
      <row>
       <entry><literal>INSERT</literal></entry>
       <entry><literal>a</literal> (<quote>append</quote>)</entry>
-      <entry><literal>TABLE</literal>, table column</entry>
+      <entry><literal>TABLE</literal>, colonne de table</entry>
      </row>
      <row>
       <entry><literal>UPDATE</literal></entry>
@@ -1870,7 +1891,7 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
        <literal>LARGE OBJECT</literal>,
        <literal>SEQUENCE</literal>,
        <literal>TABLE</literal>,
-       table column
+       colonne de table
       </entry>
      </row>
      <row>
@@ -1886,7 +1907,7 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <row>
       <entry><literal>REFERENCES</literal></entry>
       <entry><literal>x</literal></entry>
-      <entry><literal>TABLE</literal>, table column</entry>
+      <entry><literal>TABLE</literal>, colonne de table</entry>
      </row>
      <row>
       <entry><literal>TRIGGER</literal></entry>
@@ -1935,22 +1956,22 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
   </table>
 
   <para>
-   <xref linkend="privileges-summary-table"/> summarizes the privileges
-   available for each type of SQL object, using the abbreviations shown
-   above.
-   It also shows the <application>psql</application> command
-   that can be used to examine privilege settings for each object type.
+   <xref linkend="privileges-summary-table"/> résume les privilèges
+   disponibles pour chaque objet SQL, avec les abréviations ci-dessus.
+   Il affiche aussi la commande <application>psql</application>
+   à utiliser pour consulter les valeurs des privilèges de chaque type
+   d'objet.
   </para>
 
   <table id="privileges-summary-table">
-   <title>Summary of Access Privileges</title>
+   <title>Résumé des privilèges d'accès</title>
    <tgroup cols="4">
     <thead>
      <row>
-      <entry>Object Type</entry>
-      <entry>All Privileges</entry>
-      <entry>Default <literal>PUBLIC</literal> Privileges</entry>
-      <entry><application>psql</application> Command</entry>
+      <entry>Type d'objet</entry>
+      <entry>Tous les privilèges</entry>
+      <entry>Privilèges par défaut pour <literal>PUBLIC</literal></entry>
+      <entry>Commande <application>psql</application></entry>
      </row>
     </thead>
     <tbody>
@@ -1967,7 +1988,7 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
       <entry><literal>\dD+</literal></entry>
      </row>
      <row>
-      <entry><literal>FUNCTION</literal> or <literal>PROCEDURE</literal></entry>
+      <entry><literal>FUNCTION</literal> ou <literal>PROCEDURE</literal></entry>
       <entry><literal>X</literal></entry>
       <entry><literal>X</literal></entry>
       <entry><literal>\df+</literal></entry>
@@ -1975,13 +1996,13 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <row>
       <entry><literal>FOREIGN DATA WRAPPER</literal></entry>
       <entry><literal>U</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\dew+</literal></entry>
      </row>
      <row>
       <entry><literal>FOREIGN SERVER</literal></entry>
       <entry><literal>U</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\des+</literal></entry>
      </row>
      <row>
@@ -1993,37 +2014,37 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
      <row>
       <entry><literal>LARGE OBJECT</literal></entry>
       <entry><literal>rw</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry></entry>
      </row>
      <row>
       <entry><literal>SCHEMA</literal></entry>
       <entry><literal>UC</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\dn+</literal></entry>
      </row>
      <row>
       <entry><literal>SEQUENCE</literal></entry>
       <entry><literal>rwU</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\dp</literal></entry>
      </row>
      <row>
-      <entry><literal>TABLE</literal> (and table-like objects)</entry>
+      <entry><literal>TABLE</literal> (et objets similaires)</entry>
       <entry><literal>arwdDxt</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\dp</literal></entry>
      </row>
      <row>
-      <entry>Table column</entry>
+      <entry>Colonne de table</entry>
       <entry><literal>arwx</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\dp</literal></entry>
      </row>
      <row>
       <entry><literal>TABLESPACE</literal></entry>
       <entry><literal>C</literal></entry>
-      <entry>none</entry>
+      <entry>aucun</entry>
       <entry><literal>\db+</literal></entry>
      </row>
      <row>
@@ -2040,68 +2061,75 @@ ALTER TABLE <replaceable>nom_table</replaceable> OWNER TO <replaceable>nouveau_p
    <indexterm>
     <primary><type>aclitem</type></primary>
    </indexterm>
-   The privileges that have been granted for a particular object are
-   displayed as a list of <type>aclitem</type> entries, where each
-   <type>aclitem</type> describes the permissions of one grantee that
-   have been granted by a particular grantor.  For example,
-   <literal>calvin=r*w/hobbes</literal> specifies that the role
-   <literal>calvin</literal> has the privilege
-   <literal>SELECT</literal> (<literal>r</literal>) with grant option
-   (<literal>*</literal>) as well as the non-grantable
-   privilege <literal>UPDATE</literal> (<literal>w</literal>), both granted
-   by the role <literal>hobbes</literal>.  If <literal>calvin</literal>
-   also has some privileges on the same object granted by a different
-   grantor, those would appear as a separate <type>aclitem</type> entry.
-   An empty grantee field in an <type>aclitem</type> stands
-   for <literal>PUBLIC</literal>.
+   Les privilèges accordés à un objet particulier sont affichés comme une
+   liste d'entrées <type>aclitem</type>, où chaque <type>aclitem</type>
+   décrit les permissions d'un bénéficiaire à qui des droits ont été
+   octroyés par un utilisateur différent.
+   Par exemple, <literal>calvin=r*w/hobbes</literal> indique que le rôle
+   <literal>calvin</literal> a le privilège <literal>SELECT</literal>
+   (<literal>r</literal>) avec possibilité de transmission
+   (<foreignphrase><quote>with grant option</quote></foreignphrase>)
+   ainsi que le privilège <literal>UPDATE</literal> (<literal>w</literal>),
+   sans retransmission possible&nbsp;; privilèges accordés tous les deux
+   par le rôle <literal>hobbes</literal>. Si <literal>calvin</literal>
+   a aussi des privilèges sur le même objet accordés par un autre utilisateur,
+   ils apparaîtraient comme une entrée <type>aclitem</type> séparée.
+   Un champ vide dans un <type>aclitem</type> indique <literal>PUBLIC</literal>.
   </para>
 
   <para>
-   As an example, suppose that user <literal>miriam</literal> creates
-   table <literal>mytable</literal> and does:
+   Par exemple, supposons que l'utilisateur <literal>miriam</literal> crée
+   une table <literal>mytable</literal> et fasse&nbsp;:
 <programlisting>
 GRANT SELECT ON mytable TO PUBLIC;
 GRANT SELECT, UPDATE, INSERT ON mytable TO admin;
 GRANT SELECT (col1), UPDATE (col1) ON mytable TO miriam_rw;
 </programlisting>
-   Then <application>psql</application>'s <literal>\dp</literal> command
-   would show:
+
+   alors dans <application>psql</application> la commande <literal>\dp</literal>
+   afficherait&nbsp;:
+
 <programlisting>
 =&gt; \dp mytable
-                                  Access privileges
- Schema |  Name   | Type  |   Access privileges   |   Column privileges   | Policies
---------+---------+-------+-----------------------+-----------------------+----------
- public | mytable | table | miriam=arwdDxt/miriam+| col1:                +|
-        |         |       | =r/miriam            +|   miriam_rw=rw/miriam |
-        |         |       | admin=arw/miriam      |                       |
-(1 row)
+                                        Droits d'accès
+ Schéma |   Nom   | Type  |     Droits d'accès    | Droits d'accès à la colonne | Politiques 
+--------+---------+-------+-----------------------+-----------------------------+------------
+ public | mytable | table | miriam=arwdDxt/miriam+| col1:                      +|            
+        |         |       | =r/miriam            +|   miriam_rw=rw/miriam       |            
+        |         |       | admin=arw/miriam      |                             |            
+(1 ligne)
 </programlisting>
   </para>
 
   <para>
-   If the <quote>Access privileges</quote> column is empty for a given
-   object, it means the object has default privileges (that is, its
-   privileges entry in the relevant system catalog is null).  Default
-   privileges always include all privileges for the owner, and can include
-   some privileges for <literal>PUBLIC</literal> depending on the object
-   type, as explained above.  The first <command>GRANT</command>
-   or <command>REVOKE</command> on an object will instantiate the default
-   privileges (producing, for
-   example, <literal>miriam=arwdDxt/miriam</literal>) and then modify them
-   per the specified request.  Similarly, entries are shown in <quote>Column
-   privileges</quote> only for columns with nondefault privileges.
-   (Note: for this purpose, <quote>default privileges</quote> always means
-   the built-in default privileges for the object's type.  An object whose
-   privileges have been affected by an <command>ALTER DEFAULT
-   PRIVILEGES</command> command will always be shown with an explicit
-   privilege entry that includes the effects of
-   the <command>ALTER</command>.)
+   Si la colonne <quote>Droits d'accès</quote> est vide pour
+   un objet donné, cela signifie que l'objet a les privilèges par défaut
+   (c'est-à-dire que l'entrée des privilèges dans les catalogues système
+   est NULL). Les privilèges par défaut incluent toujours tous les
+   privilèges pour le propriétaire, et peuvent inclure certains privilèges
+   pour <literal>PUBLIC</literal> en fonction du type d'objet commme
+   expliqué plus haut.
+   La première commande <command>GRANT</command> ou <command>REVOKE</command>
+   sur un objet va instancier les privilèges par défaut (en produisant,
+   par exemple, <literal>miriam=arwdDxt/miriam</literal>) puis les modifier
+   selon la requête.
+   De manière similaire, des entrées ne sont affichées dans
+   <quote>Droits d'accès à la colonne</quote> que pour les colonnes qui n'ont
+   pas les privilèges par défaut.
+   (Note&nbsp;: dans ce contexte, on entend par
+   <quote>privilèges par défaut</quote> les privilèges par défaut
+   intégrés à PostgreSQL pour le type d'objet.
+   Un objet dont les privilèges auront été affectés par une
+   commande <command>ALTER DEFAULT PRIVILEGES</command> montrera toujours
+   une entrée de privilèges explicite qui inclue les effets du
+    <command>ALTER</command>.)
   </para>
 
   <para>
-   Notice that the owner's implicit grant options are not marked in the
-   access privileges display.  A <literal>*</literal> will appear only when
-   grant options have been explicitly granted to someone.
+   Notez que les droits de transmission (<foreignphrase>grant
+   option</foreignphrase>) implicites ne sont pas indiqués dans l'affichage des
+   droits d'accès. Un <literal>*</literal> n'apparaîtra que si la
+   transmission a été explicitement accordée à quelqu'un.
   </para>
  </sect1>
 
@@ -2281,7 +2309,6 @@ CREATE POLICY user_sel_policy ON users
 CREATE POLICY user_mod_policy ON users
     USING (user_name = current_user);
  </programlisting>
- 
   <para>
    Pour une commande <command>SELECT</command>, ces deux politique sont combinées
    à l'aide de <literal>OR</literal>, ayant pour effet que toutes les lignes
@@ -3467,9 +3494,10 @@ VALUES ('Albany', NULL, NULL, 'NY');</programlisting>
       </listitem>
     </itemizedlist>
 
-    Ces déficiences seront probablement corrigées dans une version future,
-    mais, en attendant, il est obligatoire de réfléchir consciencieusement à l'utilité
-    de l'héritage pour une application donnée.
+    Certaines fonctionnalité non implémentées pour l'héritage le
+    sont pour le partitionnement déclaratif.
+    Réfléchissez soigneusement avant de décider de l'utilité de
+    l'ancien partitionnement par héritage pour votre application.
   </para>
 
    </sect2>
@@ -3648,7 +3676,7 @@ VALUES ('Albany', NULL, NULL, 'NY');</programlisting>
     table standard ou une table partitionnée contenant des données comme une
     partition d'une table partitionnée, ou de supprimer une partition d'une
     table partitionnée, la transformant en table standard; voir <xref
-        linkend="sql-altertable"/> pour en apprendre plus sur les sous-commandes 
+        linkend="sql-altertable"/> pour en apprendre plus sur les sous-commandes
         <command>ATTACH PARTITION</command> et <command>DETACH
         PARTITION</command>.
    </para>
@@ -3705,12 +3733,12 @@ VALUES ('Albany', NULL, NULL, 'NY');</programlisting>
       <para>
        Les partitions ne peuvent pas avoir de colonnes qui ne sont pas
        présentes dans le parent. Il n'est pas non plus possible de spécifier
-       des colonnes quand une partition est créée avec <command>CREATE 
+       des colonnes quand une partition est créée avec <command>CREATE
        TABLE</command>, pas plus qu'il n'est possible d'ajouter des colonnes
-       aux partitions une fois celles-ci créées en utilisant <command>ALTER 
-       TABLE</command>. Des tables peuvent être ajoutées comme des
+       aux partitions par la suite  avec <command>ALTER
+       TABLE</command>. Des tables ne peuvent être ajoutées en tant que
        partitions avec <command>ALTER TABLE ... ATTACH PARTITION</command>
-       seulement si leurs colonnes correspondent exactement à celles du parent.
+       que si leurs colonnes correspondent exactement à celles du parent.
       </para>
      </listitem>
 
@@ -3937,12 +3965,12 @@ ALTER TABLE measurement DETACH PARTITION measurement_y2006m02;
 </programlisting>
 
      Cela permet d'effectuer ensuite d'autres opérations sur les données avant
-     de la supprimer. Par exemple, il s'agit souvent du moment idéal pour
+     la suppression. Par exemple, il s'agit souvent du moment idéal pour
      sauvegarder les données en utilisant <command>COPY</command>,
      <application>pg_dump</application>, ou des outils similaires.  Cela
      pourrait également être le bon moment pour agréger les données dans un
      format moins volumineux, effectuer d'autres manipulations de données ou
-     exécuter des rapports.
+     lancer des rapports.
    </para>
 
    <para>
@@ -3957,9 +3985,9 @@ CREATE TABLE measurement_y2008m02 PARTITION OF measurement
     TABLESPACE fasttablespace;
 </programlisting>
 
-     De manière alternative, il est parfois plus utile de créer la nouvelle
+     De manière alternative, il est parfois plus pratique de créer la nouvelle
      table en dehors de la structure de la partition, et d'en faire une
-     partition plus tard.  Cela permet de charger des données, les vérifier et
+     vraie partition plus tard.  Cela permet de charger des données, les vérifier et
      effectuer des transformations avant que les données apparaissent dans la
      table partitionnée&nbsp;:
 
@@ -3972,7 +4000,7 @@ ALTER TABLE measurement_y2008m02 ADD CONSTRAINT y2008m02
    CHECK ( logdate &gt;= DATE '2008-02-01' AND logdate &lt; DATE '2008-03-01' );
 
 \copy measurement_y2008m02 from 'measurement_y2008m02'
--- possibly some other data preparation work
+-- et éventuellement d'autres étapes de préparation
 
 ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
     FOR VALUES FROM ('2008-02-01') TO ('2008-03-01' );
@@ -3982,15 +4010,57 @@ ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
     <para>
      Avant d'exécuter une commande <command>ATTACH PARTITION</command>, il est
      recommandé de créer une contrainte <literal>CHECK</literal> sur la table
-     qui doit être attachée décrivant la contrainte de partition désirée.  De
+     à attacher décrivant la contrainte de partition désirée. De
      cette manière, le système n'aura pas besoin d'effectuer un parcours de la
-     table pour valider la contrainte de partition implicite. Sans une telle
+     table pour valider la contrainte de partitionnement implicite. Sans une telle
      contrainte, la table sera parcourue pour valider la contrainte de
      partition tout en ayant un verrou de niveau <literal>ACCESS
      EXCLUSIVE</literal> sur la partition et un verrou de niveau
-     <literal>SHARE UPDATE EXCLUSIVE</literal> sur la table parente. Vous
-     pouvez alors supprimer la contrainte après que <command>ATTACH
-     PARTITION</command> soit fini, car elle n'est plus nécessaire.
+     <literal>SHARE UPDATE EXCLUSIVE</literal> sur la table parente.
+     On poura ensuite supprimer la contrainte après que <command>ATTACH
+     PARTITION</command> a fini, car elle n'est plus nécessaire.
+    </para>
+
+    <para>
+     Comme expliqué ci-dessus, il est possible de créer des index sur des
+     tables partitionnées, et ceux-ci sont appliqués automatiquement sur la
+     hiérarchie entière. C'est très pratique, car non seulement les partitions
+     déjà créées seront indexées, mais aussi toutes les partitions créées dans
+     le futur.
+     Une limitation est qu'il n'est pas possible d'utiliser <literal>CONCURRENTLY</literal>
+     pour créer un index partitionné. Pour éviter des verrous trop longs,
+     il est possible d'utiliser <command>CREATE INDEX ON ONLY</command> sur la
+     table partitionnée&nbsp;; un tel index sera marqué invalide, et il ne
+     sera pas appliqué automatiquement sur les partitions.
+     Les index sur les partitions peuvent être créés séparément avec
+     <literal>CONCURRENTLY</literal>, et plus tard rattachés (<firstterm>attached</firstterm>)
+     à l'index sur le parent avec <command>ALTER INDEX .. ATTACH PARTITION</command>.
+     Une fois les index de toutes les partitions attachés à l'index parent,
+     celui-ci sera automatiquement marqué comme valide. Exemple&nbsp;:
+
+<programlisting>
+CREATE INDEX measurement_usls_idx ON ONLY measurement (unitsales);
+
+CREATE INDEX measurement_usls_200602_idx
+    ON measurement_y2006m02 (unitsales);
+ALTER INDEX measurement_usls_idx
+    ATTACH PARTITION measurement_usls_200602_idx;
+...
+</programlisting>
+
+      Cette technique peut aussi être utilisée avec des contraintes
+      <literal>UNIQUE</literal> et <literal>PRIMARY KEY</literal>&nbsp;;
+      les index sont créés implicitement quand la contrainte est créée.
+      Exemple&nbsp;:
+
+ programlisting>
+ALTER TABLE ONLY measurement ADD UNIQUE (city_id, logdate);
+
+ALTER TABLE measurement_y2006m02 ADD UNIQUE (city_id, logdate);
+ALTER INDEX measurement_city_id_logdate_key
+    ATTACH PARTITION measurement_y2006m02_city_id_logdate_key;
+...
+</programlisting>
     </para>
    </sect3>
 
@@ -4011,18 +4081,8 @@ ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
 
      <listitem>
       <para>
-       Alors que les clés primaires sont prises en charge sur les tables
-       partitionnées, les clés étrangères faisant référence à des tables
-       partitionnées ne sont pas prises en charge. (Les références de clés
-       étrangères d'une table partitionnée vers une autre table sont supportées.)
-
-      </para>
-     </listitem>
-
-     <listitem>
-      <para>
        en cas de besoin, les triggers <literal>BEFORE ROW</literal> doivent
-       être définies sur des partitions individuelles, et non sur la table
+       être définis sur les partitions individuelles, et non sur la table
        partitionnée.
       </para>
      </listitem>
@@ -4416,7 +4476,15 @@ ALTER TABLE mesure_a2008m02 INHERIT mesure;
 
       <listitem>
        <para>
-        les schémas montrés ici supposent que les colonnes clés du
+        Les contraintes d'index et de clés étrangères s'appliquent à des
+        tables seules et non à leurs enfants par héritage, il y a donc des
+        <link linkend="ddl-inherit-caveats">caveats</link> à connaître.
+       </para>
+      </listitem>
+
+      <listitem>
+       <para>
+        Les schémas montrés ici supposent que les colonnes clés du
         partitionnement d'une ligne ne changent jamais ou, tout du moins, ne
         changent pas suffisamment pour nécessiter un déplacement vers une autre
         partition. Une commande  <command>UPDATE</command> qui tente de le
@@ -4537,21 +4605,21 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     Il est à noter que l'élagage des partitions n'est piloté que par les
     contraintes définies implicitement par les clés de partition, et non par
     la présence d'index&nbsp;: il n'est donc pas nécessaire de définir des index
-    sur les colonnes clés. Si un index doit être créé pour une partition donnée,
-    ceci dépendra du fait que vous vous attendez à ce que les requêtes qui
-    parcourent la partition parcourent généralement une grande partie de la
-    partition ou seulement une petite partie. Un index sera utile dans ce dernier
+    sur les colonnes clés. Pour savoir si un index doit être créé pour une partition donnée,
+    il vous faut juger si les requêtes sur
+    cette partition en parcourent généralement une grande
+    ou seulement une petite partie. Un index sera utile dans ce dernier
     cas, mais pas dans le premier.
    </para>
 
    <para>
-    L'élagage des partitions peut être effectuée non seulement lors de la
+    L'élagage des partitions peut être effectué non seulement lors de la
     planification d'une requête, mais aussi lors de son exécution. Ceci est
     utile car cela peut permettre d'élaguer plus de partitions lorsque les
     clauses contiennent des expressions dont les valeurs ne sont pas connues
-    au moment de la planification de la requête&nbsp;; par exemple, des paramètres
+    au moment de la planification de la requête, par exemple des paramètres
     définis dans une instruction <command>PREPARE</command>, utilisant une
-    valeur obtenue d'une sous-requête ou utilisant une valeur paramétrée sur
+    valeur obtenue d'une sous-requête, ou utilisant une valeur paramétrée sur
     la partie interne du n&oelig;ud de boucle imbriqué (<literal>nested loop join</literal>.
     L'élagage de la partition pendant l'exécution peut être réalisé à l'un des
     moments suivant&nbsp;:
@@ -4559,12 +4627,12 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     <itemizedlist>
      <listitem>
       <para>
-       Lors de l'initialisation du plan d'exécution, l'élagage de partition peut
-       être effectué pour les valeurs de paramètres qui sont connues pendant
-       cette phase. Les partitions qui ont été élaguées pendant cette étape
+       Lors de l'initialisation du plan d'exécution. L'élagage de partition peut
+       être effectué pour les valeurs de paramètres déjà connues à
+       cette phase. Les partitions élaguées pendant cette étape
        n'apparaîtront pas dans l'<command>EXPLAIN</command> ou l'<command>EXPLAIN
-       ANALYZE</command> de la requête. Il est tout de même possible de
-       déterminer le nombre de partitions qui ont été supprimées pendant cette
+       ANALYZE</command> de la requête. Il est même possible de
+       déterminer le nombre de partitions supprimées pendant cette
        phase en observant la propriété <quote>Subplans Removed</quote>
        (sous-plans supprimés) dans la sortie d'<command>EXPLAIN</command>.
       </para>
@@ -4579,15 +4647,15 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
        pendant la recherche comme lors des n&oelig;uds de boucle imbriqué
        (<literal>nested loop join</literal>).
        Comme la valeur de ces paramètres peut changer plusieurs fois pendant
-       l'exécution de la requête, l'élagage de la partition est effectué chaque
+       l'exécution de la requête, l'élagage de partitions est effectué chaque
        fois que l'un des paramètres d'exécution utilisés pour celui-ci change.
        Déterminer si les partitions ont été élaguées pendant cette phase nécessite
-       une inspection minutieuse de la propriété <literal>nloops</literal> de la
+       une inspection minutieuse de la propriété <literal>loops</literal> de la
        sortie d'<command>EXPLAIN ANALYZE</command>. Les sous-plans correspondant
-       aux différentes partitions pourraient avoir différentes valeurs dépendant
-       du nombre de fois chacun d'entre eux a été évité lors de l'exécution.
-       Certains pourraient être affichés comme <literal>(never executed)</literal>
-       (littéralement, <literal>jamais exécuté</literal>) s'ils sont évités à
+       aux différentes partitions peuvent avoir différentes valeurs dépendant
+       du nombre de fois où chacun d'eux a été élagué lors de l'exécution.
+       Certains peuvent être affichés comme <literal>(never executed)</literal>
+       (littéralement, <literal>jamais exécuté</literal>) s'ils sont élagués à
        chaque fois.
       </para>
      </listitem>
@@ -4658,7 +4726,7 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
    </para>
 
  <para>
-  Les restrictions suivantes s'appliquent à l'exclusion de contraintes&nbsp;:
+  Les avertissement suivants s'appliquent à l'exclusion de contraintes&nbsp;:
 
   <itemizedlist>
    <listitem>
@@ -4710,6 +4778,99 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
   </itemizedlist>
  </para>
 </sect2>
+
+
+<sect2 id="ddl-partitioning-declarative-best-practices">
+    <title>Bonnes pratiques avec le partitionnement déclaratif</title>
+
+   <para>
+    Il faut choisir avec soin le partitionnement d'une table car les
+    performances en planification et à l'exécution peuvent pâtir d'une
+    mauvaise conception.
+   </para>
+
+   <para>
+    Un des choix les plus cruciaux portera sur la ou les colonnes par
+    lesquelles vous partitionnerez. Souvent le meilleur choix sera la
+    colonne ou l'ensemble de colonnes qui apparaissent le plus souvent
+    dans les clauses <literal>WHERE</literal> des requêtes exécutées sur
+    la table.
+    Les clauses <literal>WHERE</literal> portant sur la clé de partitionnement
+    et compatibles avec elle peuvent être utilisées pour élaguer les
+    partitions inutiles. Cependant, le choix peut vous être imposé par
+    des exigences sur la <literal>PRIMARY KEY</literal> ou une contrainte
+    <literal>UNIQUE</literal>. La suppression de données indésirables est
+    aussi un facteur à considérer pour préparer votre
+    stratégie de partitionnement.
+    Une partition entière peut être détachée assez vite, et cela peut
+    valoir le coup de concevoir votre partitionnement pour que
+    toutes les données à supprimer en même temps soient situées dans la
+    même partition.
+   </para>
+
+   <para>
+    Choisir le nombre cible de partitions par lequel la table sera divisée
+    est aussi une décision critique à prendre.
+    Ne pas avoir assez de partitions peut signifier que les index resteront
+    trop gros et que la localité des données restera faible, ce qui entraînera
+    de mauvais <foreignphrase>hit ratios</foreignphrase>.
+    Cependant, diviser la table en trop de partitions a aussi ses inconvénients.
+    Trop de partitions peuvent entraîner des temps de planification plus longs
+    et une plus grande consommation de mémoire pendant la planification comme
+    pendant l'exécution.
+    Lors du choix du partitionnement de votre table, il est aussi important de
+    considérer ce qui va changer dans le futur.
+    Par exemple, si vous choisissez d'avoir une partition par client alors que vous n'avez
+    actuellement qu'un petit nombre de gros clients, considérez les implications
+    si, dans quelques années, vous vous retrouvez avec un grand nombre de
+    petits clients. Dans ce cas, il serait meilleur de choisir une partition par
+    <literal>HASH</literal> et de choisir un nombre raisonnable de partitions
+    plutôt que d'essayer de partitionner par <literal>LIST</literal> et d'espérer
+    que le nombre de clients n'augmente pas au-delà de ce qu'il est en pratique
+    possible de partitionner.
+   </para>
+
+   <para>
+    Sous-partitionner peut être utile pour diviser encore des partitions qui
+    devraient devenir plus grandes que d'autres partitions, bien qu'un
+    sous-partitionnement excessif puisse facilement mener à un grand nombre
+    de partitions et puisse causer les mêmes problèmes que mentionnés au
+    paragraphe précédent.
+   </para>
+
+   <para>
+    Il est aussi important de considérer le surcroît de travail pour la
+    planification et l'exécution dû au partitionnement. Le planificateur de
+    requêtes est généralement capable de manipuler correctement des hiérarchies jusqu'à
+    plusieurs milliers de partitions, pourvu que les requêtes
+    courantes lui permettent d'élaguer toutes les partitions à l'exception d'un
+    petit nombre.
+    Les temps de planification s'allongent et la consommation
+    de mémoire grandit s'il reste beaucoup de partitions
+    une fois que le planificateur a fait l'élégage.
+    C'est particulièrement vrai pour les commandes <command>UPDATE</command>
+    et <command>DELETE</command>.
+    Une autre raison de se méfier d'un grand nombre de partitions est que la
+    consommation mémoire du serveur peut augmenter significativement au fil du temps,
+    particulièrement si beaucoup de sessions touchent de nombreuses partitions.
+    La cause en est que chaque partition a besoin que ses métadonnées soient
+    chargées dans la mémoire locale d'une session qui y touche.
+   </para>
+
+   <para>
+    Avec une charge de type entrepôt de données, il y a plus de sens à utiliser
+    un grand nombre de partitions que pour une charge de type <acronym>OLTP</acronym>.
+    Généralement, en décisionnel, le temps de planification est moins un souci
+    puisque la majorité du temps de traitement est dépensé pendant l'exécution.
+    Avec l'un comme l'autre de ces types de charge, il est important de prendre tôt
+    la bonne décision, car re-partitionner de grandes quantités de données peut
+    être douloureusement long. Des simulation de la charge attendue sont souvent
+    souhaitables pour optimiser la stratégie de partitionnement. Ne supposez
+    jamais que plus de partitions valent mieux que moins de partitions et vice-versa.
+   </para>
+  </sect2>
+
+
 </sect1>
 
 <sect1 id="ddl-foreign-data">


### PR DESCRIPTION
Traduction de nouveautés de ddl.xml, par rapport à la version dans HEAD ces jours, d'où l'ajout de quelques paragraphes absents de la bêta1

Quelques formulations modifiées au passage pour tenter d'alléger le style.