### PR TITLE
Traduction pgtrgm.xml vs 13β1 + relecture complète

### DIFF
--- a/postgresql/pgtrgm.xml
+++ b/postgresql/pgtrgm.xml
@@ -398,7 +398,7 @@
      </term>
      <listitem>
       <para>
-       Configure la limite de similarité utilisée par les opérateurs
+       Configure la limite de similarité de mot utilisée par les opérateurs
        <literal>&lt;%</literal> et <literal>%&gt;</literal>. La limite doit être
        comprise entre 0 et 1 (la valeur par défaut est 0,6).
       </para>
@@ -416,7 +416,7 @@
      </term>
      <listitem>
       <para>
-       Configure la limite de similarité utilisée par les opérateurs
+       Configure la limite de similarité de mot stricte utilisée par les opérateurs
        <literal>&lt;&lt;%</literal> et <literal>%&gt;&gt;</literal>. La limite doit être
        comprise entre 0 et 1 (la valeur par défaut est 0,5).
       </para>

--- a/postgresql/pgtrgm.xml
+++ b/postgresql/pgtrgm.xml
@@ -20,9 +20,10 @@
  </para>
 
  <para>
-  This module is considered <quote>trusted</quote>, that is, it can be
-  installed by non-superusers who have <literal>CREATE</literal> privilege
-  on the current database.
+   Ce module est considéré comme <quote>trusted</quote>, c'est-à-dire qu'il
+   peut être installé par des utilisateurs simples (sans attribut
+   <literal>SUPERUSER</literal>) possédant l'attribut <literal>CREATE</literal>
+   sur la base de données courante.
  </para>
 
  <sect2>
@@ -36,8 +37,6 @@
    langues.
   </para>
 
-  <!-- SAS 20081203 : Cette présentation rend mal-aisée la compréhension de
-  l'exemple du fait des espaces induites par les <quote> -->
   <note>
    <para>
     <filename>pg_trgm</filename> ignore les caractères qui ne forment pas
@@ -47,10 +46,10 @@
     suffixe lors de la détermination de l'ensemble de trigrammes contenu dans
     la chaîne. Par exemple, l'ensemble des trigrammes dans la chaîne
     <quote><literal>cat</literal></quote> est
-    <quote><literal>  c</literal></quote> ('  c'),
-    <quote><literal> ca</literal></quote> (' ca'),
+    <quote><literal>  c</literal></quote>,
+    <quote><literal> ca</literal></quote>,
     <quote><literal>cat</literal></quote> et
-    <quote><literal>at </literal></quote> ('at ').
+    <quote><literal>at </literal></quote>.
     L'ensemble de trigrammes dans la chaîne
     <quote><literal>foo|bar</literal></quote> est
     <quote><literal>  f</literal></quote>,
@@ -156,7 +155,8 @@
         <literal>%</literal>. Ceci configure la similarité minimale entre deux
         mots pour qu'ils soient considérés suffisamment proches pour être des
         fautes d'orthographe l'un de l'autre
