### PR TITLE
Fix: ko (et non Ko), Coréen, standardisation sur plateforme sans tiret

### DIFF
--- a/postgresql/catalogs.xml
+++ b/postgresql/catalogs.xml
@@ -4446,7 +4446,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
    suffisamment petits pour être facilement stockés dans des lignes de
    <structname>pg_largeobject</structname>.
    La taille de données par page est définie par <symbol>LOBLKSIZE</symbol>, qui vaut
-   actuellement <literal>BLCKSZ/4</literal>, soit habituellement 2&nbsp;Ko).
+   actuellement <literal>BLCKSZ/4</literal>, soit habituellement 2&nbsp;ko).
   </para>
 
   <para>

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -1171,7 +1171,7 @@ by pg_wchar_table.mblen function for each encoding.
       <row>
        <entry><literal>JOHAB</literal></entry>
        <entry><acronym>JOHAB</acronym></entry>
-       <entry>Koréen (Hangul)</entry>
+       <entry>Coréen (Hangul)</entry>
        <entry>Non</entry>
        <entry>Non</entry>
        <entry>1-3</entry>
@@ -1333,7 +1333,7 @@ by pg_wchar_table.mblen function for each encoding.
       <row>
        <entry><literal>UHC</literal></entry>
        <entry>Code unifié Hangul</entry>
-       <entry>Koréen</entry>
+       <entry>Coréen</entry>
        <entry>Non</entry>
        <entry>Non</entry>
        <entry>1-2</entry>

--- a/postgresql/config.xml
+++ b/postgresql/config.xml
@@ -76,7 +76,7 @@
       <emphasis>Numérique avec unité</emphasis>&nbsp;:
       Quelques paramètres numériques ont une unité implicite car elles
       décrivent des quantités de mémoire ou de temps. L'unité pourra être
-      des octets, des kilo-octets, des blocs (généralement 8 Ko), des millisecondes,
+      des octets, des kilo-octets, des blocs (généralement 8&nbsp;ko), des millisecondes,
       des secondes ou des minutes. Une valeur numérique sans unité pour
       un de ces paramètres utilisera l'unité par défaut du paramètre, qui
       est disponible dans le champ
@@ -1549,7 +1549,7 @@ include 'nom_fichier'
     utiliser pour les fichiers temporaires, comme par exemple ceux
     utilisés pour les tris et hachages, ou le fichier de stockage pour
     un curseur détenu. Une transaction tentant de dépasser cette limite
-    sera annulée. La valeur a pour unité le Ko. La valeur spéciale
+    sera annulée. La valeur a pour unité le ko. La valeur spéciale
     <literal>-1</literal> (valeur par défaut) signifie sans limite. Seuls
     les superutilisateurs peuvent modifier cette configuration.
    </para>