-        (<emphasis>obsolète</emphasis>; instead use <command>SHOW</command>
+        (<emphasis>obsolète</emphasis>&nbsp;; utilisez à la place
+        <command>SHOW</command>
         <varname>pg_trgm.similarity_threshold</varname>.).
        </para></entry>
       </row>
@@ -169,9 +169,10 @@
        </para>
        <para>
         Configure la limite de similarité actuelle utilisée par l'opérateur
-        <literal>%</literal>. Le limite se positionne entre 0 et 1, elle vaut
-        par défaut 0,3. Renvoie la valeur passée (<emphasis>obsolète</emphasis>;
-        instead use <command>SET</command>
+        <literal>%</literal>. La limite doit valoir entre 0 et 1
+        (le défaut est 0,3).
+        (<emphasis>obsolète</emphasis>&nbsp;; utilisez à la place
+        <command>SET</command>
         <varname>pg_trgm.similarity_threshold</varname>.).
        </para></entry>
       </row>
@@ -259,7 +260,7 @@
        </para></entry>
       </row>
 
-      <row>
+      <row> <!--  text <% text → boolean  -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;%</literal> <type>text</type>
         <returnvalue>boolean</returnvalue>
@@ -267,96 +268,99 @@
        <para>
         Renvoie <literal>true</literal> si la similarité entre l'ensemble de
         trigrammes du premier argument et une étendue continue d'un ensemble
-        trie de trigrammes dans le second argument est plus grande que la
+        trié de trigrammes dans le second argument est plus grande que la
         limite de similarité actuelle, telle qu'elle est configurée avec le
         paramètre <varname>pg_trgm.word_similarity_threshold</varname>.
        </para></entry>
       </row>
 
-      <row>
+      <row> <!-- text %> text → boolean -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>%&gt;</literal> <type>text</type>
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
-        Commutateur de l'opérateur <literal>&lt;&lt;%</literal>.
+        Inverse de l'opérateur <literal>&lt;&lt;%</literal>.
        </para></entry>
       </row>
 
-      <row>
+      <row> <!-- text <<% text → boolean -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;&lt;%</literal> <type>text</type>
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
-        Returns <literal>true</literal> if its second argument has a continuous
-        extent of an ordered trigram set that matches word boundaries,
-        and its similarity to the trigram set of the first argument is greater
-        than the current strict word similarity threshold set by the
-        <varname>pg_trgm.strict_word_similarity_threshold</varname> parameter.
+        <!-- FIXME : clair comme du jus de chique  -->
+        Renvoie <literal>true</literal> si son second argument 
+        possède une étendue continue d'un ensemble de trigrammes trié
+        correspondant aux limites de mots, et que sa similarité avec
+        l'ensemble de trigrammes du premier argument est plus grand
+        que la limite de similarité stricte de mot strict courante,
+        telle que configurée par le paramètre
+        <varname>pg_trgm.strict_word_similarity_threshold</varname>
        </para></entry>
       </row>
 
-      <row>
+      <row> <!--  text %>> text → boolean -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>%&gt;&gt;</literal> <type>text</type>
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
-        Commutator of the <literal>&lt;&lt;%</literal> operator.
+        Inverse de l'opérateur <literal>&lt;&lt;%</literal>.
        </para></entry>
       </row>
 
-      <row>
+      <row>  <!-- text <-> text → real -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;-&gt;</literal> <type>text</type>
         <returnvalue>real</returnvalue>
        </para>
        <para>
-        Returns the <quote>distance</quote> between the arguments, that is
-        one minus the <function>similarity()</function> value.
+        Retourne la <quote>distance</quote> entre les arguments,
+        c'est-à-dire un moins la valeur de <function>similarity()</function>.
        </para></entry>
       </row>
 
-      <row>
+      <row> <!--  text <<-> text → real -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;&lt;-&gt;</literal> <type>text</type>
         <returnvalue>real</returnvalue>
        </para>
        <para>
-        Returns the <quote>distance</quote> between the arguments, that is
-        one minus the <function>word_similarity()</function> value.
+        Retourne la <quote>distance</quote> entre les arguments,
+        c'est-à-dire un moins la valeur de <function>word_similarity()</function>.
        </para></entry>
       </row>
 
-      <row>
+      <row>   <!--  text <->> text → real   -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;-&gt;&gt;</literal> <type>text</type>
         <returnvalue>real</returnvalue>
        </para>
        <para>
-        Commutator of the <literal>&lt;&lt;-&gt;</literal> operator.
+        Inverse de l'opérateur <literal>&lt;&lt;-&gt;</literal>.
        </para></entry>
       </row>
 
-      <row>
+      <row>  <!--  text <<<-> text → real   -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;&lt;&lt;-&gt;</literal> <type>text</type>
         <returnvalue>real</returnvalue>
        </para>
        <para>
-        Returns the <quote>distance</quote> between the arguments, that is
-        one minus the <function>strict_word_similarity()</function> value.
+        Retourne la <quote>distance</quote> entre les arguments,
+        c'est-à-dire un moins la valeur de <function>strict_word_similarity()</function>.
        </para></entry>
       </row>
 
-      <row>
+      <row> <!--  text <->>> text → real -->
        <entry role="func_table_entry"><para role="func_signature">
         <type>text</type> <literal>&lt;-&gt;&gt;&gt;</literal> <type>text</type>
         <returnvalue>real</returnvalue>
        </para>
        <para>
-        Commutator of the <literal>&lt;&lt;&lt;-&gt;</literal> operator.
+        Inverse de l'opérateur <literal>&lt;&lt;&lt;-&gt;</literal>.
        </para></entry>
       </row>
      </tbody>
@@ -377,7 +381,7 @@
     </term>
     <listitem>
      <para>
-      Configure la limite actuelle de similarité utilisée par l'opérateur
+      Configure la limite de similarité utilisée par l'opérateur
       <literal>%</literal>. La limite doit se situer entre 0 et 1 (la valeur
       par défaut est 0,3).
      </para>
@@ -394,15 +398,33 @@
      </term>
      <listitem>
       <para>
-       Configure la limite actuelle de similarité utilisée par les opérateurs
+       Configure la limite de similarité utilisée par les opérateurs
        <literal>&lt;%</literal> et <literal>%&gt;</literal>. La limite doit être
        comprise entre 0 et 1 (la valeur par défaut est 0,6).
       </para>
      </listitem>
     </varlistentry>
   </variablelist>
+   <varlistentry id="guc-pgtrgm-strict-word-similarity-threshold" xreflabel="pg_trgm.strict_word_similarity_threshold">
+     <term>
+      <varname>pg_trgm.strict_word_similarity_threshold</varname> (<type>real</type>)
+      <indexterm>
+       <primary>
+        paramètre de configuration <varname>pg_trgm.strict_word_similarity_threshold</varname>
+       </primary>
+      </indexterm>
+     </term>
+     <listitem>
+      <para>
+       Configure la limite de similarité utilisée par les opérateurs
+       <literal>&lt;&lt;%</literal> et <literal>%&gt;&gt;</literal>. La limite doit être
+       comprise entre 0 et 1 (la valeur par défaut est 0,5).
+      </para>
+     </listitem>
+    </varlistentry>
+  </variablelist>
  </sect2>
-
+ 
  <sect2>
   <title>Support des index</title>
 
@@ -415,7 +437,7 @@
    requêtes <literal>LIKE</literal>, <literal>ILIKE</literal>, <literal>~</literal>
    et <literal>~*</literal>. (Ces index
    ne supportent pas les opérateurs d'égalité ou de comparaison simple, donc
-   vous pouvez aussi avoir besoin d'un index B-tree).
+   vous pouvez aussi avoir besoin d'un index B-tree classique).
   </para>
 
   <para>
@@ -432,17 +454,20 @@ CREATE INDEX trgm_idx ON test_trgm USING GIN (t gin_trgm_ops);
   </para>
 
   <para>
-   <literal>gist_trgm_ops</literal> GiST opclass approximates a set of
-   trigrams as a bitmap signature.  Its optional integer parameter
-   <literal>siglen</literal> determines the
-   signature length in bytes.  The default length is 12 bytes.
-   Valid values of signature length are between 1 and 2024 bytes.  Longer
-   signatures lead to a more precise search (scanning a smaller fraction of the index and
-   fewer heap pages), at the cost of a larger index.
+   L'opérateur de classe GiST <literal>gist_trgm_ops</literal>
+   assimile un ensemble de trigramme à une signature bitmap.
+   Son paramètre entier optionnel <literal>siglen</literal> détermine
+   la longueur de la signature en octets.
+   La valeur par défaut est de 12 octets.
+   Les valeurs valides vont de 1 à 2024 octets.
+   Les signatures longues mènent à une recherche plus précise
+   (parcourant une plus petite fraction de l'index
+   et moins de pages de la table), au prix d'un index plus gros.
   </para>
 
   <para>
-   Example of creating such an index with a signature length of 32 bytes:
+   Exemple de création d'un tle index avec une longueur de signature
+   de 32 octets&nbsp;:
   </para>
 <programlisting>
 CREATE INDEX trgm_idx ON test_trgm USING GIST (t gist_trgm_ops(siglen=32));
@@ -460,8 +485,8 @@ SELECT t, similarity(t, '<replaceable>word</replaceable>') AS sml
   ORDER BY sml DESC, t;
   </programlisting>
   <para>
-   Ceci renverra toutes les valeurs dans la colonne texte qui sont suffisamment
-   similaire à <replaceable>word</replaceable>, triées de la meilleure
+   Ceci renverra toutes les valeurs dans la colonne texte suffisamment
+   similaires à <replaceable>word</replaceable>, triées de la meilleure
    correspondance à la pire. L'index sera utilisé pour accélérer l'opération
    même sur un grand ensemble de données.
   </para>
@@ -475,12 +500,12 @@ SELECT t, t &lt;-&gt; '<replaceable>word</replaceable>' AS dist
    </programlisting>
    Ceci peut être implémenté assez efficacement par des index GiST, mais pas
    par des index GIN. Cela battra généralement la première formulation quand
-   seulement un petit nombre de correspondances proches est demandé.
+   on demande juste un petit nombre de correspondances proches.
   </para>
 
   <para>
    De plus, vous pouvez utiliser un index sur la colonne
-   <structfield>t</structfield> pour la similarité (stricte ou pas) entre mots.
+   <structfield>t</structfield> pour la similarité, stricte ou pas, entre mots.
   Des requêtes typiques sont&nbsp;:
 <programlisting>
 SELECT t, strict_word_similarity('<replaceable>word</replaceable>', t) AS sml
@@ -496,10 +521,10 @@ SELECT t, word_similarity('<replaceable>word</replaceable>', t) AS sml
   ORDER BY sml DESC, t;
 </programlisting>
    Ceci renverra toutes les valeurs dans la colonne texte pour lesquelles il
-   existe une étendue continue de l'ensemble ordonné de trigrammes qui est
+   existe une étendue continue de l'ensemble ordonné de trigrammes
    suffisamment similaire à l'ensemble de trigrammes de
    <replaceable>word</replaceable>, trié de la meilleure correspondance à la
-   pire. L'index sera utilisé pour accélérer l'opération y compris sur des
+   pire. L'index sera utilisé pour accélérer l'opération, y compris sur de
    très gros ensembles de données.
   </para>
 
@@ -528,36 +553,38 @@ SELECT t, '<replaceable>word</replaceable>' &lt;&lt;&lt;-&gt; t AS dist
 SELECT * FROM test_trgm WHERE t LIKE '%foo%bar';
    </programlisting>
    La recherche par index fonctionne par extraction des trigrammes à partir
-   de la chaîne recherchée puis en les recherchant dans l'index. Plus le
+   de la chaîne recherchée, puis en les recherchant dans l'index. Plus le
    nombre de trigrammes dans la recherche est important, plus efficace sera la
-   recherche. Contrairement à des recherches basées sur les B-tree, la chaîne
-   de recherche ne doit pas avoir un signe de pourcentage sur le côté gauche.
+   recherche.
+   Contrairement à des recherches basées sur les B-tree, la chaîne
+   de recherche n'a pas besoin d'un signe pourcentage sur le côté gauche.
   </para>
 
   <para>
    À partir de <productname>PostgreSQL</productname> 9.3, ces types d'index
-   supportent aussi les recherches dans l'index pour les correspondances
+   supportent aussi les recherches de correspondances
    d'expressions rationnelles (opérateurs <literal>~</literal> et
    <literal>~*</literal>). Par exemple
    <programlisting>
 SELECT * FROM test_trgm WHERE t ~ '(foo|bar)';
    </programlisting>
    La recherche dans l'index fonctionne en extrayant les trigrammes de
-   l'expression rationnelles et en les recherchant dans l'index. Plus il est
+   l'expression rationnelles, puis en les recherchant dans l'index. Plus il est
    possible d'extraire de trigrammes de l'expression rationnelle, plus la
-   recherche dans l'index sera efficace. Contrairement aux recherches dans un
-   B-tree, la chaîne de recherche n'a pas besoin d'être fixe à gauche.
+   recherche dans l'index sera efficace.
+   Contrairement à des recherches basées sur les B-tree, la chaîne
+   de recherche n'a pas besoin d'un signe pourcentage sur le côté gauche.
   </para>
 
   <para>
-   Pour les recherches <literal>LIKE</literal> ainsi que les recherches dans des
+   Pour les recherches <literal>LIKE</literal> comme avec des
    expressions rationnelles, gardez en tête qu'un motif sans trigramme extractible
-   sera la cause d'un parcours complet de l'index.
+   dégénérera en parcours complet de l'index.
   </para>
 
   <para>
-   Le choix d'un indexage GiST ou GIN dépend des caractéristiques relatives
-   de performance qui sont discutées ailleurs.
+   Le choix d'un indexage GiST ou GIN dépend de leurs caractéristiques
+   de performance relatives, qui sont discutées ailleurs.
   </para>
  </sect2>
 
@@ -565,11 +592,11 @@ SELECT * FROM test_trgm WHERE t ~ '(foo|bar)';
   <title>Intégration à la recherche plein texte</title>
 
   <para>
-   La correspondance de trigramme est un outil très utile lorsqu'il est
+   La correspondance de trigrammes est un outil très utile lorsqu'il est
    utilisé en conjonction avec un index plein texte. En particulier, il peut
-   aider à la reconnaissance des mots mal orthographiés (ou tout simplement
-   mal saisis), mots pour lesquels le mécanisme de recherche plein texte ne
-   pourra pas faire une reconnaissance.
+   aider à la reconnaissance des mots mal orthographiés,
+   pour lesquels le mécanisme de recherche plein texte ne trouvera pas de
+   correspondance.
   </para>
 
   <para>
@@ -583,12 +610,12 @@ CREATE TABLE words AS SELECT word FROM
   </programlisting>
 
   <para>
-   où <structname>documents</structname> est une table qui a un champ texte
-   <structfield>bodytext</structfield> où nous voulons faire nos recherches.
+   où <structname>documents</structname> est une table avec un champ texte
+   <structfield>bodytext</structfield>, où nous voulons faire nos recherches.
    La raison de l'utilisation de la configuration <literal>simple</literal>
-   avec la fonction <function>to_tsvector</function>, au lieu d'une
-   configuration spécifique à la langue, est que nous voulons une liste des
-   mots originaux.
+   dans la fonction <function>to_tsvector</function>
+   est que nous voulons une liste des mots originaux (non réduits à leur racine),
+   plutôt qu'une configuration spécifique à la langue.
   </para>
 
   <para>
@@ -600,20 +627,21 @@ CREATE INDEX words_idx ON words USING GIN(word gin_trgm_ops);
   </programlisting>
 
   <para>
-   Maintenant, une requête <command>SELECT</command> similaire à l'exemple
-   précédent peut être utilisée pour suggérer des mots dans les termes de la
-   recherche de l'utilisateur. Un test utile supplémentaire vient à demander
-   que les mots sélectionnés soient aussi d'une longueur similaire au mot
+   Maintenant, une requête <command>SELECT</command>, similaire à l'exemple
+   précédent, peut être utilisée pour suggérer des mots mal orthographiés
+   dans la recherche de l'utilisateur.
+   Un test utile supplémentaire est de demander aussi
+   que les mots sélectionnés soient d'une longueur similaire au mot
    mal orthographié.
   </para>
 
   <note>
    <para>
     Comme la table <structname>words</structname> a été générée comme une table
-    statique, séparée, il sera nécessaire de la regénérer périodiquement
-    pour qu'elle reste raisonnablement à jour avec la collection des
-    documents. Qu'elle soit exactement identique en permanence n'est
-    habituellement pas nécessaire.
+    statique, séparée, il sera nécessaire de la régénérer périodiquement,
+    afin qu'elle reste raisonnablement à jour avec la collection des
+    documents. Il n'est pas nécessaire, généralement, qu'elle soit
+    en permanence totalement à jour.
    </para>
   </note>
  </sect2>


### PR DESCRIPTION
Mise à jour de pgtrm.xml vs 13_BETA1.

Tenté d'alléger quelques formulations.
Supprimé un commentaire et un doublonnage dans le premier exemple sur "cat" (peut-être nécessaires en 2008 ?)
J'ai laissé un FIXME sur un passage dont je n'arrive pas à faire quelque chose de réellement  compréhensible en français.
Remplacé "Commutateur de" par "Inverse de", à mon sens plus compréhensible.
Ajouté en commentaire les opérateurs `<<->` et consorts, car en HTML c'était illisible.
Il manquait un des GUC