@@ -1587,7 +1587,7 @@ include 'nom_fichier'
      128&nbsp;Mo, peut être automatiquement abaissée si la configuration du
      noyau ne la supporte pas (déterminé lors de l'exécution de
      l'<application>initdb</application>). Ce paramètre doit être au minimum
-     de 128&nbsp;Ko + 16&nbsp;Ko par <xref linkend="guc-max-connections"/>.
+     de 128&nbsp;ko + 16&nbsp;ko par <xref linkend="guc-max-connections"/>.
      (Des valeurs personnalisées de <symbol>BLCKSZ</symbol> agissent sur ce
      minimum.) Des valeurs significativement plus importantes que ce minimum
      sont généralement nécessaires pour de bonnes performances. Ce paramètre
@@ -2229,7 +2229,7 @@ block : bloc vidé,  dirty bloc : bloc à vider ?
      entre <literal>0</literal>, qui désactive le <quote>writeback</quote>
      forcé, et <literal>2MB</literal>.  La valeur par défaut est
      <literal>512KB</literal> sur Linux, <literal>0</literal> ailleurs. (Si
-     <symbol>BLCKSZ</symbol> ne vaut pas 8 Ko, les valeurs par défaut et
+     <symbol>BLCKSZ</symbol> ne vaut pas 8&nbsp;ko, les valeurs par défaut et
      maximales évoluent de façon proportionnelles à cette constante.) Ce
      paramètre est seulement configurable dans le fichier
      <filename>postgresql.conf</filename> et à la ligne de commande.
@@ -2448,7 +2448,7 @@ block : bloc vidé,  dirty bloc : bloc à vider ?
      <literal>0</literal>, qui désactive le <quote>writeback</quote> forcé,
      et <literal>2MB</literal>.  La valeur par défaut est <literal>0</literal>
      (autrement dit pas de vidage forcé). (Si <symbol>BLCKSZ</symbol> ne vaut
-     pas 8 Ko, la valeur maximale évolue de façon proportionnelle à cette
+     pas 8&nbsp;ko, la valeur maximale évolue de façon proportionnelle à cette
      constante.)
     </para>
    </listitem>
@@ -3101,7 +3101,7 @@ block : bloc vidé,  dirty bloc : bloc à vider ?
      entre <literal>0</literal>, qui désactive le <quote>writeback</quote>
      forcé, et <literal>2MB</literal>. La valeur par défaut est
      <literal>256KB</literal> sur Linux, <literal>0</literal> ailleurs. (Si
-     <symbol>BLCKSZ</symbol> ne vaut pas 8 Ko, les valeurs par défaut et
+     <symbol>BLCKSZ</symbol> ne vaut pas 8&nbsp;ko, les valeurs par défaut et
      maximale n'évoluent pas de façon proportionnelle à cette constante.) Ce
      paramètre est seulement configurable dans le fichier
      <filename>postgresql.conf</filename> et à la ligne de commande.

--- a/postgresql/datatype.xml
+++ b/postgresql/datatype.xml
@@ -718,7 +718,7 @@ FROM generate_series(-3.5, 3.5, 1) as x;
         pour des calculs compliqués avec ces types
         pour quoi que ce soit d'important, et particulièrement pour
         le comportement aux limites (infini, zéro), l'implantation spécifique
-	à la plate-forme doit être étudiée avec soin&nbsp;;
+	à la plateforme doit être étudiée avec soin&nbsp;;
        </para>
       </listitem>
 
@@ -794,7 +794,7 @@ FROM generate_series(-3.5, 3.5, 1) as x;
       Le paramètre <xref linkend="guc-extra-float-digits"/> contrôle le nombre
       de chiffres significatifs inclus lorsqu'une valeur à virgule flottante
       est convertie en texte. Avec la valeur par défaut de
-      <literal>0</literal>, la sortie est la même sur chaque plate-forme
+      <literal>0</literal>, la sortie est la même sur chaque plateforme
       supportée par PostgreSQL. L'augmenter va produire une sortie représentant
       plus précisément la valeur stockée, mais il est possible que la sortie
       soit différente suivant les plates-formes.

--- a/postgresql/diskusage.xml
+++ b/postgresql/diskusage.xml
@@ -60,7 +60,7 @@
  base/16384/16806     |       60
 (1 row)
    </programlisting>
-   Chaque page a une taille de 8 Ko, typiquement. (Rappelez-vous que
+   Chaque page a une taille de 8&nbsp;ko, typiquement. (Rappelez-vous que
    <structfield>relpages</structfield> est seulement mis à jour par
    <command>VACUUM</command>, <command>ANALYZE</command> et quelques commandes
    DDL telles que <command>CREATE INDEX</command>.)  Le chemin du fichier n'a

--- a/postgresql/ecpg.xml
+++ b/postgresql/ecpg.xml
@@ -8554,7 +8554,7 @@ if (*(int2 *)sqldata->sqlvar[i].sqlind != 0)
      <listitem>
       <para>
        C'est égal à <literal>sqldata</literal> si <literal>sqllen</literal>
-       est plus grand que 32 Ko.
+       est plus grand que 32nbsp;ko.
       </para>
      </listitem>
     </varlistentry>

--- a/postgresql/information_schema.xml
+++ b/postgresql/information_schema.xml
@@ -6477,7 +6477,7 @@ ORDER BY c.ordinal_position;
   </para>
 
   <para>
-   SQL connaît deux genres de types définis par les utilisateursénbsp;: les
+   SQL connaît deux genres de types définis par les utilisateurs&nbsp;: les
    types structurés (aussi connu sous le nom de types composites dans
    <productname>PostgreSQL</productname>) et les types distincts (non
    implémentés dans <productname>PostgreSQL</productname>). Pour être prêt,

--- a/postgresql/jdbc.xml
+++ b/postgresql/jdbc.xml
@@ -25,7 +25,7 @@
   <productname>PostgreSQL</productname> fournit un pilote <acronym>JDBC</acronym> de
   <firstterm>type 4</firstterm>. Le type 4 indique que le pilote est écrit en
   pur Java et communique dans le propre protocole réseau du système des bases
-  de données. De ce fait, le pilote est indépendant de la plate-forme.
+  de données. De ce fait, le pilote est indépendant de la plateforme.
   Une fois compilé, le pilote peut être utilisé sur tout système.
  </para>
 

--- a/postgresql/ltree.xml
+++ b/postgresql/ltree.xml
@@ -36,7 +36,7 @@
    ou plusieurs labels séparés par des points, par exemple
    <literal>L1.L2.L3</literal>, ce qui représente le chemin de la racine
    jusqu'à un nœud particulier. La longueur d'un chemin
-   est limité à 65&nbsp;Ko, mais une longueur inférieure ou égale à 2&nbsp;Ko
+   est limité à 65&nbsp;ko, mais une longueur inférieure ou égale à 2&nbsp;ko
    est préférable.
   </para>
 

--- a/postgresql/monitoring.xml
+++ b/postgresql/monitoring.xml
@@ -4792,7 +4792,7 @@ D'autres peuvent être ajoutées pour améliorer la surveillance de
     arg0 indique un tri de la table, de l'index ou d'un datum.
     arg1 est true si on force les valeurs uniques.
     arg2 est le nombre de colonnes clés.
-    arg3 est le nombre de Ko de mémoire autorisé pour ce travail.
+    arg3 est le nombre de ko de mémoire autorisé pour ce travail.
     arg4 est true si un accès aléatoire au résultat du tri est requis
     arg5 indicates serial when <literal>0</literal>, parallel worker when
     <literal>1</literal>, or parallel leader when <literal>2</literal>.</entry>
@@ -4803,7 +4803,7 @@ D'autres peuvent être ajoutées pour améliorer la surveillance de
    <entry>Sonde qui se déclenche quand un tri est terminé.
     arg0 est true pour un tri externe, false pour un tri interne.
     arg1 est le nombre de blocs disque utilisés pour un tri externe, ou le
-    nombre de Ko de mémoire utilisés pour un tri interne</entry>
+    nombre de ko de mémoire utilisés pour un tri interne</entry>
   </row>
   <row>
    <entry><literal>lwlock-acquire</literal></entry>

--- a/postgresql/problems.xml
+++ b/postgresql/problems.xml
@@ -171,7 +171,7 @@
       Si le programme se termine avec une erreur du système d'exploitation,
       dites-le. Même si le résultat de votre test est un arrêt brutal du
       programme ou un autre souci évident, il pourrait ne pas survenir sur
-      notre plate-forme. Le plus simple est de copier directement la sortie du
+      notre plateforme. Le plus simple est de copier directement la sortie du
       terminal, si possible.
      </para>
      <note>
@@ -262,7 +262,7 @@
 
     <listitem>
      <para>
-      Informations sur la plate-forme. Ceci inclut le nom du noyau et sa
+      Informations sur la plateforme. Ceci inclut le nom du noyau et sa
       version, bibliothèque C, processeur, mémoires et ainsi de suite. Dans la
       plupart des cas, il est suffisant de préciser le vendeur et la version,
       mais ne supposez pas que tout le monde sait ce que <quote>Debian</quote>
@@ -360,11 +360,11 @@
   </para>
 
   <para>
-   Si votre bogue concerne un problème de portabilité sur une plate-forme non
+   Si votre bogue concerne un problème de portabilité sur une plateforme non
    supportée, envoyez un courrier électronique à
    <email>pgsql-hackers@lists.postgresql.org</email>, pour que nous puissions
    travailler sur le portage de <productname>PostgreSQL</productname> sur votre
-   plate-forme.
+   plateforme.
   </para>
 
   <note>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1565,17 +1565,17 @@ SELECT 1/0;
     préfixées par leur longueur exprimée en entier de quatre octets
     dans l'ordre du réseau.
     Il est à noter que le serveur acceptera uniquement du client des
-    paquets chiffrés dont la longueur est inférieure à 16&nbsp;Ko&nbsp;;
+    paquets chiffrés dont la longueur est inférieure à 16&nbsp;ko&nbsp;;
     <function>gss_wrap_size_limit()</function> devrait être utilisée
     par le client pour déterminer quelle taille de message non chiffré
     n'excède pas cette limite, et découper les messages plus grands
     pour les passer en plusieurs appels à
     <function>gss_wrap()</function>.
 
-    La taille typique des segments non chiffrées est de 8&nbsp;Ko, donnant des paquets
-    chiffrés légèrement plus grands que 8&nbsp;Ko mais bien en-dessous du maximum de
-    16&nbsp;Ko.
-    Le serveur n'est pas censé envoyer des paquets chiffrés plus grands que 16&nbsp;Ko
+    La taille typique des segments non chiffrées est de 8&nbsp;ko, donnant des paquets
+    chiffrés légèrement plus grands que 8&nbsp;ko mais bien en-dessous du maximum de
+    16&nbsp;ko.
+    Le serveur n'est pas censé envoyer des paquets chiffrés plus grands que 16&nbsp;ko
     au client. Pour continuer après la réception du <literal>N</literal>,
     envoyer le StartupMessage usuel et continuer sans chiffrement.
    </para>
@@ -2846,9 +2846,9 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
          <listitem>
           <para>
            Limite la quantité maximale de données transférées du serveur au
-           client par unité de temps. L'unité attendue est le Ko/s. Si cette
+           client par unité de temps. L'unité attendue est le ko/s. Si cette
            option est indiquée, la valeur doit être soit égale à zéro, soit être
-           comprise entre 32 Ko et 1 Go (inclus). Si zéro est passé ou que l'option
+           comprise entre 32&nbsp;ko et 1nbsp;Go (inclus). Si zéro est passé ou que l'option
            n'est pas indiquée, aucune restriction n'est imposée sur le transfert.
           </para>
          </listitem>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -2848,7 +2848,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
            Limite la quantité maximale de données transférées du serveur au
            client par unité de temps. L'unité attendue est le ko/s. Si cette
            option est indiquée, la valeur doit être soit égale à zéro, soit être
-           comprise entre 32&nbsp;ko et 1nbsp;Go (inclus). Si zéro est passé ou que l'option
+           comprise entre 32&nbsp;ko et 1&nbsp;Go (inclus). Si zéro est passé ou que l'option
            n'est pas indiquée, aucune restriction n'est imposée sur le transfert.
           </para>
          </listitem>

--- a/postgresql/ref/create_index.xml
+++ b/postgresql/ref/create_index.xml
@@ -495,7 +495,7 @@
      <listitem>
       <para>
        Personnalise le paramètre <xref linkend="guc-gin-pending-list-limit"/>.
-       Cette valeur est spécifiée en Ko.
+       Cette valeur est spécifiée en ko.
       </para>
      </listitem>
     </varlistentry>

--- a/postgresql/spgist.xml
+++ b/postgresql/spgist.xml
@@ -924,7 +924,7 @@ typedef struct spgLeafConsistentOut
 
    <para>
     Les lignes de feuille individuelles et les lignes intermédiaires doivent tenir dans une
-    unique page d'index (8 Ko par défaut). Cependant, lorsque des données de taille variable
+    unique page d'index (8&nbsp;ko par défaut). Cependant, lorsque des données de taille variable
     sont indexées, les longues valeurs ne sont uniquement supportées que par les arbres suffixés,
     dans lesquels chaque niveau de l'arbre contient un préfixe qui est suffisamment petit
     pour tenir dans une page. La classe d'opérateur doit uniquement définir <structfield>longValuesOK</structfield>

--- a/postgresql/storage.xml
+++ b/postgresql/storage.xml
@@ -344,7 +344,7 @@
 
   <para>
    Puisque <productname>PostgreSQL</productname> utilise une taille de page fixe
-   (habituellement 8&nbsp;Ko) et n'autorise pas qu'une ligne s'étende sur plusieurs
+   (habituellement 8&nbsp;ko) et n'autorise pas qu'une ligne s'étende sur plusieurs
    pages. Du coup, il n'est pas possible de stocker de grandes valeurs directement
    dans les champs. Pour dépasser cette limitation, les valeurs de champ
    volumineuses sont compressées et/ou divisées en plusieurs lignes physiques. Ceci
@@ -475,10 +475,10 @@
    <para>
     Le code <acronym>TOAST</acronym> est déclenché seulement quand une valeur de ligne
     à stocker dans une table est plus grande que <symbol>TOAST_TUPLE_THRESHOLD</symbol> octets (habituellement
-    2&nbsp;Ko). Le code <acronym>TOAST</acronym> compressera et/ou déplacera les valeurs
+    2&nbsp;ko). Le code <acronym>TOAST</acronym> compressera et/ou déplacera les valeurs
     de champ hors la ligne jusqu'à ce que la valeur de la ligne soit plus petite que
     <symbol>TOAST_TUPLE_TARGET</symbol> octets  (habituellement là-aussi
-    2&nbsp;Ko) ou que plus aucun gain ne puisse être réalisé.
+    2&nbsp;ko) ou que plus aucun gain ne puisse être réalisé.
     Lors d'une opération UPDATE, les valeurs des champs non modifiées sont habituellement
     préservées telles quelles&nbsp;; donc un UPDATE sur une ligne avec des valeurs hors
     ligne n'induit pas de coûts à cause de <acronym>TOAST</acronym> si aucune des valeurs
@@ -560,7 +560,7 @@
     table principale contenait moins de 10&nbsp;% de la totalité des données (les
     URL et quelques petites pages HTML). Il n'y avait pas de différence à l'exécution
     en comparaison avec une table non <acronym>TOAST</acronym>ée, dans laquelle toutes les
-    pages HTLM avaient été coupées à 7&nbsp;Ko pour tenir.
+    pages HTLM avaient été coupées à 7&nbsp;ko pour tenir.
    </para>
   </sect2>
   
@@ -790,7 +790,7 @@
 
   <para>
    Chaque table et index est stocké comme un tableau de <firstterm>pages</firstterm> d'une
-   taille fixe (habituellement 8&nbsp;Ko, bien qu'une taille de page différente
+   taille fixe (habituellement 8&nbsp;ko, bien qu'une taille de page différente
    peut être sélectionnée lors de la compilation du serveur). Dans une table,
    toutes les pages sont logiquement équivalentes pour qu'un élément (ligne)
    particulier puisse être stocké dans n'importe quelle page. Dans les index, la

--- a/postgresql/textsearch.xml
+++ b/postgresql/textsearch.xml
@@ -4073,7 +4073,7 @@ Parser: "pg_catalog.default"
    <productname>PostgreSQL</productname> sont&nbsp;:
    <itemizedlist  spacing="compact" mark="bullet">
     <listitem>
-     <para>La longueur de chaque lexème doit être inférieure à 2&nbsp;Ko</para>
+     <para>La longueur de chaque lexème doit être inférieure à 2&nbsp;ko</para>
     </listitem>
     <listitem>
      <para>La longueur d'un <type>tsvector</type> (lexèmes + positions) doit


### PR DESCRIPTION
Le Ko n'existe pas (Kelvin-octet ?!), le système SI donne k pour kilo comme dans kg.
(On pourrait choisir des kibioctets, soit Kio...)
Corrigé "Koréen" au passage.
L'Académie française accepte la forme "plate-forme" mais recommande depuis 1990 de
supprimer les tirets si possible, et la version sans tiret était déjà majoritaire.