### PR TITLE
Installation.xml : traduction 13β1 + relecture complète

### DIFF
--- a/postgresql/installation.xml
+++ b/postgresql/installation.xml
@@ -486,7 +486,7 @@ build-postgresql:
    <title>Tests de régression</title>
 
    <indexterm>
-    <primary>regression test</primary>
+    <primary>tests de régression</primary>
    </indexterm>
 
    <para>
@@ -570,7 +570,7 @@ build-postgresql:
     L'installation standard fournit tous les fichiers d'en-tête nécessaire au
     développement d'applications clientes, comme pour celui côté serveur,
     par exemple pour des fonctions spécifiques ou des types de données codés en C.
-    (Avant <productname>PostgreSQL</productname>&nbps;8.0,
+    (Avant <productname>PostgreSQL</productname>&nbsp;8.0,
     un <literal>make install-all-headers</literal> séparé était nécessaire pour
     le deuxième cas, mais cette étape a été intégrée dans l'installation standard.)
    </para>
@@ -634,7 +634,7 @@ build-postgresql:
    <title>Options de <filename>configure</filename></title>
 
    <indexterm zone="configure-options">
-    <primary>configure options</primary>
+    <primary>configure (options)</primary>
    </indexterm>
 
    <para>
@@ -1348,7 +1348,7 @@ build-postgresql:
        <productname>PostgreSQL</productname>.
       </para>
 
-      <indexterm><primary>cross compilation</primary></indexterm>
+      <indexterm><primary>compilation croisée</primary></indexterm>
 
       <para>
        Cette option est surtout destinée aux distributeurs de paquets binaires,
@@ -1356,7 +1356,7 @@ build-postgresql:
        Le principal avantage de cette option est que le paquet de PostgreSQL
        n'aura pas besoin de mise à jour à chaque changement des règles des fuseaux
        horaires. Un autre avantage est que PostgreSQL peut être
-       cross-compilé<indexterm><primary>cross compilation</primary></indexterm>
+       cross-compilé<indexterm><primary>compilation croisée</primary></indexterm>
        plus simplement si les fichiers des fuseaux horaires n'ont pas besoin
        d'être construits lors de l'installation.
       </para>
@@ -1679,7 +1679,7 @@ build-postgresql:
   <title>Variables d'environnement de <filename>configure</filename></title>
 
   <indexterm zone="configure-envvars">
-   <primary>configure environment variables</primary>
+   <primary>configure (variables d'environnement)</primary>
   </indexterm>
 
   <para>
@@ -2145,15 +2145,15 @@ build-postgresql:
    <title>Bibliothèques partagées</title>
 
    <indexterm>
-    <primary>bibliothèque partagée</primary>
+    <primary>bibliothèques partagées</primary>
    </indexterm>
 
    <para>
-    Sur certains systèmes qui utilisent les bibliothèques partagées (ce que font
-    de nombreux systèmes), vous avez besoin de leurs spécifier comment trouver
+    Sur certains systèmes gérant des bibliothèques partagées,
+    il faut spécifier comment trouver
     les nouvelles bibliothèques partagées. Les systèmes sur lesquels ce
-    <emphasis>n'est</emphasis> pas nécessaire comprennent <systemitem
-    class="osname">FreeBSD</systemitem>,
+    n'est <emphasis>pas</emphasis> nécessaire comprennent
+    <systemitem class="osname">FreeBSD</systemitem>,
     <systemitem class="osname">HP-UX</systemitem>,
     <systemitem class="osname">Linux</systemitem>,
     <systemitem class="osname">NetBSD</systemitem>, <systemitem
@@ -2162,9 +2162,9 @@ build-postgresql:
    </para>
 
    <para>
-    La méthode pour le faire varie selon la plateforme, mais la méthode la plus
-    répandue consiste à positionner des variables d'environnement comme
-    <envar>LD_LIBRARY_PATH</envar>&nbsp;: avec les shells Bourne
+    La méthode pour le faire varie selon la plateforme, mais la plus
+    répandue consiste à positionner la variable d'environnement
+    <envar>LD_LIBRARY_PATH</envar> ainsi&nbsp;: avec les shells Bourne
     (<command>sh</command>, <command>ksh</command>, <command>bash</command>, <command>zsh</command>)&nbsp;:
 <programlisting>LD_LIBRARY_PATH=/usr/local/pgsql/lib
 export LD_LIBRARY_PATH</programlisting>
@@ -2173,8 +2173,8 @@ export LD_LIBRARY_PATH</programlisting>
     Remplacez <literal>/usr/local/pgsql/lib</literal> par la valeur donnée à
     <option><literal>--libdir</literal></option> dans l'<xref linkend="configure"/>.
     Vous pouvez mettre ces commandes dans un script de démarrage tel
-    que <filename>/etc/profile</filename> ou <filename>~/.bash_profile</filename>. Certaines
-    informations pertinentes au sujet de mises en garde associées à cette
+    que <filename>/etc/profile</filename> ou <filename>~/.bash_profile</filename>.
+    De bons conseils sur les mises en garde associées à cette
     méthode peuvent être trouvées sur
     <ulink url="http://xahlee.info/UnixResource_dir/_/ldpath.html"></ulink>.
    </para>
@@ -2188,7 +2188,7 @@ export LD_LIBRARY_PATH</programlisting>
 
    <para>
     Avec <systemitem class="osname">Cygwin</systemitem>, placez le répertoire
-    des bibliothèques dans la variable <envar>PATH</envar> ou déplacez les
+    des bibliothèques dans la variable <envar>PATH</envar>, ou déplacez les
     fichiers <filename>.dll</filename> dans le répertoire
     <filename>bin</filename>.
    </para>
@@ -2199,7 +2199,7 @@ export LD_LIBRARY_PATH</programlisting>
     ultérieurement un message tel que
 <screen>psql: error in loading shared libraries
 libpq.so.2.1: cannot open shared object file: No such file or directory</screen>
-    alors cette étape est vraiment nécessaire. Faites-y attention.
+    alors cette étape est vraiment nécessaire. Occupez-vous en alors.
    </para>
 
    <para>
@@ -2232,17 +2232,17 @@ libpq.so.2.1: cannot open shared object file: No such file or directory</screen>
 
    <para>
     Si l'installation a été réalisée dans
-    <filename>/usr/local/pgsql</filename> ou à un autre endroit qui n'est pas dans les
-    répertoires contenant les exécutables par défaut, vous devez ajouter
+    <filename>/usr/local/pgsql</filename> ou à un autre chemin hors des
+    répertoires où par défaut sont recherchés les exécutables, vous devez ajouter
     <filename>/usr/local/pgsql/bin</filename> (ou le répertoire fourni à
     <option><literal>--bindir</literal></option> au moment de l'<xref linkend="configure"/>)
-    dans votre <envar>PATH</envar>. Techniquement, ce n'est pas une obligation mais
+    dans votre <envar>PATH</envar>. À strictement parler, ce n'est pas une obligation, mais
     cela rendra l'utilisation de <productname>PostgreSQL</productname> plus confortable.
    </para>
 
    <para>
     Pour ce faire, ajoutez ce qui suit dans le fichier d'initialisation de
-    votre shell, par exemple
+    votre shell, comme
     <filename>~/.bash_profile</filename> (ou <filename>/etc/profile</filename>, si vous voulez
     que tous les utilisateurs l'aient)&nbsp;:
 <programlisting>PATH=/usr/local/pgsql/bin:$PATH
@@ -2259,7 +2259,7 @@ export PATH</programlisting>
     Pour que votre système trouve la documentation <application>man</application>,
     il vous faut ajouter des lignes telles que celles qui suivent à votre
     fichier d'initialisation du shell, à moins que vous installiez ces pages
-    dans un répertoire où elles sont mises normalement&nbsp;:
+    dans un répertoire où elles sont recherchées normalement&nbsp;:
 <programlisting>MANPATH=/usr/local/pgsql/share/man:$MANPATH
 export MANPATH</programlisting>
    </para>
@@ -2268,8 +2268,9 @@ export MANPATH</programlisting>
     Les variables d'environnement <envar>PGHOST</envar> et <envar>PGPORT</envar>
     indiquent aux applications clientes l'hôte et le port du serveur de base.
     Elles surchargent les valeurs utilisées lors de la compilation. Si vous
-    exécutez des applications clientes à distance, alors c'est plus pratique si
-    tous les utilisateurs peuvent paramétrer <envar>PGHOST</envar>. Ce n'est pas une
+    exécutez des applications clientes à distance, alors il est plus pratique que
+    tous les utilisateurs prévoyant d'utiliser la base de données
+    paramètrent <envar>PGHOST</envar>. Ce n'est pas une
     obligation, cependant, la configuration peut être communiquée via les
     options de lignes de commande à la plupart des programmes clients.
    </para>
@@ -2304,26 +2305,26 @@ export MANPATH</programlisting>
    architectures n'ont pas été testées récemment à notre connaissance. Il est
    souvent possible de construire <productname>PostgreSQL</productname> sur
    un type de processeur non supporté en précisant
-   <option>--disable-spinlocks</option>. Cependant, les performances en
-   souffriront.
+   <option>--disable-spinlocks</option>&nsbp;; mais les performances
+   seront mauvaises.
   </para>
 
   <para>
-   <productname>PostgreSQL</productname> doit fonctionner sur les systèmes
+   De manière générale, <productname>PostgreSQL</productname> doit fonctionner sur les systèmes
    d'exploitation suivants&nbsp;: Linux (toutes les distributions récentes),
    Windows (XP et ultérieurs), FreeBSD, OpenBSD, NetBSD, macOS,
-   AIX, HP/UX et Solaris. D'autres systèmes style
-   Unix peuvent aussi fonctionner mais n'ont pas été récemment testés. Dans
+   AIX, HP/UX et Solaris. D'autres systèmes de type
+   Unix peuvent aussi fonctionner, mais ne sont pas testés pour le moment. Dans
    la plupart des cas, toutes les architectures processeurs supportées par
    un système d'exploitation donné fonctionneront. Cherchez dans le
    répertoire <xref linkend="installation-platform-notes"/> ci-dessous pour
    voir s'il y a des informations spécifiques à votre système d'exploitation,
-   tout particulièrement dans le cas d'un vieux système.
+   tout particulièrement dans le cas d'un ancien système.
   </para>
 
   <para>
-   Si vous avez des problèmes d'installation sur une plateforme qui est connue
-   comme étant supportée d'après les récents résultats de la ferme de
+   Si vous avez des problèmes d'installation sur une plateforme connue
+   comme supportée d'après des résultats récents de la ferme de
    construction, merci de rapporter cette information à
    <email>pgsql-bugs@lists.postgresql.org</email>. Si vous êtes intéressé pour porter
    <productname>PostgreSQL</productname> sur une nouvelle plateforme,

--- a/postgresql/installation.xml
+++ b/postgresql/installation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <chapter id="installation">
- <title>Procédure d'installation du code source</title>
+ <title>Procédure d'installation depuis le code source</title>
 
  <indexterm zone="installation">
   <primary>installation</primary>
@@ -9,18 +9,17 @@
  <!-- See also the version of this text in standalone-install.xml -->
  <para>
   Ce chapitre décrit l'installation de <productname>PostgreSQL</productname>
-  en utilisant le code source. Ce chapitre peut être ignoré lors de
-  l'installation d'une distribution pré-empaquetée, paquet RPM ou Debian, par
-  exemple. Il est alors plus utile de lire les instruction du mainteneur du
-  paquet.
+  à partir du code source. Si vous installez un paquet fourni
+  une distribution, comme un paquet RPM ou Debian, ignorez ce chapitre,
+  et allez lire les instructions du mainteneur du paquet.
  </para>
 
  <para>
   Si vous construisez <productname>PostgreSQL</productname> pour Microsoft
   Windows, continuez la lecture de ce chapitre si vous avez pour but
   d'utiliser MinGW ou Cygwin&nbsp;; par contre, si vous voulez utiliser
-  <productname>Visual C++</productname> de Microsoft, lire à la place <xref
-  linkend="install-windows"/>.
+  <productname>Visual C++</productname> de Microsoft, lisez à la place
+  <xref linkend="install-windows"/>.
  </para>
 
  <sect1 id="install-short">
@@ -43,12 +42,11 @@ su - postgres
   </para>
  </sect1>
 
-
  <sect1 id="install-requirements">
   <title>Prérequis</title>
 
   <para>
-   En général, les plateformes style unix modernes sont capables
+   En général, les plateformes Unix modernes sont capables
    d'exécuter <productname>PostgreSQL</productname>.
    Les plateformes sur lesquelles des tests ont été effectués sont décrites
    dans la <xref linkend="supported-platforms"/> ci-après.
@@ -83,8 +81,8 @@ su - postgres
       <acronym>ISO</acronym>/<acronym>ANSI</acronym> (au minimum compatible
       avec C99). Une version récente de
       <productname>GCC</productname> est recommandée, mais
-      <productname>PostgreSQL</productname> est connu pour être compilable avec de
-      nombreux compilateurs de divers vendeurs.
+      <productname>PostgreSQL</productname> est connu pour compiler avec de
+      nombreux compilateurs de différents vendeurs.
      </para>
     </listitem>
 
@@ -108,18 +106,19 @@ su - postgres
       La bibliothèque <acronym>GNU</acronym> <productname>Readline</productname> est
       utilisée par défaut. Elle permet à <application>psql</application>
       (l'interpréteur de ligne de commandes SQL de PostgreSQL) de se souvenir de
-      chaque commande saisie, et permet d'utiliser les touches
-      de flèches pour rappeler et éditer les commandes précédentes. C'est très
-      pratique et fortement recommandé. Pour ne pas l'utiliser, il
-      faut préciser <option>--without-readline</option> au moment de l'exécution
-      de la commande <filename>configure</filename>. Une alternative possible est
+      chaque commande saisie, et permet d'utiliser les flèches du clavier
+      pour rappeler et éditer les commandes précédentes. C'est très
+      pratique et fortement recommandé.
+      Si vous n'en voulez pas, vous devrez renseigner l'option
+      <option>--without-readline</option> lors de l'appel à
+      la commande <filename>configure</filename>. Une alternative possible est
       l'utilisation de la bibliothèque <filename>libedit</filename> sous licence
-      BSD, développée au début sur <productname>NetBSD</productname>. La
+      BSD, développée au départ sur <productname>NetBSD</productname>. La
       bibliothèque <filename>libedit</filename> est compatible
-      GNU <productname>Readline</productname> et est utilisée si cette dernière
-      n'est pas trouvée ou si <option>--with-libedit-preferred</option> est utilisé
-      sur la ligne de commande de <filename>configure</filename>. Lorsqu'une
-      distribution Linux à base de paquets est utilisée, si les paquets
+      GNU <productname>Readline</productname>, et est utilisée si cette dernière
+      n'est pas trouvée, ou si l'option <option>--with-libedit-preferred</option>
+      est fournie à <filename>configure</filename>. Si vous utilisez une
+      distribution Linux à base de paquets, et que ceux de
       <literal>readline</literal> et <literal>readline-devel</literal> sont
       séparés, il faut impérativement installer les deux.
      </para>
@@ -132,7 +131,7 @@ su - postgres
       </indexterm>
 
       La bibliothèque de compression <productname>zlib</productname> est
-      utilisée par défaut. Pour ne pas l'utiliser, il faut préciser
+      utilisée par défaut. Si vous n'en voulez pas, il faut préciser
       <option>--without-zlib</option> à
       <filename>configure</filename>. Cela a pour conséquence de désactiver le
       support des archives compressées dans <application>pg_dump</application> et
@@ -152,7 +151,7 @@ su - postgres
    <itemizedlist>
     <listitem>
      <para>
-      Pour installer le langage procédural <application>PL/Perl</application>,
+      Pour compiler le langage procédural <application>PL/Perl</application>,
       une installation complète de <productname>Perl</productname>,
       comprenant la bibliothèque <filename>libperl</filename> et les
       fichiers d'en-tête, est nécessaire.
@@ -164,12 +163,14 @@ su - postgres
       la bibliothèque <indexterm><primary>libperl</primary></indexterm>
       <filename>libperl</filename> doit aussi être partagée sur la plupart des
       plateformes. C'est désormais le choix par défaut dans les versions
-      récentes de <productname>Perl</productname>, mais ce n'était pas le cas
-      dans les versions plus anciennes. Dans tous les cas, c'est du ressort de
-      celui qui installe Perl.  <filename>configure</filename> échouera si la
-      construction de <application>PL/Perl</application> est sélectionnée mais
+      récentes de <productname>Perl</productname>, mais ce ne l'était pas
+      dans les versions plus anciennes&nbsp;; dans tous les cas, c'est du ressort de
+      celui qui a installé Perl chez vous.
+      <filename>configure</filename> échouera si la
+      compilation de <application>PL/Perl</application> est sélectionnée mais
       qu'il ne trouve pas une bibliothèque partagée
-      <filename>libperl</filename>. Dans ce cas, vous devrez reconstruire et
+      <filename>libperl</filename>.
+      Dans ce cas, vous devrez recompiler et
       installer <productname>Perl</productname> manuellement pour être capable
       de construire <application>PL/Perl</application>. Lors du processus de
       configuration pour <productname>Perl</productname>, demandez une
@@ -203,16 +204,17 @@ su - postgres
       <indexterm><primary>libpython</primary></indexterm>
       <filename>libpython</filename> doit l'être aussi sur la plupart des
       plateformes. Ce n'est pas le cas des installations par défaut de
-      <productname>Python</productname> construits à partir des sources mais,
+      <productname>Python</productname> compilées à partir des sources, mais
       une bibliothèque partagée est disponible dans de nombreuses
       distributions de systèmes d'exploitation. <filename>configure</filename>
       échouera si la construction de <application>PL/Python</application> est
       sélectionnée et qu'il ne peut pas trouver une bibliothèque partagée
-      <filename>libpython</filename>. Cela pourrait signifier que vous avez
-      soit besoin d'installer des packages supplémentaires soit reconstruire
-      (une partie de) l'installation <productname>Python</productname> pour
+      <filename>libpython</filename>.
+      Cela peut impliquer que vous devez
+      soit installer des packages supplémentaires, soit reconstruire
+      (une partie de) votre installation <productname>Python</productname> pour
       fournir cette bibliothèque partagée. Lors de la construction à partir
-      des sources, exécutez le configure de <productname>Python</productname>
+      des sources, lancez le <filename>configure</filename> de <productname>Python</productname>
       avec l'option <literal>--enable-shared</literal>.
      </para>
     </listitem>
@@ -220,9 +222,8 @@ su - postgres
     <listitem>
      <para>
       Pour construire le langage procédural
-      <application>PL/Tcl</application>, <productname>Tcl</productname> doit
-      être installé. La version minimale requise de
-      <productname>Tcl</productname> est la 8.4.
+      <application>PL/Tcl</application>, <productname>Tcl</productname> doit bien sûr
+      être installé. La version minimale requise est <productname>Tcl</productname> 8.4.
      </para>
     </listitem>
 
@@ -230,17 +231,18 @@ su - postgres
      <para>
       Pour activer le support de langage natif (<acronym>NLS</acronym>), qui
       permet d'afficher les messages d'un programme dans une langue autre que l'anglais,
-      une implantation de l'<acronym>API</acronym>
-      <application>Gettext</application> est nécessaire. Certains systèmes d'exploitation
+      une implémentation de l'<acronym>API</acronym>
+      <application>Gettext</application> est nécessaire.
+      Certains systèmes d'exploitation
       l'intègrent (par exemple, <systemitem class="osname">Linux</systemitem>,
       <systemitem class="osname">NetBSD</systemitem>,
-      <systemitem class="osname">Solaris</systemitem>). Pour les autres systèmes,
-      un paquet additionnel peut être téléchargé sur <ulink
-      url="http://www.gnu.org/software/gettext/"></ulink>.
-      Pour utiliser l'implantation <application>Gettext</application> des
-      bibliothèques C <acronym>GNU</acronym>, certains utilitaires nécessitent
+      <systemitem class="osname">Solaris</systemitem>) &nbsp;;
+      pour d'autres systèmes,  un paquet additionnel peut être téléchargé sur
+      <ulink url="http://www.gnu.org/software/gettext/"></ulink>.
+      Si vous utilisez l'implémentation <application>Gettext</application> des
+      bibliothèques C <acronym>GNU</acronym>, certains utilitaires nécessiteront
       le paquet <productname>GNU Gettext</productname>.
-      Il n'est pas nécessaire dans les autres implantations.
+      Il n'est pas nécessaire dans les autres implémentations.
      </para>
     </listitem>
 
@@ -274,8 +276,8 @@ su - postgres
   </para>
 
   <para>
-   En cas de compilation à partir d'une arborescence <acronym>Git</acronym> et
-   non d'un paquet de sources publié, ou pour faire du développement au
+   Si vous compilez depuis une arborescence <acronym>Git</acronym> et
+   non d'un paquet des sources publié, ou pour faire du développement au
    niveau serveur, les paquets suivants seront également nécessaires&nbsp;:
 
    <itemizedlist>
@@ -295,11 +297,11 @@ su - postgres
       </indexterm>
 
       GNU <application>Flex</application> et <application>Bison</application>
-      sont nécessaires pour compiler à partir d'un export du Git ou lorsque les
-      fichiers de définition de l'analyseur ou du « scanner » sont modifiés.
-      Les versions nécessaires sont <application>Flex</application> 2.5.31 ou
+      sont nécessaires pour compiler à partir d'un export du Git, ou si vous avez changé
+      les fichiers de définition de l'analyseur ou du «&nbsp;scanner&nbsp;».
+      Au besoin, les versions nécessaires sont <application>Flex</application> 2.5.31 ou
       ultérieure et <application>Bison</application> 1.875 ou ultérieure.
-      Les autres programmes <application>lex</application> et
+      D'autres programmes <application>lex</application> et
       <application>yacc</application> ne peuvent pas être utilisés.
      </para>
     </listitem>
@@ -310,20 +312,20 @@ su - postgres
       </indexterm>
 
       <application>Perl</application> 5.8.3 ou ultérieur est aussi nécessaire pour
-      construire les sources du Git, ou lorsque les fichiers en entrée pour
-      n'importe laquelle des étapes de construction qui utilisent des scripts
-      Perl ont été modifiés. Sous Windows, <application>Perl</application> est
+      compiler les sources du Git, ou si vous avez changé les fichiers en entrée pour
+      n'importe laquelle des étapes qui utilisent des scripts Perl.
+      Sous Windows, <application>Perl</application> est
       nécessaire dans tous les cas. <application>Perl</application> est aussi
-	  requis pour exécuter certains tests unitaires.
+      nécessaire pour lancer certains jeux de tests.
      </para>
     </listitem>
    </itemizedlist>
   </para>
 
   <para>
-   Si d'autres paquets <acronym>GNU</acronym> sont nécessaires, ils peuvent
-   être récupérés sur un site miroir de <acronym>GNU</acronym> (voir <ulink
-   url="https://www.gnu.org/order/ftp.html"></ulink> pour la liste) ou sur
+   Si avez besoin de récupérer un paquet <acronym>GNU</acronym>, vous le trouverez
+   sur votre site miroir local de <acronym>GNU</acronym> (voir
+   <ulink url="https://www.gnu.org/order/ftp.html"></ulink> pour la liste) ou sur
    <ulink url="ftp://ftp.gnu.org/gnu/"></ulink>.
   </para>
 
@@ -331,10 +333,10 @@ su - postgres
    Il est important de vérifier qu'il y a suffisamment d'espace disque
    disponible. 350&nbsp;Mo sont nécessaires pour la compilation et 60&nbsp;Mo pour le
    répertoire d'installation. Un groupe de bases de données vide nécessite
-   40&nbsp;Mo&nbsp;; les fichiers des bases prennent cinq fois plus d'espace que des
+   40&nbsp;Mo&nbsp;; les bases de données prennent environ cinq fois plus d'espace que des
    fichiers texte contenant les mêmes données. Si des tests de
    régression sont prévus, 300&nbsp;Mo supplémentaires sont temporairement
-   nécessaires. On peut utiliser la commande <command>df</command> pour
+   nécessaires. Utilisez la commande <command>df</command> pour
    vérifier l'espace disque disponible.
   </para>
  </sect1>
@@ -343,20 +345,21 @@ su - postgres
   <title>Obtenir les sources</title>
 
   <para>
-   Les sources de <productname>PostgreSQL</productname> &version; peuvent être
-   obtenues dans la section de téléchargement de notre site web&nbsp;:
+   Les sources de <productname>PostgreSQL</productname> &version; sont
+   disponibles dans la section de téléchargement de notre site web&nbsp;:
    <ulink url="https://www.postgresql.org/download/">téléchargement</ulink>.
-   Vous devriez obtenir un fichier nommé
+   Vous devez récupéré un fichier nommé
    <filename>postgresql-&version;.tar.gz</filename> ou
    <filename>postgresql-&version;.tar.bz2</filename>.
    Après avoir obtenu le fichier, on le décompresse&nbsp;:
 <screen><userinput>gunzip postgresql-&version;.tar.gz</userinput>
 <userinput>tar xf postgresql-&version;.tar</userinput></screen>
    (Utilisez <command>bunzip2</command> à la place de <command>gunzip</command>
-   si vous avez le fichier <filename>.bz2</filename>. Also, note that most
-   modern versions of <command>tar</command> can unpack compressed archives
-   directly, so you don't really need the
-   separate <command>gunzip</command> or <command>bunzip2</command> step.)
+   si vous avez le fichier <filename>.bz2</filename>.
+   Notez aussi que la plupart des versions modernes de <command>tar</command>
+   peuvent décompacter des archives compressées directement&bnsp;;
+   vous n'avez alors pas besoin de l'étape avec la commande
+   <command>gunzip</command> ou <command>bunzip2</command>s séparée. )
    Cela crée un répertoire <filename>postgresql-&version;</filename>
    contenant les sources de <productname>PostgreSQL</productname> dans le répertoire
    courant. Le reste de la procédure d'installation s'effectue depuis ce
@@ -383,24 +386,25 @@ su - postgres
 
    <para>
     La première étape de la procédure d'installation est de configurer
-    l'arborescence système et de choisir les options intéressantes.
-    Ce qui est fait en exécutant le script <filename>configure</filename>. Pour une
+    l'arborescence système et de choisir les options qui vous intéressent.
+    Cela se fait en exécutant le script <filename>configure</filename>. Pour une
     installation par défaut, entrer simplement
 <screen><userinput>./configure</userinput></screen>
     Ce script exécutera de nombreux tests afin de déterminer les valeurs
-    de certaines variables dépendantes du système et de détecter certains aléas
-    relatifs au système d'exploitation. Il créera divers
+    de certaines variables dépendantes du système, et de détecter certaines
+    spécificités de votre système d'exploitation. Il créera divers
     fichiers dans l'arborescence de compilation pour enregistrer ce qui a été
     trouvé.
    </para>
 
    <para>
-    <filename>configure</filename> peut aussi être exécuté à
-    partir d'un répertoire hors de l'arborescence des sources, and then build there, pour
-    conserver l'arborescence de compilation séparée from the original source files. Cette procédure est aussi
-    appelée une construction de type
+    Pour garder une arborescence de compilation séparée de celle des sources,
+    <filename>configure</filename> peut être exécuté à
+    partir d'un répertoire hors de l'arborescence des sources,
+    où la construction s'effectuera.
+    Cette procédure est aussi appelée une construction de type
     <indexterm><primary>VPATH</primary></indexterm><firstterm>VPATH</firstterm>.
-    Voici comment la faire&nbsp;:
+    Voici comment faire&nbsp;:
 <screen>
 <userinput>mkdir build_dir</userinput>
 <userinput>cd build_dir</userinput>
@@ -410,136 +414,146 @@ su - postgres
   </para>
 
   <para>
-   La configuration par défaut compilera le serveur et les utilitaires, aussi
-   bien que toutes les applications clientes et interfaces qui requièrent
-   seulement un compilateur C. Tous les fichiers seront installés par défaut
+   La configuration par défaut compilera le serveur et les utilitaires,
+   ainsi que toutes les applications clientes et les interfaces ne nécessitant
+   qu'un compilateur C.
+   Tous les fichiers seront installés par défaut
    sous <filename>/usr/local/pgsql</filename>.
   </para>
 
   <para>
    Les processus de compilation et d'installation peuvent être personnalisés
-   par l'utilisation d'une ou plusieurs options sur la ligne de commande après
+   en fournissant une ou plusieurs options de ligne de commande à
    <filename>configure</filename>.
-    Typically you would customize the install location, or the set of
-    optional features that are built.  <filename>configure</filename>
-    has a large number of options, which are described in
+   Généralement, vous allez personnaliser l'endroit de l'installation,
+   ou la liste des fonctionnalités optionnelle à construire.
+   <filename>configure</filename> a beaucoup d'options, décrites dans
     <xref linkend="configure-options"/>.
    </para>
 
    <para>
-    Also, <filename>configure</filename> responds to certain environment
-    variables, as described in <xref linkend="configure-envvars"/>.
-    These provide additional ways to customize the configuration.
+    <filename>configure</filename> tient compte aussi de certaines
+    variables d'environnement, comme décrit dans <xref linkend="configure-envvars"/>.
+    Elle offre d'autres moyens de personnaliser la configuration.
    </para>
   </step>
 
   <step id="build">
-   <title>Build</title>
+      <title>Compilation</title> <!-- "Construction" littéralement, mais jamais entendu ça en FR -->
 
    <para>
-    To start the build, type either of:
+    Pour démarrer la compilation, entrez l'un de ces ordres&nbsp;:
 <screen>
 <userinput>make</userinput>
 <userinput>make all</userinput>
 </screen>
-    (Remember to use <acronym>GNU</acronym> <application>make</application>.)
-    The build will take a few minutes depending on your
-    hardware. The last line displayed should be:
+    (Rappelez-vous qu'il faut <acronym>GNU</acronym> <application>make</application>.)
+    La durée de la compilation sera de quelques minutes, et dépend de votre matériel.
+    La dernière ligne affichée doit être&nbsp;:
 <screen>
 All of PostgreSQL successfully made. Ready to install.
 </screen>
    </para>
 
   <para>
-   If you want to build everything that can be built, including the
-   documentation (HTML and man pages), and the additional modules
-   (<filename>contrib</filename>), type instead:
+   Si vous voulez construire tout ce qui peut l'être,
+   dont la documentation (HTML et pages de manuel)
+   et les modules optionnels (<filename>contrib</filename>),
+   entrez plutôt&nbsp;:
 <screen>
 <userinput>make world</userinput>
 </screen>
-   The last line displayed should be:
+    La dernière ligne affichée doit être&nbsp;:
 <screen>
 PostgreSQL, contrib, and documentation successfully made. Ready to install.
 </screen>
    </para>
 
    <para>
-    If you want to invoke the build from another makefile rather than
-    manually, you must unset <varname>MAKELEVEL</varname> or set it to zero,
-    for instance like this:
+    Si vous voulez appeler la compilation depuis un autre makefile
+    plutôt que manuellement, vous devez désactiver la variable
+    <varname>MAKELEVEL</varname> ou la mettre à zéro, par exemple ainsi&nbsp;:
 <programlisting>
 build-postgresql:
         $(MAKE) -C postgresql MAKELEVEL=0 all
 </programlisting>
-    Failure to do that can lead to strange error messages, typically about
-    missing header files.
+    L'oublier peut mener à d'étranges messages d'erreur,
+    typiquement sur des fichiers d'en-tête manquants.
    </para>
   </step>
 
   <step>
-   <title>Regression Tests</title>
+   <title>Tests de régression</title>
 
    <indexterm>
     <primary>regression test</primary>
    </indexterm>
 
    <para>
-    If you want to test the newly built server before you install it,
-    you can run the regression tests at this point. The regression
-    tests are a test suite to verify that <productname>PostgreSQL</productname>
-    runs on your machine in the way the developers expected it
-    to. Type:
+    Si vous voulez tester ce serveur nouvellement compilé avant de l'installer,
+    vous devez lancer les tests de régression maintenant.
+    Il s'agit d'une suite de tests pour vérifier que <productname>PostgreSQL</productname>
+    fonctionne sur votre machine de la manière prévue par ses développeurs.
+    Entrez&nbsp;:
 <screen>
 <userinput>make check</userinput>
 </screen>
-    (This won't work as root; do it as an unprivileged user.)
-    See <xref linkend="regress"/> for
-    detailed information about interpreting the test results. You can
-    repeat this test at any later time by issuing the same command.
+    (Cela ne fonctionnera pas en tant que root&nbsp;; faites-le en tant
+    qu'utilisateur non privilégié.)
+    Voir <xref linkend="regress"/> pour des informations détaillées sur
+    l'interprétation des résultats des tests.
+    Vous pouvez répéter ces tests n'importe quand par la suite en 
+    entrant la même commande.
    </para>
   </step>
 
   <step id="install">
-   <title>Installing the Files</title>
+   <title>Installer les fichiers/title>
 
    <note>
     <para>
-     If you are upgrading an existing system be sure to read
+     Si vous mettez à jour un système existant, assurez-vous 
+     de lire
      <xref linkend="upgrading"/>,
-     which has instructions about upgrading a
-     cluster.
+     qui contient des instructions sur la mise à jour d'une instance.
     </para>
    </note>
 
    <para>
-    To install <productname>PostgreSQL</productname> enter:
+    Pour installer <productname>PostgreSQL</productname>, entrez&nbsp;:
 <screen>
 <userinput>make install</userinput>
 </screen>
-    This will install files into the directories that were specified
-    in <xref linkend="configure"/>. Make sure that you have appropriate
-    permissions to write into that area. Normally you need to do this
-    step as root. Alternatively, you can create the target
-    directories in advance and arrange for appropriate permissions to
-    be granted.
+    Cela installera les fichiers dans les répertoires spécifiés dans
+    <xref linkend="configure"/>. Assurez-vous que vous avez les
+    droits nécessaires pour y écrire.
+    Normalement, vous devez faire cela en tant que root.
+    Une alternative est de créer les répertoires cibles par avance,
+    et de vous arranger pour obtenir les permissions adéquates.
    </para>
 
    <para>
-    To install the documentation (HTML and man pages), enter:
+    Pour installer la documentation (HTML et pages de manuel),
+    entrez&nbsp;:
 <screen>
 <userinput>make install-docs</userinput>
 </screen>
    </para>
 
    <para>
-    If you built the world above, type instead:
+    Si vous avez entré <literal>make word</literal> plus haut,
+    entrez plutôt&nbsp;:
 <screen>
 <userinput>make install-world</userinput>
 </screen>
-    This also installs the documentation.
+    Cela va installer aussi la documentation.
    </para>
 
    <para>
+    Vous pouvez aussi utiliser <literal>make install-strip</literal>
+    au lieu de <literal>make install</literal> pour purger les
+    fichiers exécutables et les 
+       
     You can use <literal>make install-strip</literal> instead of
     <literal>make install</literal> to strip the executable files and
     libraries as they are installed.  This will save some space.  If

--- a/postgresql/installation.xml
+++ b/postgresql/installation.xml
@@ -207,13 +207,13 @@ su - postgres
       <productname>Python</productname> compilées à partir des sources, mais
       une bibliothèque partagée est disponible dans de nombreuses
       distributions de systèmes d'exploitation. <filename>configure</filename>
-      échouera si la construction de <application>PL/Python</application> est
+      échouera si la compilation de <application>PL/Python</application> est
       sélectionnée et qu'il ne peut pas trouver une bibliothèque partagée
       <filename>libpython</filename>.
       Cela peut impliquer que vous devez
       soit installer des packages supplémentaires, soit recompiler
       (une partie de) votre installation <productname>Python</productname> pour
-      fournir cette bibliothèque partagée. Lors de la construction à partir
+      fournir cette bibliothèque partagée. Lors de la compilation à partir
       des sources, lancez le <filename>configure</filename> de <productname>Python</productname>
       avec l'option <literal>--enable-shared</literal>.
      </para>
@@ -401,8 +401,8 @@ su - postgres
     Pour garder une arborescence de compilation séparée de celle des sources,
     <filename>configure</filename> peut être exécuté à
     partir d'un répertoire hors de l'arborescence des sources,
-    où la construction s'effectuera.
-    Cette procédure est aussi appelée une construction de type
+    où la compilation s'effectuera.
+    Cette procédure est aussi appelée une compilation de type
     <indexterm><primary>VPATH</primary></indexterm><firstterm>VPATH</firstterm>.
     Voici comment faire&nbsp;:
 <screen>
@@ -1879,7 +1879,7 @@ build-postgresql:
        <listitem>
         <para>
          programme interpréteur Perl. Il sera utilisé pour déterminer les
-         dépendances pour la construction de PL/Perl. La valeur par défaut est
+         dépendances pour la compilation de PL/Perl. La valeur par défaut est
          <command>perl</command>.
         </para>
        </listitem>
@@ -1890,7 +1890,7 @@ build-postgresql:
        <listitem>
         <para>
          chemin complet vers l'interpréteur Python. Il sera utilisé pour
-         déterminer les dépendances pour la construction de PL/Python. De
+         déterminer les dépendances pour la compilation de PL/Python. De
          plus, si Python 2 ou 3 est spécifié ici (ou implicitement choisi), il
          détermine la variante de PL/Python qui devient disponible.
          Voir <xref linkend="regress-tap"/> pour plus d'informations.
@@ -2041,7 +2041,7 @@ build-postgresql:
        <listitem>
         <para>
          chemin complet vers l'interpréteur Perl. Il sera utilisé pour déterminer
-         les dépendances pour la construction de PL/Perl.
+         les dépendances pour la compilation de PL/Perl.
         </para>
        </listitem>
       </varlistentry>
@@ -2051,7 +2051,7 @@ build-postgresql:
        <listitem>
         <para>
          programme interpréteur Python. Il sera utilisé pour
-         déterminer les dépendances pour la construction de PL/Python. De
+         déterminer les dépendances pour la compilation de PL/Python. De
          plus, si Python 2 ou 3 est spécifié ici (ou implicitement choisi), il
          détermine la variante de PL/Python qui devient disponible. Voir
          <xref linkend="plpython-python23"/> pour plus d'informations.
@@ -2066,7 +2066,7 @@ build-postgresql:
        <listitem>
         <para>
          programme interpréteur Tcl. Il sera utilisé pour déterminer
-         les dépendances pour la construction de PL/Tcl.
+         les dépendances pour la compilation de PL/Tcl.
          Si ce paramètre n'est pas en place, seront testés dans cet ordre&nbsp;:
          <literal>tclsh tcl tclsh8.6 tclsh86 tclsh8.5 tclsh85
          tclsh8.4 tclsh84</literal>.
@@ -2291,7 +2291,7 @@ export MANPATH</programlisting>
    url="https://buildfarm.postgresql.org/">ferme de compilation de
    PostgreSQL</ulink>. Si vous êtes intéressé par l'utilisation de
    <productname>PostgreSQL</productname> sur une plateforme qui n'est pas
-   représentée dans la ferme de construction, mais pour laquelle le code
+   représentée dans la ferme de compilation, mais pour laquelle le code
    fonctionne ou peut fonctionner, nous vous suggérons fortement de monter
    une machine qui sera membre de la ferme pour que la compatibilité puisse
    être assurée dans la durée.
@@ -2303,7 +2303,7 @@ export MANPATH</programlisting>
    PowerPC 64, S/390, S/390x, Sparc, Sparc 64, ARM, MIPS, MIPSEL
    et PA-RISC. Un support du code existe pour M68K, M32R et VAX mais ces
    architectures n'ont pas été testées récemment à notre connaissance. Il est
-   souvent possible de construire <productname>PostgreSQL</productname> sur
+   souvent possible de compiler <productname>PostgreSQL</productname> sur
    un type de processeur non supporté en précisant
    <option>--disable-spinlocks</option>&nsbp;; mais les performances
    seront mauvaises.
@@ -2325,7 +2325,7 @@ export MANPATH</programlisting>
   <para>
    Si vous avez des problèmes d'installation sur une plateforme connue
    comme supportée d'après des résultats récents de la ferme de
-   construction, merci de rapporter cette information à
+   compilation, merci de rapporter cette information à
    <email>pgsql-bugs@lists.postgresql.org</email>. Si vous êtes intéressé pour porter
    <productname>PostgreSQL</productname> sur une nouvelle plateforme,
    <email>pgsql-hackers@lists.postgresql.org</email> est l'endroit approprié pour en
@@ -2359,9 +2359,9 @@ export MANPATH</programlisting>
    </indexterm>
 
    <para>
-    PostgreSQL fonctionne sur AIX, mais les versions AIX avant la 6.1 ont
-    différents problèmes et ne sont donc pas recommendés. Vous pouvez utiliser
-    soit GCC soit le compilateur natif IBM <command>xlc</command>.
+    PostgreSQL fonctionne sur AIX, mais les versions avant la 6.1 ont
+    différents problèmes et ne sont pas recommandés. Vous pouvez utiliser
+    soit GCC, soit le compilateur natif IBM <command>xlc</command>.
    </para>
 
    <sect3>
@@ -2386,17 +2386,17 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": A memory address 
 =# CREATE EXTENSION plperl;
 ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
      </screen>
-     On a un autre exemple avec les erreurs 'out of memory' dans les traces
-     du serveur PostgreSQL, avec toute allocation de mémoire proche ou supérieure
-     256&nbsp;Mo qui échoue.
+     On a un autre exemple avec les erreurs <foreign>out of memory</foreign> dans les traces
+     du serveur PostgreSQL, avec toutes les allocations de mémoire vers
+     256&nbsp;Mo ou plus qui échouent.
     </para>
 
     <para>
      La cause générale de ces problèmes est le nombre de bits et le modèle mémoire
      utilisé par le processus serveur. Par défaut, tous les binaires compilés sur
-     AIX sont 32-bits. Cela ne dépend pas du matériel ou du noyau en cours
-     d'utilisation. Ces processus 32-bits sont limités à 4&nbsp;Go de mémoire
-     présentée en segments de 256&nbsp;Mo utilisant un parmi quelques modèles.
+     AIX sont 32 bits. Cela ne dépend pas du matériel ou du noyau en cours
+     d'utilisation. Ces processus 32 bits sont limités à 4&nbsp;Go de mémoire,
+     présentée en segments de 256&nbsp;Mo utilisant un modèle parmi quelques-uns.
      Le modèle par défaut permet moins de 256&nbsp;Mo dans le tas, comme il partage
      un seul segment avec la pile.
     </para>
@@ -2404,23 +2404,23 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
     <para>
      Dans le cas de l'exemple <literal>plperl</literal> ci-dessus, vérifiez
      votre umask et les droits des binaires de l'installation PostgreSQL.
-     Les binaires de l'exemple étaient 32-bits et installés en mode 750 au lieu
-     de 755. En raison des droits, seul le propriétaire ou un membre
+     Les binaires de l'exemple étaient en 32 bits et installés en mode 750 au lieu
+     de 755. En raison de ces droits, seul le propriétaire ou un membre
      du groupe propriétaire peut charger la bibliothèque. Puisqu'il n'est pas
-     lisible par tout le mode, le chargeur place l'objet dans le tas du
+     lisible par tout le monde, le chargeur place l'objet dans le tas du
      processus au lieu d'un segment de mémoire de bibliothèque où il aurait
      été sinon placé.
     </para>
 
     <para>
-     La solution <quote>idéale</quote> pour ceci est d'utiliser une version
+     La solution «&nbsp;idéale&nbsp;» est d'utiliser une version
      64-bits de PostgreSQL, mais ce n'est pas toujours pratique, parce
-     que les systèmes équipés de processeurs 32-bits peuvent compiler mais ne
-     peuvent pas exécuter de binaires 64-bits.
+     que les systèmes équipés de processeurs 32 bits peuvent compiler, mais
+     pas exécuter, des binaires 64 bits.
     </para>
 
     <para>
-     Si un binaire 32-bits est souhaité, positionnez <symbol>LDR_CNTRL</symbol>
+     Si un binaire 32 bits est souhaité, positionnez <symbol>LDR_CNTRL</symbol>
      à <literal>MAXDATA=0x<replaceable>n</replaceable>0000000</literal>,
      où 1&lt;=n &lt;= 8 avant de démarrer le serveur PostgreSQL, et essayez
      différentes valeurs et paramètres de <filename>postgresql.conf</filename>
@@ -2436,7 +2436,7 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
     </para>
 
     <para>
-     Pour une compilation 64-bits, positionnez <envar>OBJECT_MODE</envar> à
+     Pour une compilation en 64 bits, positionnez <envar>OBJECT_MODE</envar> à
      64 et passez <literal>CC="gcc -maix64"</literal> et
      <literal>LDFLAGS="-Wl,-bbigtoc"</literal> à <command>configure</command>.
      (Les options pour <command>xlc</command> pourraient différer.) Si vous omettez
@@ -2452,12 +2452,12 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
      peut se produire. Bien que nous ne l'ayons jamais constaté,
      AIX tuera des processus quand il se trouvera à court de mémoire et
      que la zone surallouée est accédée. Le comportement le plus proche de
-     ceci que nous ayons constaté est l'échec de fork parce que le système
+     ceci que nous ayons constaté est l'échec d'un <foreign>fork</foreign>, parce que le système
      avait décidé qu'il n'y avait plus de suffisamment de mémoire disponible
      pour un nouveau processus. Comme beaucoup d'autres parties d'AIX,
-     la méthode d'allocation de l'espace de pagination et le « out-of-memory
-     kill » sont configurables soit pour le système soit pour un processus,
-     si cela devient un problème.
+     la méthode d'allocation de l'espace de pagination et l'arrêt suite à un
+     «&nbsp;out-of-memory&nbsp;» sont configurables,
+     soit pour le système, soit pour un processus, si cela devient un problème.
     </para>
 
     <bibliography>
@@ -2527,23 +2527,23 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
    </indexterm>
 
    <para>
-    PostgreSQL peut être construit avec Cygwin, un environnement similaire à
+    PostgreSQL peut être compilé avec Cygwin, un environnement similaire à
     Linux pour Windows, mais cette méthode est inférieure à la version native
     Windows (voir <xref linkend="install-windows"/>) et
     faire tourner un serveur sur Cygwin n'est plus recommandé.
    </para>
 
    <para>
-    Quand vous compilez à partir des sources, suivant la procédure style Unix
-    d'installation (c'est-à-dire <literal>./configure;
-     make</literal>; etc...), notez les différences suivantes spécifiques à
-    Cygwin&nbsp;:
+    Quand vous compilez à partir des sources, suivant la procédure
+    d'installation de style Unix (c'est-à-dire
+    <literal>./configure; make;</literal>, etc.),
+    notez les différences suivantes spécifiques à Cygwin&nbsp;:
 
     <itemizedlist>
      <listitem>
       <para>
-       Positionnez le path pour utiliser le répertoire binaire Cygwin avant
-       celui des utilitaires Windows. Cela permettra d'éviter des problèmes avec
+       Positionnez le PATH pour utiliser le répertoire binaire Cygwin avant
+       celui des utilitaires Windows. Cela évitera des problèmes à
        la compilation.
       </para>
      </listitem>
@@ -2586,11 +2586,11 @@ ERROR:  could not load library "/opt/dbs/pgsql/lib/plperl.so": Bad address
 
      <listitem>
       <para>
-       Il se peut que la construction échoue sur certains système quand
+       Il se peut que la compilation échoue sur certains systèmes quand
        une locale autre que C est utilisée. Pour résoudre ce problème,
        positionnez la locale à C avec la commande
-       <command>export LANG=C.utf8</command> avant de lancer la construction, et ensuite, une fois
-       que vous avez installé PostgreSQL, repositionnez-là à son ancienne valeur.
+       <command>export LANG=C.utf8</command> avant de lancer la compilation,
+       puis, une fois PostgreSQL installé, repositionnez-là à son ancienne valeur.
       </para>
      </listitem>
 
@@ -2636,10 +2636,10 @@ make MAX_CONNECTIONS=5 check
     pour résultat la génération d'un script
     <application>configure</application> variant suivant la version du SDK
     utilisée durant <application>configure</application>. Ceci ne devrait pas
-    poser de problèmes dans les scénarios simples mais si vous essayez de
-    faire quelque chose comme la construction d'une extension sur une machine
-    différente que celle sur laquelle le code serveur a été construit, vous
-    pourriez avoir besoin de forcer l'utilisation d'un chemin sysroot
+    poser de problèmes dans les scénarios simples, mais si vous essayez de
+    faire quelque chose comme compiler une extension sur une machine
+    différente que celle sur laquelle le code serveur a été compilé, vous
+    pouvez avoir besoin de forcer l'utilisation d'un chemin sysroot
     différent. Pour cela, configurez <varname>PG_SYSROOT</varname> ainsi par
     exemple
 <programlisting>
@@ -2649,15 +2649,16 @@ make PG_SYSROOT=<replaceable>/desired/path</replaceable> all
 <programlisting>
 xcodebuild -version -sdk macosx Path
 </programlisting>
-    Notez que construire une extension en utilisant une version sysroot
-    différente que celle utilisée pour construire le serveur n'est pas
-    vraiment recommandée&nbsp;; dans le pire des cas, cela impliquerait des
-    incohérences sur l'ABI difficiles à débugger.
+    Notez que compiler une extension en utilisant une version sysroot
+    différente que celle utilisée pour compiler le serveur n'est pas
+    vraiment recommandée&nbsp;; dans le pire des cas, cela peut entraîner des
+    incohérences d'ABI difficiles à débugger.
    </para>
 
    <para>
     Vous pouvez aussi sélectionner un chemin sysroot différent de celui par
-    défaut lors du configure en indiquant <varname>PG_SYSROOT</varname> à
+    défaut lors du <application>configure</application>
+    en indiquant <varname>PG_SYSROOT</varname> à
     <application>configure</application>&nbsp;:
 <programlisting>
 ./configure ... PG_SYSROOT=<replaceable>/desired/path</replaceable>
@@ -2666,12 +2667,12 @@ xcodebuild -version -sdk macosx Path
 
    <para>
     La fonctionnalité <quote>System Integrity Protection</quote> (SIP) de
-    <productname>macOS</productname> casse <literal>make check</literal> parce
-    qu'elle empêche de passer la configuration nécessaire de
+    <productname>macOS</productname> casse <literal>make check</literal>,
+    car elle empêche de transmettre la configuration nécessaire de
     <literal>DYLD_LIBRARY_PATH</literal> vers les exécutables en cours de
     tests. Vous pouvez contourner cela en exécutant <literal>make
     install</literal> avant <literal>make check</literal>. Ceci étant dit, la
-    plupart des développeurs Postgres désactivent SIP.
+    plupart des développeurs Postgres désactivent simplement SIP.
    </para>
   </sect2>
 
@@ -2690,7 +2691,7 @@ xcodebuild -version -sdk macosx Path
     <productname>Visual C++</productname> de Microsoft.
     La variante de compilation MinGW utilise le système de compilation normal
     décrit dans ce chapitre&nbsp;; la compilation via Visual C++ fonctionne de
-    façon totalement différente et est décrite dans <xref linkend="install-windows"/>.
+    façon totalement différente, et est décrite dans <xref linkend="install-windows"/>.
    </para>
 
    <para>
@@ -2705,7 +2706,7 @@ xcodebuild -version -sdk macosx Path
    </para>
 
    <para>
-    Pour construire les binaires 64 bits avec MinGW, installez l'ensemble d'outils 64 bits à
+    Pour compiler les binaires 64 bits avec MinGW, installez l'ensemble d'outils 64 bits à
     partir de <ulink url="https://mingw-w64.org/"></ulink>, ajoutez le répertoire des binaires de MinGW dans
     la variable d'environnement <envar>PATH</envar>, et lancez la commande
     <command>configure</command> avec l'option
@@ -2713,7 +2714,7 @@ xcodebuild -version -sdk macosx Path
    </para>
 
    <para>
-    Après que vous ayez tout installé, il vous est conseillé de lancer
+    Après que vous avez tout installé, il vous est conseillé de lancer
     <application>psql</application> dans <command>CMD.EXE</command>, car
     la console MSYS a des problèmes de tampons.
    </para>
@@ -2724,7 +2725,8 @@ xcodebuild -version -sdk macosx Path
     <para>
      Si PostgreSQL sous Windows plante, il peut générer des
      <productname>minidumps</productname> qui peuvent être utilisés pour dépister la cause du plantage&nbsp;;
-     ils sont semblables aux core dumps d'Unix. Vous pouvez lire ces dumps avec
+     ils sont semblables aux <foreign>core dumps</foreign> d'Unix.
+     Vous pouvez lire ces dumps avec
      <productname>Windows Debugger Tools</productname> ou avec
      <productname>Visual Studio</productname>. Pour permettre la génération des dumps sous Windows, créez un
      sous-répertoire nommé <filename>crashdumps</filename>
@@ -2744,7 +2746,7 @@ xcodebuild -version -sdk macosx Path
 
    <para>
     PostgreSQL est bien supporté sous Solaris. Plus le système d'exploitation
-    est à jour, moins de problèmes vous aurez.
+    est à jour, moins vous aurez de problèmes.
    </para>
 
    <sect3>
@@ -2775,9 +2777,9 @@ xcodebuild -version -sdk macosx Path
 
     <para>
      Si <command>configure</command> se plaint d'un programme de test en échec,
-     c'est probablement un cas de l'éditeur de lien à l'exécution qui ne trouve
+     il s'agit probablement de l'éditeur de lien à l'exécution qui ne trouve
      pas une bibliothèque, probablement libz, libreadline ou une autre bibliothèque
-     non standard telle que libssl. Pour l'amener au bon endroit, positionnez
+     non standard telle que libssl. Pour lui indiquer le bon endroit, positionnez
      la variable d'environnement <envar>LDFLAGS</envar> sur la ligne de commande
      de <command>configure</command>, par exemple,
      <programlisting>
@@ -2796,8 +2798,8 @@ configure ... LDFLAGS="-R /usr/sfw/lib:/opt/sfw/lib:/usr/local/lib"
      Sur l'architecture SPARC, Sun Studio est fortement recommandé pour
      la compilation. Essayez d'utiliser l'option d'optimisation
      <option>-xO5</option> pour générer des binaires sensiblement
-     plus rapides. N'utilisez pas d'options qui modifient le comportement
-     des opérations à virgule flottante et le traitement de
+     plus rapides. N'utilisez pas d'options modifiant le comportement
+     des opérations à virgule flottante ni le traitement de
      <varname>errno</varname> (par exemple, <option>-fast</option>).
     </para>
 

--- a/postgresql/installation.xml
+++ b/postgresql/installation.xml
@@ -15,7 +15,7 @@
  </para>
 
  <para>
-  Si vous construisez <productname>PostgreSQL</productname> pour Microsoft
+  Si vous compilez <productname>PostgreSQL</productname> pour Microsoft
   Windows, continuez la lecture de ce chapitre si vous avez pour but
   d'utiliser MinGW ou Cygwin&nbsp;; par contre, si vous voulez utiliser
   <productname>Visual C++</productname> de Microsoft, lisez à la place
@@ -172,7 +172,7 @@ su - postgres
       <filename>libperl</filename>.
       Dans ce cas, vous devrez recompiler et
       installer <productname>Perl</productname> manuellement pour être capable
-      de construire <application>PL/Perl</application>. Lors du processus de
+      de compiler <application>PL/Perl</application>. Lors du processus de
       configuration pour <productname>Perl</productname>, demandez une
       bibliothèque partagée.
      </para>
@@ -211,7 +211,7 @@ su - postgres
       sélectionnée et qu'il ne peut pas trouver une bibliothèque partagée
       <filename>libpython</filename>.
       Cela peut impliquer que vous devez
-      soit installer des packages supplémentaires, soit reconstruire
+      soit installer des packages supplémentaires, soit recompiler
       (une partie de) votre installation <productname>Python</productname> pour
       fournir cette bibliothèque partagée. Lors de la construction à partir
       des sources, lancez le <filename>configure</filename> de <productname>Python</productname>
@@ -221,7 +221,7 @@ su - postgres
 
     <listitem>
      <para>
-      Pour construire le langage procédural
+      Pour compiler le langage procédural
       <application>PL/Tcl</application>, <productname>Tcl</productname> doit bien sûr
       être installé. La version minimale requise est <productname>Tcl</productname> 8.4.
      </para>
@@ -267,7 +267,7 @@ su - postgres
 
     <listitem>
      <para>
-      Pour construire la documentation <productname>PostgreSQL</productname>,
+      Pour compiler la documentation <productname>PostgreSQL</productname>,
       il existe un ensemble de prérequis séparé&nbsp;; voir
       <xref linkend="docguide-toolsets"/>.
      </para>
@@ -348,7 +348,7 @@ su - postgres
    Les sources de <productname>PostgreSQL</productname> &version; sont
    disponibles dans la section de téléchargement de notre site web&nbsp;:
    <ulink url="https://www.postgresql.org/download/">téléchargement</ulink>.
-   Vous devez récupéré un fichier nommé
+   Vous devez récupérer un fichier nommé
    <filename>postgresql-&version;.tar.gz</filename> ou
    <filename>postgresql-&version;.tar.bz2</filename>.
    Après avoir obtenu le fichier, on le décompresse&nbsp;:
@@ -426,20 +426,20 @@ su - postgres
    en fournissant une ou plusieurs options de ligne de commande à
    <filename>configure</filename>.
    Généralement, vous allez personnaliser l'endroit de l'installation,
-   ou la liste des fonctionnalités optionnelle à construire.
+   ou la liste des fonctionnalités optionnelles à compiler.
    <filename>configure</filename> a beaucoup d'options, décrites dans
     <xref linkend="configure-options"/>.
    </para>
 
    <para>
-    <filename>configure</filename> tient compte aussi de certaines
+    <filename>configure</filename> tient aussi compte de certaines
     variables d'environnement, comme décrit dans <xref linkend="configure-envvars"/>.
     Elle offre d'autres moyens de personnaliser la configuration.
    </para>
   </step>
 
   <step id="build">
-      <title>Compilation</title> <!-- "Construction" littéralement, mais jamais entendu ça en FR -->
+      <title>Compilation</title> <!-- "Construction" littéralement, mais jamais entendu en fr -->
 
    <para>
     Pour démarrer la compilation, entrez l'un de ces ordres&nbsp;:
@@ -456,7 +456,7 @@ All of PostgreSQL successfully made. Ready to install.
    </para>
 
   <para>
-   Si vous voulez construire tout ce qui peut l'être,
+   Si vous voulez compiler tout ce qui peut l'être,
    dont la documentation (HTML et pages de manuel)
    et les modules optionnels (<filename>contrib</filename>),
    entrez plutôt&nbsp;:
@@ -470,7 +470,7 @@ PostgreSQL, contrib, and documentation successfully made. Ready to install.
    </para>
 
    <para>
-    Si vous voulez appeler la compilation depuis un autre makefile
+    Si vous voulez lancer la compilation depuis un autre makefile
     plutôt que manuellement, vous devez désactiver la variable
     <varname>MAKELEVEL</varname> ou la mettre à zéro, par exemple ainsi&nbsp;:
 <programlisting>
@@ -490,7 +490,7 @@ build-postgresql:
    </indexterm>
 
    <para>
-    Si vous voulez tester ce serveur nouvellement compilé avant de l'installer,
+    Si, avant de l'installer, vous voulez tester ce serveur nouvellement compilé,
     vous devez lancer les tests de régression maintenant.
     Il s'agit d'une suite de tests pour vérifier que <productname>PostgreSQL</productname>
     fonctionne sur votre machine de la manière prévue par ses développeurs.
@@ -541,7 +541,7 @@ build-postgresql:
    </para>
 
    <para>
-    Si vous avez entré <literal>make word</literal> plus haut,
+    Si vous avez entré <literal>make world</literal> plus haut,
     entrez plutôt&nbsp;:
 <screen>
 <userinput>make install-world</userinput>
@@ -551,112 +551,118 @@ build-postgresql:
 
    <para>
     Vous pouvez aussi utiliser <literal>make install-strip</literal>
-    au lieu de <literal>make install</literal> pour purger les
-    fichiers exécutables et les 
-       
-    You can use <literal>make install-strip</literal> instead of
-    <literal>make install</literal> to strip the executable files and
-    libraries as they are installed.  This will save some space.  If
-    you built with debugging support, stripping will effectively
-    remove the debugging support, so it should only be done if
-    debugging is no longer needed.  <literal>install-strip</literal>
-    tries to do a reasonable job saving space, but it does not have
-    perfect knowledge of how to strip every unneeded byte from an
-    executable file, so if you want to save all the disk space you
-    possibly can, you will have to do manual work.
+    au lieu de <literal>make install</literal> pour dépouiller
+    (<foreign>to strip</foreign>)
+    les fichiers exécutables et les bibliothèques de leurs
+    informations de débogage lors de l'installation.
+    Cela économisera un peu d'espace disque.
+    Dans une compilation avec le support du débogage, cette purge
+    va supprimer ce support&nbsp;; ce n'est donc à faire que s'il n'y a
+    plus besoin de débogage.
+    <literal>install-strip</literal> réussit assez bien à économiser de
+    l'espace, mais ne sait pas toujours effacer
+    le moindre octet inutile d'un exécutable&nbsp;;
+    pour récupérer tout l'espace disque possible, vous devrez donc
+    terminer manuellement.
    </para>
 
    <para>
-    The standard installation provides all the header files needed for client
-    application development as well as for server-side program
-    development, such as custom functions or data types written in C.
-    (Prior to <productname>PostgreSQL</productname> 8.0, a separate <literal>make
-    install-all-headers</literal> command was needed for the latter, but this
-    step has been folded into the standard install.)
+    L'installation standard fournit tous les fichiers d'en-tête nécessaire au
+    développement d'applications clientes, comme pour celui côté serveur,
+    par exemple pour des fonctions spécifiques ou des types de données codés en C.
+    (Avant <productname>PostgreSQL</productname>&nbps;8.0,
+    un <literal>make install-all-headers</literal> séparé était nécessaire pour
+    le deuxième cas, mais cette étape a été intégrée dans l'installation standard.)
    </para>
 
    <formalpara>
-    <title>Client-only installation:</title>
+    <title>Installation cliente&nbsp;:</title>
     <para>
-     If you want to install only the client applications and
-     interface libraries, then you can use these commands:
+     Si vous voulez installer uniquement les applications clientes
+     et les bibliothèques d'interface, vous pouvez utiliser ces commandes&nbsp;:
 <screen>
 <userinput>make -C src/bin install</userinput>
 <userinput>make -C src/include install</userinput>
 <userinput>make -C src/interfaces install</userinput>
 <userinput>make -C doc install</userinput>
 </screen>
-    <filename>src/bin</filename> has a few binaries for server-only use,
-    but they are small.
+    <filename>src/bin</filename> contient quelques binaires
+    utilisables uniquement sur le serveur, mais ils sont petits.
     </para>
    </formalpara>
   </step>
   </procedure>
 
   <formalpara>
-   <title>Uninstallation:</title>
+   <title>Désinstallation&nbsp;:</title>
    <para>
-    To undo the installation use the command <command>make
-    uninstall</command>. However, this will not remove any created directories.
+    Pour annuler l'installation, utilisez la commande
+    <command>make uninstall</command>.
+    Cependant, cela ne supprimera pas tous les répertoires qui ont été créés.
    </para>
   </formalpara>
 
   <formalpara>
-   <title>Cleaning:</title>
+   <title>Nettoyage&nbsp;:</title>
 
    <para>
-    After the installation you can free disk space by removing the built
-    files from the source tree with the command <command>make
-    clean</command>. This will preserve the files made by the <command>configure</command>
-    program, so that you can rebuild everything with <command>make</command>
-    later on. To reset the source tree to the state in which it was
-    distributed, use <command>make distclean</command>. If you are going to
-    build for several platforms within the same source tree you must do
-    this and re-configure for each platform.  (Alternatively, use
-    a separate build tree for each platform, so that the source tree
-    remains unmodified.)
+    Après l'installation, vous pouvez libérer de l'espace disque en supprimant
+    les fichiers compilés de l'arborescence des sources avec la commande
+    <command>make clean</command>.
+    Cela préservera les fichiers créés par <command>configure</command>,
+    pour que vous puissiez tout recompiler plus tard avec <command>make</command>.
+    Pour réinitialiser l'arbre des sources dans l'état où il est distribué,
+    utilisez <command>make distclean</command>.
+    Si vous voulez compiler pour plusieurs plateformes au sein de la même
+    arborescence, vous devez le lancer et re-configurer pour chaque
+    plateforme.
+    (Une alternative est d'utiliser une arborescence pour chaque plateforme,
+    pour qu'elles ne soient pas modifiées.)
    </para>
   </formalpara>
 
   <para>
-   If you perform a build and then discover that your <command>configure</command>
-   options were wrong, or if you change anything that <command>configure</command>
-   investigates (for example, software upgrades), then it's a good
-   idea to do <command>make distclean</command> before reconfiguring and
-   rebuilding.  Without this, your changes in configuration choices
-   might not propagate everywhere they need to.
+   Si, après compilation, vous découvrez que vos options à <command>configure</command>
+   étaient fausses, ou si vous changez quelque chose que <command>configure</command>
+   a pris en compte (par exemple, par une mise à jour logicielle),
+   il est conseillé de faire <command>make distclean</command> avant de reconfigurer
+   et recompiler. Sans cela, vos choix de configuration pourraient ne pas se
+   propager à tous les endroits nécessaires.
   </para>
 
   <sect2 id="configure-options">
-   <title><filename>configure</filename> Options</title>
+   <title>Options de <filename>configure</filename></title>
 
    <indexterm zone="configure-options">
     <primary>configure options</primary>
    </indexterm>
 
    <para>
-    <command>configure</command>'s command line options are explained below.
-    This list is not exhaustive (use <literal>./configure --help</literal>
-    to get one that is).  The options not covered here are meant for
-    advanced use-cases such as cross-compilation, and are documented in
-    the standard Autoconf documentation.
+    Les paramètres en ligne de commande à <command>configure</command>
+    sont expliqués ci-dessous.
+    Cette liste n'est pas exhaustive (utilisez <literal>./configure --help</literal>
+    pour en avoir une qui le soit). Les options non évoquées ici sont
+    destinées à des utilisations avancées, comme la compilation croisée,
+    et figurent dans la documentation standard d'Autoconf.
    </para>
 
    <sect3 id="configure-options-locations">
-    <title>Installation Locations</title>
+    <title>Emplacements de l'installation</title>
 
      <para>
-      These options control where <literal>make install</literal> will put
-      the files.  The <option>--prefix</option> option is sufficient for
-      most cases.  If you have special needs, you can customize the
-      installation subdirectories with the other options described in this
-      section.  Beware however that changing the relative locations of the
-      different subdirectories may render the installation non-relocatable,
-      meaning you won't be able to move it after installation.
-      (The <literal>man</literal> and <literal>doc</literal> locations are
-      not affected by this restriction.)  For relocatable installs, you
-      might want to use the <literal>--disable-rpath</literal> option
-      described later.
+      Ces options contrôlent où <literal>make install</literal> va poser
+      les fichiers.
+      L'option <option>--prefix</option> est suffisante dans la plupart des cas.
+      Pour des besoins spécifiques, vous pouvez personnaliser les sous-répertoires
+      d'installation avec d'autres options décrites dans cette section.
+      Attention&nbsp;: changer les emplacements relatifs des différents sous-répertoires
+      peut rendre l'installation non-déplaçable,  <!--  non-délocalisable ? (non) -->
+      c'est-à-dire que vous ne pourrez
+      plus la déplacer après installation.
+      (Les emplacements pour <literal>man</literal> et <literal>doc</literal>
+      ne sont pas concernés par cette restriction.)
+      Pour obtenir des installations déplaçables, vous pouvez utiliser
+      l'option <literal>--disable-rpath</literal> décrite plus bas.
      </para>
 
    <variablelist>
@@ -666,7 +672,7 @@ build-postgresql:
       <para>
        Installe tous les fichiers dans le répertoire <replaceable>PREFIX</replaceable>
        au lieu du répertoire <filename>/usr/local/pgsql</filename>.
-       Les fichiers actuels seront installés dans divers
+       Les fichiers eux-mêmes seront installés dans divers
        sous-répertoires&nbsp;; aucun fichier ne sera directement installé
        sous <replaceable>PREFIX</replaceable>.
       </para>
@@ -678,11 +684,12 @@ build-postgresql:
      <listitem>
       <para>
        Les fichiers qui dépendent de l'architecture peuvent être installés dans
-       un répertoire différent, <replaceable>EXEC-PREFIX</replaceable>, de celui donné
-       par <replaceable>PREFIX</replaceable>. Cela peut être utile pour partager
-       les fichiers indépendant de l'architecture entre plusieurs machines.
+       un répertoire avec un préfixe différent, <replaceable>EXEC-PREFIX</replaceable>,
+       différent de celui donné par <replaceable>PREFIX</replaceable>.
+       Cela peut être utile pour partager entre plusieurs machines
+       les fichiers indépendants de l'architecture.
        S'il est omis, <replaceable>EXEC-PREFIX</replaceable> est égal à
-       <replaceable>PREFIX</replaceable> et les fichiers dépendants seront installés
+       <replaceable>PREFIX</replaceable>, et les fichiers dépendants seront installés
        sous la même arborescence que les fichiers indépendants de
        l'architecture, ce qui est probablement le but recherché.
       </para>
@@ -693,7 +700,7 @@ build-postgresql:
      <term><option>--bindir=<replaceable>REPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       Précise le répertoire des exécutables. Par défaut, il s'agit de
+       Indique le répertoire des exécutables. Par défaut, il s'agit de
        <filename><replaceable>EXEC-PREFIX</replaceable>/bin</filename>, ce
        qui signifie <filename>/usr/local/pgsql/bin</filename>.
       </para>
@@ -704,8 +711,8 @@ build-postgresql:
      <term><option>--sysconfdir=<replaceable>REPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       Précise le répertoire de divers fichiers de configuration. Par défaut,
-       il s'agit de <filename><replaceable>PREFIX</replaceable>/etc</filename>.
+       Précise le répertoire de divers fichiers de configuration,
+       par défaut <filename><replaceable>PREFIX</replaceable>/etc</filename>.
       </para>
      </listitem>
     </varlistentry>
@@ -725,7 +732,7 @@ build-postgresql:
      <term><option>--includedir=<replaceable>REPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       Précise le répertoire d'installation des en-têtes C et C++. Par défaut, il
+       Précise le répertoire d'installation des fichiers d'en-tête C et C++. Par défaut, il
        s'agit de <filename><replaceable>PREFIX</replaceable>/include</filename>.
       </para>
      </listitem>
@@ -750,7 +757,7 @@ build-postgresql:
        Indique le répertoire pour les fichiers de données en lecture seule
        utilisés par les programmes installés. La valeur par défaut est
        <filename><replaceable>DATAROOTDIR</replaceable></filename>.
-       Cela n'a aucun rapport avec l'endroit où les fichiers de base de données
+       NB&nbsp;: cela n'a aucun rapport avec l'endroit où les fichiers de base de données
        seront placés.
       </para>
      </listitem>
@@ -760,8 +767,8 @@ build-postgresql:
      <term><option>--localedir=<replaceable>REPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       Indique le répertoire pour installer les données locales, en
-       particulier les fichiers catalogues de traductions de messages. La
+       Indique le répertoire pour installer les données de localisation, en
+       particulier les fichiers des catalogues de traduction des messages. La
        valeur par défaut est
        <filename><replaceable>DATAROOTDIR</replaceable>/locale</filename>.
       </para>
@@ -772,7 +779,7 @@ build-postgresql:
      <term><option>--mandir=<replaceable>REPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       Les pages man fournies avec <productname>PostgreSQL</productname> seront
+       Les pages de manuel fournies avec <productname>PostgreSQL</productname> seront
        installées sous ce répertoire, dans leur sous-répertoire
        <filename>man<replaceable>x</replaceable></filename> respectif.
        Par défaut, il s'agit de <filename><replaceable>DATAROOTDIR</replaceable>/man</filename>.
@@ -796,7 +803,7 @@ build-postgresql:
      <term><option>--htmldir=<replaceable>RÉPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       La documentation formatée en HTML pour <productname>PostgreSQL</productname>
+       La documentation de <productname>PostgreSQL</productname>, formatée en HTML,
        sera installée dans ce répertoire. La valeur par défaut est
        <filename><replaceable>DATAROOTDIR</replaceable></filename>.
       </para>
@@ -808,8 +815,8 @@ build-postgresql:
     <para>
      Une attention toute particulière a été prise afin de rendre possible
      l'installation de <productname>PostgreSQL</productname> dans des répertoires
-     partagés (comme <filename>/usr/local/include</filename>) sans
-     interférer avec des noms de fichiers relatifs au reste du système.
+     partagés (comme <filename>/usr/local/include</filename>), sans
+     interférer avec l'espace de noms du reste du système.
      En premier lieu, le mot <quote><literal>/postgresql</literal></quote>
      est automatiquement ajouté aux répertoires <varname>datadir</varname>,
      <varname>sysconfdir</varname> et <varname>docdir</varname>,
@@ -818,29 +825,29 @@ build-postgresql:
      <quote><literal>pgsql</literal></quote>. Par exemple, si
      <filename>/usr/local</filename> est choisi comme préfixe,
      la documentation sera installée dans
-     <filename>/usr/local/doc/postgresql</filename>, mais si le
-     préfixe est <filename>/opt/postgres</filename>, alors il sera dans
+     <filename>/usr/local/doc/postgresql</filename>&nbsp;; mais si le
+     préfixe est <filename>/opt/postgres</filename>, alors ce sera dans
      <filename>/opt/postgres/doc</filename>. Les fichiers d'en-tête
-     publiques C de l'interface cliente seront installés sous
-     <varname>includedir</varname> et sont indépendants des noms de
-     fichiers relatifs au reste du système. Les fichiers d'en-tête privés et
-     les fichiers d'en-tête du serveur sont installés dans des répertoires
+     C publics pour les interfaces clientes sont installés sous
+     <varname>includedir</varname>, et sont indépendants de l'espace
+     de noms du système. Les fichiers d'en-tête internes et
+     ceux du serveur sont installés dans des répertoires
      privés sous <varname>includedir</varname>.
      Voir la documentation de chaque interface pour savoir comment obtenir
      ces fichiers d'en-tête.
-     Enfin, un répertoire privé sera aussi créé si nécessaire sous
-     <varname>libdir</varname> pour les modules chargeables dynamiquement.
+     Enfin, si nécessaire, un répertoire privé sera aussi créé sous
+     <varname>libdir</varname>, pour les modules chargeables dynamiquement.
     </para>
    </note>
  </sect3>
 
  <sect3 id="configure-options-features">
-  <title><productname>PostgreSQL</productname> Features</title>
+  <title>Fonctionnalités de <productname>PostgreSQL</productname></title>
   <para>
-   The options described in this section enable building of
-   various <productname>PostgreSQL</productname> features that are not
-   built by default.  Most of these are non-default only because they
-   require additional software, as described in
+   Les options décrites dans cette section permettent d'ajouter
+   diverses fonctionnalités de <productname>PostgreSQL</productname>
+   qui ne sont pas compilées par défaut&nbsp;; pour la plupart à cause du
+   besoin d'autres logiciels, comme décrit dans
    <xref linkend="install-requirements"/>.
   </para>
 
@@ -849,11 +856,11 @@ build-postgresql:
      <term><option>--enable-nls<optional>=<replaceable>LANGUES</replaceable></optional></option></term>
      <listitem>
       <para>
-       Permet de mettre en place le support des langues natives
-       (<acronym>NLS</acronym>). C'est la capacité d'afficher les messages
+       Active le support des langues natives
+       (<acronym>NLS</acronym>), c'est-à-dire la capacité d'afficher les messages
        d'un programme dans une langue autre que l'anglais.
        <replaceable>LANGUES</replaceable> est une liste optionnelle des codes
-       de langue que vous voulez supporter séparés par un espace. Par
+       de langue que vous voulez supporter, séparés par un espace&nbsp;; par
        exemple, <literal>--enable-nls='de fr'</literal> (l'intersection entre la
        liste et l'ensemble des langues traduites actuellement sera calculée
        automatiquement). En l'absence de liste, toutes les
@@ -861,7 +868,7 @@ build-postgresql:
       </para>
 
       <para>
-       Pour utiliser cette option, une implantation de
+       Pour utiliser cette option, une implémentation de
        l'API <application>Gettext</application> est nécessaire.
       </para>
      </listitem>
@@ -871,8 +878,7 @@ build-postgresql:
      <term><option>--with-perl</option></term>
      <listitem>
       <para>
-       Permet l'utilisation du langage de procédures <application>PL/Perl</application>
-       côté serveur.
+       Permet la compilation du langage côté serveur <application>PL/Perl</application>
       </para>
      </listitem>
     </varlistentry>
@@ -881,7 +887,7 @@ build-postgresql:
      <term><option>--with-python</option></term>
      <listitem>
       <para>
-       Permet la compilation du langage de procédures <application>PL/Python</application>.
+       Permet la compilation du langage côté serveur <application>PL/Python</application>.
       </para>
      </listitem>
     </varlistentry>
@@ -890,7 +896,7 @@ build-postgresql:
      <term><option>--with-tcl</option></term>
      <listitem>
       <para>
-       Permet la compilation du langage de procédures <application>PL/Tcl</application>.
+       Permet la compilation du langage côté serveur <application>PL/Tcl</application>.
       </para>
      </listitem>
     </varlistentry>
@@ -899,11 +905,12 @@ build-postgresql:
      <term><option>--with-tclconfig=<replaceable>REPERTOIRE</replaceable></option></term>
      <listitem>
       <para>
-       Tcl installe les fichiers <filename>tclConfig.sh</filename>, contenant
-       certaines informations de configuration nécessaires pour compiler le
-       module d'interfaçage avec Tcl. Ce fichier est trouvé automatiquement
+       Tcl installe les fichiers <filename>tclConfig.sh</filename>, qui contient
+       des informations de configuration nécessaires pour compiler le
+       module d'interfaçage avec Tcl.
+       Ce fichier est normalement trouvé automatiquement à un emplacement connu,
        mais pour utiliser une version différente de Tcl, il faut indiquer le
-       répertoire dans lequel <filename>tclConfig.sh</filename> se trouve.
+       répertoire où chercher <filename>tclConfig.sh</filename>.
       </para>
      </listitem>
     </varlistentry>
@@ -912,32 +919,31 @@ build-postgresql:
      <term><option>--with-icu</option></term>
      <listitem>
       <para>
-       Build with support for
-       the <productname>ICU</productname><indexterm><primary>ICU</primary></indexterm>
-       library, enabling use of ICU collation
-       features<phrase condition="standalone-ignore"> (see
-       <xref linkend="collation"/>)</phrase>.
-       This requires the <productname>ICU4C</productname> package
-       to be installed.  The minimum required version
-       of <productname>ICU4C</productname> is currently 4.2.
+       Compiler avec le support de la bibliothèque
+       <productname>ICU</productname><indexterm><primary>ICU</primary></indexterm>,
+       activant les collations ICU
+       <phrase condition="standalone-ignore"> (voir <xref linkend="collation"/>)</phrase>.
+       Le paquet <productname>ICU4C</productname> doit être installé.
+       Sa version minimum nécessaire est actuellement la 4.2.
       </para>
  
-        <para>
-         By default,
-         <productname>pkg-config</productname><indexterm><primary>pkg-config</primary></indexterm>
-         will be used to find the required compilation options.  This is
-         supported for <productname>ICU4C</productname> version 4.6 and later.
-         For older versions, or if <productname>pkg-config</productname> is
-         not available, the variables <envar>ICU_CFLAGS</envar>
-         and <envar>ICU_LIBS</envar> can be specified
-         to <filename>configure</filename>, like in this example:
+      <para>
+       Par défaut,
+       <productname>pkg-config</productname><indexterm><primary>pkg-config</primary></indexterm>
+       sera utilisé pour déterminer les options de compilation nécessaires.
+       Cela est supporté pour <productname>ICU4C</productname> version 4.6
+       et suivantes.
+       Pour des versions plus anciennes, ou si <productname>pkg-config</productname>
+       n'est pas disponible, les variables <envar>ICU_CFLAGS</envar>
+       et <envar>ICU_LIBS</envar> peuvent être fourniers à <filename>configure</filename>,
+       comme dans cet exemple&nbsp;:
 <programlisting>
 ./configure ... --with-icu ICU_CFLAGS='-I/some/where/include' ICU_LIBS='-L/some/where/lib -licui18n -licuuc -licudata'
 </programlisting>
-         (If <productname>ICU4C</productname> is in the default search path
-         for the compiler, then you still need to specify nonempty strings in
-         order to avoid use of <productname>pkg-config</productname>, for
-         example, <literal>ICU_CFLAGS=' '</literal>.)
+        (Si <productname>ICU4C</productname> est dans le chemin par défaut
+        du compilateur, vous aurez besoin de préciser des chaînes non vides
+        pour éviter l'appel à <productname>pkg-config</productname>,
+        par exemple <literal>ICU_CFLAGS=' '</literal>.)
         </para>
        </listitem>
       </varlistentry>
@@ -946,22 +952,21 @@ build-postgresql:
      <term><option>--with-llvm</option></term>
      <listitem>
       <para>
-       Permet la compilation avec le support de <acronym>JIT</acronym> basée sur
-       <productname>LLVM</productname><phrase
-       condition="standalone-ignore"> (see <xref
-       linkend="jit"/>)</phrase>. Ceci nécessite l'installation de la
-	   bibliothèque <productname>LLVM</productname>. La version minimale
-	   requise de <productname>LLVM</productname> est actuellement la 3.9.
+       Compile avec le support de <acronym>JIT</acronym>, basé sur
+       <productname>LLVM</productname>
+       <phrase condition="standalone-ignore"> (voir <xref linkend="jit"/>)</phrase>.
+       Ceci nécessite l'installation de la bibliothèque <productname>LLVM</productname>.
+       Sa version minimale requise est actuellement la 3.9.
       </para>
       <para>
        <command>llvm-config</command><indexterm><primary>llvm-config</primary></indexterm>
-       sera utilisé pour trouver les options de compilation requises.
+       sera utilisé pour trouver les options de compilation nécessaires.
        <command>llvm-config</command>, puis
-       <command>llvm-config-$major-$minor</command> pour toutes les versions
-	   supportées, seront recherché dans <envar>PATH</envar>. Dans le cas où
-	   le bon programme n'est pas trouvé, il faut utiliser la variable
-	   <envar>LLVM_CONFIG</envar> afin de spécifier le chemin vers le bon
-	   <command>llvm-config</command>. Par exemple&nbsp;:
+       <command>llvm-config-$major-$minor</command> pour toutes les versions supportées,
+       seront recherchés dans votre <envar>PATH</envar>.
+       Au cas où le bon programme n'est pas trouvé, il faut utiliser la variable
+       <envar>LLVM_CONFIG</envar> pour spécifier le chemin du bon
+       <command>llvm-config</command>. Par exemple&nbsp;:
 <programlisting>
 ./configure ... --with-llvm LLVM_CONFIG='/path/to/llvm/bin/llvm-config'
 </programlisting>
@@ -969,11 +974,10 @@ build-postgresql:
 
       <para>
        Le support de <productname>LLVM</productname> nécessite un compilateur
-       <command>clang</command> compatible (qui peut être spécifié, si
-	   nécessaire, en utilisant la variable d'environnement
-	   <envar>CLANG</envar>, et un compilateur C++ fonctionnel (qui peut être
-	   spécifié, si nécessaire, en utilisant la variable d'environnement
-       <envar>CXX</envar>).
+       <command>clang</command> compatible (à spécifier, si nécessaire,
+       avec la variable d'environnement <envar>CLANG</envar>),
+       et un compilateur C++ fonctionnel (à spécifier, si nécessaire,
+       avec la variable d'environnement <envar>CXX</envar>).
       </para>
      </listitem>
     </varlistentry>
@@ -987,10 +991,11 @@ build-postgresql:
       </indexterm>
 
       <para>
-       Compile le support de connexion <acronym>SSL</acronym> (chiffrement).
-       Le paquetage <productname>OpenSSL</productname> doit être
-       installé. <filename>configure</filename> vérifiera que les fichiers d'en-tête
-       et les bibliothèques soient installés pour s'assurer que votre
+       Compile avec le support pour les connexions <acronym>SSL</acronym>
+       (avec chiffrement).
+       Le paquet <productname>OpenSSL</productname> doit être
+       installé. <filename>configure</filename> vérifiera les fichiers d'en-tête
+       et les bibliothèques pour s'assurer que votre
        installation d'<productname>OpenSSL</productname> est suffisante avant de
        continuer.
       </para>
@@ -1001,15 +1006,17 @@ build-postgresql:
        <term><option>--with-gssapi</option></term>
        <listitem>
         <para>
-         Build with support for GSSAPI authentication. On many systems, the
-         GSSAPI system (usually a part of the Kerberos installation) is not
-         installed in a location
-         that is searched by default (e.g., <filename>/usr/include</filename>,
-         <filename>/usr/lib</filename>), so you must use the options
-         <option>--with-includes</option> and <option>--with-libraries</option> in
-         addition to this option.  <filename>configure</filename> will check
-         for the required header files and libraries to make sure that
-         your GSSAPI installation is sufficient before proceeding.
+         Compile avec le support de l'authentification GSSAPI.
+         Sur beaucoup d'environnements, le système GSSAPI
+         (habituellement une partie de l'installation Kerberos)
+         n'est pas installé dans un endroit recherché par défaut
+         (par exemple <filename>/usr/include</filename> ou
+         <filename>/usr/lib</filename>)&nbsp;; vous devez donc
+         ajouter aussi les options
+         <option>--with-includes</option> et <option>--with-libraries</option>.
+         <filename>configure</filename> vérifiera les fichiers d'en-tête
+         et les bibliothèques pour s'assurer que votre
+         installation de GSSAPI est suffisante avant de continuer.
         </para>
        </listitem>
       </varlistentry>
@@ -1018,15 +1025,15 @@ build-postgresql:
      <term><option>--with-ldap</option></term>
      <listitem>
       <para>
-       Demande l'ajout du support de <acronym>LDAP</acronym><indexterm><primary>LDAP</primary></indexterm>
+       Compile avec le support de
+       <acronym>LDAP</acronym><indexterm><primary>LDAP</primary></indexterm>
        pour l'authentification et la recherche des paramètres de connexion
-       (voir <xref
-        linkend="libpq-ldap"/> et <xref linkend="auth-ldap"/>).
+       (voir <xref linkend="libpq-ldap"/> et <xref linkend="auth-ldap"/>).
        Sur Unix, cela requiert l'installation du paquet
        <productname>OpenLDAP</productname>. Sur Windows, la bibliothèque
        <productname>WinLDAP</productname> est utilisée par défaut.
        <filename>configure</filename> vérifiera l'existence des fichiers d'en-tête
-       et des bibliothèques requis pour s'assurer que votre installation
+       et des bibliothèques nécessaires pour s'assurer que votre installation
        d'<productname>OpenLDAP</productname> est suffisante avant de continuer.
 
       </para>
@@ -1037,8 +1044,9 @@ build-postgresql:
        <term><option>--with-pam</option></term>
        <listitem>
         <para>
-         Build with <acronym>PAM</acronym><indexterm><primary>PAM</primary></indexterm>
-         (Pluggable Authentication Modules) support.
+         Compile avec le support de
+         <acronym>PAM</acronym><indexterm><primary>PAM</primary></indexterm>
+         (<foreign>Pluggable Authentication Modules</foreign>).
         </para>
        </listitem>
       </varlistentry>
@@ -1047,9 +1055,9 @@ build-postgresql:
      <term><option>--with-bsd-auth</option></term>
      <listitem>
       <para>
-       Build with BSD Authentication support.
-       (The BSD Authentication framework is
-       currently only available on OpenBSD.)
+       Compile avec le support de l'authentification BSD.
+       (Le framework BSD Authentication n'est actuellement
+       disponible que sur OpenBSD.)
       </para>
      </listitem>
     </varlistentry>
@@ -1058,13 +1066,14 @@ build-postgresql:
      <term><option>--with-systemd</option></term>
      <listitem>
       <para>
-       Build with support
-         for <application>systemd</application><indexterm><primary>systemd</primary></indexterm>
-         service notifications.  This improves integration if the server
-         is started under <application>systemd</application> but has no impact
-         otherwise<phrase condition="standalone-ignore">; see <xref linkend="server-start"/> for more
-         information</phrase>.  <application>libsystemd</application> and the
-         associated header files need to be installed to use this option.
+       Compile avec le support du système de notifications
+       <application>systemd</application><indexterm><primary>systemd</primary></indexterm>.
+       Ceci améliore l'intégration si le serveur est démarré par
+       <application>systemd</application>, mais n'a pas d'impact sinon.
+       <phrase condition="standalone-ignore">Voir <xref linkend="server-start"/>
+       pour plus de détails.</phrase>
+       <application>libsystemd</application> et les fichiers d'en-tête associés
+       doivent être installés pour utiliser cette option.
       </para>
      </listitem>
     </varlistentry>
@@ -1073,9 +1082,10 @@ build-postgresql:
      <term><option>--with-bonjour</option></term>
      <listitem>
       <para>
-       Build with support for Bonjour automatic service discovery.
-       This requires Bonjour support in your operating system.
-       Recommended on macOS.
+       Compile avec le support du service de découverte automatique
+       Bonjour.
+       Cela nécessite le support de Bonjour dans votre système
+       d'exploitation. Recommandé sur macOS.
       </para>
      </listitem>
     </varlistentry>
@@ -1084,9 +1094,9 @@ build-postgresql:
      <term><option>--with-uuid=<replaceable>LIBRARY</replaceable></option></term>
      <listitem>
       <para>
-       Compile le module uuid-ossp (qui fournit les
-       fonctions pour générer les UUID), en utilisant la bibliothèque UUID
-       spécifiée.  <indexterm><primary>UUID</primary></indexterm>
+       Compile le module <xref linkend="uuid-ossp"/> (qui fournit des
+       fonctions pour générer des UUID), en utilisant la bibliothèque UUID
+       spécifiée.
        <replaceable>LIBRARY</replaceable> doit correspondre à une de ces
        valeurs&nbsp;:
       </para>
@@ -1094,7 +1104,7 @@ build-postgresql:
        <listitem>
         <para>
          <option>bsd</option> pour utiliser les fonctions UUID trouvées dans
-         FreeBSD, NetBSD et quelques autres systèmes dérivés de BSD
+         FreeBSD, NetBSD et d'autres systèmes dérivés de BSD
         </para>
        </listitem>
        <listitem>
@@ -1102,7 +1112,7 @@ build-postgresql:
          <option>e2fs</option> pour utiliser la bibliothèque UUID créée par
          le projet <literal>e2fsprogs</literal>&nbsp;; cette bibliothèque est
          présente sur la plupart des systèmes Linux et sur macOS, et peut
-         être obtenu sur d'autres plateformes également
+         être obtenue sur d'autres plateformes également
         </para>
        </listitem>
        <listitem>
@@ -1128,7 +1138,7 @@ build-postgresql:
      <term><option>--with-libxml</option></term>
      <listitem>
       <para>
-       Construit avec libxml2, activant ainsi le support de SQL/XML. Une
+       Compile avec libxml2, activant ainsi le support de SQL/XML. Une
        version 2.6.23 ou ultérieure de libxml2 est requise pour cette
        fonctionnalité.
       </para>
@@ -1139,22 +1149,22 @@ build-postgresql:
        installé et s'il connaît libxml2. Sinon, le programme
        <command>xml2-config</command>, qui est installé par libxml2, sera
        utilisé s'il est trouvé. L'utilisation de <command>pkg-config</command>
-       est préférée parce qu'elle gère mieux les installations
+       est préférée, parce qu'elle gère mieux les installations
        multi-architectures.
       </para>
 
       <para>
-       Pour utiliser une installation libxml2 se trouvant dans un emplacement
+       Pour utiliser une installation libxml2 située dans un emplacement
        inhabituel, vous pouvez configurer les variables d'environnement
        relatives à <command>pkg-config</command> (voir sa documentation), ou
        configurer la variable d'environnement <envar>XML2_CONFIG</envar> pour
        qu'elle pointe sur le programme <command>xml2-config</command>
        appartenant à l'installation libxml2, ou configurer les variables
        <envar>XML2_CFLAGS</envar> et <envar>XML2_LIBS</envar>. (Si
-       <command>pkg-config</command> est installé, alors pour surcharger son
-       idée de l'emplacement de libxml2 vous devez soit configurer
-       <envar>XML2_CONFIG</envar> soit <envar>XML2_CFLAGS</envar> et
-       <envar>XML2_LIBS</envar> avec des chaînes non vides.)
+       <command>pkg-config</command> est installé, alors, pour surcharger son
+       idée de l'emplacement de libxml2, vous devez renseigner soit
+       <envar>XML2_CONFIG</envar>, soit <envar>XML2_CFLAGS</envar> et
+       <envar>XML2_LIBS</envar>, avec des chaînes non vides.)
       </para>
      </listitem>
     </varlistentry>
@@ -1163,8 +1173,9 @@ build-postgresql:
      <term><option>--with-libxslt</option></term>
      <listitem>
       <para>
-       Construit avec libxslt, activant le module <xref linkend="xml2"/> to perform XSL transformations of XML.
-       <option>--with-libxml</option> must be specified as well.
+       Compile avec libxslt, activant le module
+       <xref linkend="xml2"/> pour opérer des transformations XSL sur du XML.
+       <option>--with-libxml</option> doit être spécifié aussi.
       </para>
      </listitem>
     </varlistentry>
@@ -1172,14 +1183,15 @@ build-postgresql:
   </sect3>
 
   <sect3 id="configure-options-anti-features">
-   <title>Anti-Features</title>
+   <title>Anti-Fonctionnalités</title>
 
    <para>
-    The options described in this section allow disabling
-    certain <productname>PostgreSQL</productname> features that are built
-    by default, but which might need to be turned off if the required
-    software or system features are not available.  Using these options is
-    not recommended unless really necessary.
+    Les options décrites dans cette secion permettent de désactiver
+    certaines fonctionnalités de <productname>PostgreSQL</productname>
+    compilées par défaut, mais que vous pouvez désactiver si ne sont pas
+    disponibles un logiciel ou des fonctionnalités système nécessaires.
+    L'utilisation de ces options n'est pas recommandée si ce n'est pas
+    vraiment nécessaire.
    </para>
 
    <variablelist>
@@ -1187,9 +1199,9 @@ build-postgresql:
      <term><option>--without-readline</option></term>
      <listitem>
       <para>
-       Prevents use of the <application>Readline</application> library
-       (and <application>libedit</application> as well).  This option disables
-       command-line editing and history in
+       Empêche l'utilisation de la bibliothèque <application>Readline</application>
+       (et <application>libedit</application> par la même occasion).
+       Cette option désactive l'édition de la ligne de commande et l'historique dans
        <application>psql</application>.
       </para>
      </listitem>
@@ -1199,10 +1211,10 @@ build-postgresql:
      <term><option>--with-libedit-preferred</option></term>
      <listitem>
       <para>
-       Favors the use of the BSD-licensed <application>libedit</application> library
-       rather than GPL-licensed <application>Readline</application>.  This option
-       is significant only if you have both libraries installed; the
-       default in that case is to use <application>Readline</application>.
+       Favorise l'utilisation de la bibliothèque <application>libedit</application>
+       (licence BSD). Cette option n'est importante que si vous avez les deux
+       librairies installées&nbsp;; le défaut dans ce cas est d'utiliser
+       <application>Readline</application>.
       </para>
      </listitem>
     </varlistentry>
@@ -1214,10 +1226,9 @@ build-postgresql:
        <indexterm>
         <primary>zlib</primary>
        </indexterm>
-       Prevents use of the <application>Zlib</application> library.
-       This disables
-       support for compressed archives in <application>pg_dump</application>
-       and <application>pg_restore</application>.
+       Empêche l'utilisation de la bibliothèque <application>Zlib</application>.
+       Cela désactive le support des archives compressées dans
+       <application>pg_dump</application> et <application>pg_restore</application>.
       </para>
      </listitem>
     </varlistentry>
@@ -1226,15 +1237,14 @@ build-postgresql:
      <term><option>--disable-spinlocks</option></term>
      <listitem>
       <para>
-       Autorise le succès de la construction y compris lorsque
+       Autorise le succès de la compilation même si
        <productname>PostgreSQL</productname> n'a
-       pas le support spinlock du CPU pour la plateforme. Ce manque de support
-       résultera en des performances très faibles&nbsp;; du coup, cette option
-       devra seulement être utilisée si la construction échoue et vous informe
-       du manque de support de spinlock sur votre plateforme. Si cette option
-       est requise pour construire <productname>PostgreSQL</productname> sur votre
-       plateforme, merci de rapporter le problème aux développeurs de
-       <productname>PostgreSQL</productname>.
+       pas le support des spinlocks pour le CPU de la plateforme. Ce manque de support
+       entraînera des performances très faibles&nbsp;; du coup, cette option
+       ne devra être utilisée que si la compilation échoue et vous informe
+       du manque de support des spinlocks sur votre plateforme. Si cette option
+       est nécessaire pour y compiler <productname>PostgreSQL</productname>,
+       merci de rapporter le problème à ses développeurs.
       </para>
      </listitem>
     </varlistentry>
@@ -1243,10 +1253,11 @@ build-postgresql:
      <term><option>--disable-atomics</option></term>
      <listitem>
       <para>
-       Disable use of CPU atomic operations.  This option does nothing on
-       platforms that lack such operations.  On platforms that do have
-       them, this will result in poor performance.  This option is only
-       useful for debugging or making performance comparisons.
+       Désactive l'utilisation des opérations atomiques sur le CPU.
+       Cette option ne fait rien sur les plateformes n'ont ŝpas
+       ces opérations. Sur celles qui l'ont, cela entraînera de
+       mauvaises performances. Cette option n'est utile que pour le
+       débogage ou pour des comparatifs de performance.
       </para>
      </listitem>
     </varlistentry>
@@ -1256,10 +1267,11 @@ build-postgresql:
      <listitem>
       <para>
        Désactive la sécurité des threads pour les bibliothèques clients. Ceci
-       empêche les threads concurrents dans les programmes
+       interdit aux threads concurrents dans les programmes
        <application>libpq</application> et <application>ECPG</application>
-       de contrôler en toute sécurité leurs pointeurs de connexion privés. Use this only on platforms
-       with deficient threading support.
+       de contrôler en toute sécurité leurs pointeurs de connexion privés.
+       N'utiliser que sur les plateformes avec un support des threads
+       défaillant.
       </para>
      </listitem>
     </varlistentry>
@@ -1267,39 +1279,42 @@ build-postgresql:
   </sect3>
 
   <sect3 id="configure-options-build-process">
-   <title>Build Process Details</title>
+   <title>Détails du processus de compilation</title>
 
     <variablelist>
      <varlistentry>
-      <term><option>--with-includes=<replaceable>DIRECTORIES</replaceable></option></term>
+      <term><option>--with-includes=<replaceable>RÉPERTOIRES</replaceable></option></term>
       <listitem>
        <para>
-        <replaceable>DIRECTORIES</replaceable> is a colon-separated list of
-        directories that will be added to the list the compiler
-        searches for header files. If you have optional packages
-        (such as GNU <application>Readline</application>) installed in a non-standard
-        location,
-        you have to use this option and probably also the corresponding
-        <option>--with-libraries</option> option.
+        <replaceable>RÉPERTOIRES</replaceable> est une liste de répertoires,
+        séparés par le caractère deux points (:), qui seront ajoutés à la liste de ceux
+        où le compilateur recherche des fichiers d'entête.
+        Si vous avez des paquets optionnels (comme
+        GNU <application>Readline</application>) installés dans un
+        emplacement non conventionnels, vous devez utiliser cette option,
+        et probablement aussi l'option correspondante
+        <option>--with-libraries</option>.
        </para>
        <para>
-        Example: <literal>--with-includes=/opt/gnu/include:/usr/sup/include</literal>.
+        Exemple&nbsp;: <literal>--with-includes=/opt/gnu/include:/usr/sup/include</literal>.
        </para>
       </listitem>
      </varlistentry>
 
      <varlistentry>
-      <term><option>--with-libraries=<replaceable>DIRECTORIES</replaceable></option></term>
+      <term><option>--with-libraries=<replaceable>RÉPERTOIRES</replaceable></option></term>
       <listitem>
        <para>
-        <replaceable>DIRECTORIES</replaceable> is a colon-separated list of
-        directories to search for libraries. You will probably have
-        to use this option (and the corresponding
-        <option>--with-includes</option> option) if you have packages
-        installed in non-standard locations.
+        <replaceable>RÉPERTOIRES</replaceable> est une liste de répertoires,
+        séparés par le caractère deux points (:),
+        où chercher des bibliothèques de fonctions.
+        Si vous avez des paquets installés dans des
+        emplacements non conventionnels, vous devez utiliser cette option,
+        (et probablement aussi l'option correspondante
+        <option>--with-includess</option>).
        </para>
        <para>
-        Example: <literal>--with-libraries=/opt/gnu/lib:/usr/sup/lib</literal>.
+        Exemple&nbsp;: <literal>--with-libraries=/opt/gnu/lib:/usr/sup/lib</literal>.
        </para>
       </listitem>
      </varlistentry>
@@ -1318,16 +1333,16 @@ build-postgresql:
        des fuseaux horaires, nécessaire pour les opérations sur les dates et
        les heures. Cette base de données est en fait compatible avec la base
        de fuseaux horaires IANA fournie par de nombreux
-       systèmes d'exploitation comme FreeBSD, Linux et Solaris, donc ce serait
+       systèmes d'exploitation comme FreeBSD, Linux et Solaris, donc il semble
        redondant de l'installer une nouvelle fois. Quand cette option est
-       utilisée, la base des fuseaux horaires, fournie par le système, dans
-       <replaceable>RÉPERTOIRE</replaceable> est utilisée à la place de celle
+       utilisée, la base des fuseaux horaires fournie par le système, dans
+       <replaceable>RÉPERTOIRE</replaceable>, est utilisée à la place de celle
        incluse dans la distribution des sources de PostgreSQL.
        <replaceable>RÉPERTOIRE</replaceable> doit être indiqué avec un chemin
        absolu. <filename>/usr/share/zoneinfo</filename> est un répertoire
-       très probable sur certains systèmes d'exploitation. Notez que la routine
+       courant sur certains systèmes d'exploitation. Notez que la routine
        d'installation ne détectera pas les données de fuseau horaire différentes
-       ou erronées. Si vous utilisez cette option, il vous est conseillé de
+       ou erronées. Si vous utilisez cette option, il est conseillé de
        lancer les tests de régression pour vérifier que les données de fuseau
        horaire que vous pointez fonctionnent correctement avec
        <productname>PostgreSQL</productname>.
@@ -1336,11 +1351,11 @@ build-postgresql:
       <indexterm><primary>cross compilation</primary></indexterm>
 
       <para>
-       Cette option a pour cible les distributeurs de paquets binaires qui
-       connaissent leur système d'exploitation. Le principal avantage
-       d'utiliser cette option est que le package PostgreSQL n'aura pas
-       besoin d'être mis à jour à chaque fois que les règles des fuseaux
-       horaires changent. Un autre avantage est que PostgreSQL peut être
+       Cette option est surtout destinée aux distributeurs de paquets binaires,
+       qui connaissent bien leur système d'exploitation.
+       Le principal avantage de cette option est que le paquet de PostgreSQL
+       n'aura pas besoin de mise à jour à chaque changement des règles des fuseaux
+       horaires. Un autre avantage est que PostgreSQL peut être
        cross-compilé<indexterm><primary>cross compilation</primary></indexterm>
        plus simplement si les fichiers des fuseaux horaires n'ont pas besoin
        d'être construits lors de l'installation.
@@ -1349,14 +1364,14 @@ build-postgresql:
     </varlistentry>
 
     <varlistentry>
-     <term><option>--with-extra-version=<replaceable>STRING</replaceable></option></term>
+     <term><option>--with-extra-version=<replaceable>CHAÎNE</replaceable></option></term>
      <listitem>
       <para>
-       Append <replaceable>STRING</replaceable> to the PostgreSQL version number.  You
-       can use this, for example, to mark binaries built from unreleased Git
-       snapshots or containing custom patches with an extra version string,
-       such as a <command>git describe</command> identifier or a
-       distribution package release number.
+       Ajoute <replaceable>CHAÎNE</replaceable> au numéro de version de PostgreSQL.
+       Par exemple, vous pouvez utiliser cela pour marquer des binaires compilés
+       depuis des snapshots Git, ou contenant des patchs, avec une chaîne
+       supplémentaire, comme un identifiant <command>git describe</command>
+       ou un numéro de version de distribution du paquet.
       </para>
      </listitem>
     </varlistentry>
@@ -1365,16 +1380,18 @@ build-postgresql:
        <term><option>--disable-rpath</option></term>
        <listitem>
         <para>
-         Do not mark <productname>PostgreSQL</productname>'s executables
-         to indicate that they should search for shared libraries in the
-         installation's library directory (see <option>--libdir</option>).
-         On most platforms, this marking uses an absolute path to the
-         library directory, so that it will be unhelpful if you relocate
-         the installation later.  However, you will then need to provide
-         some other way for the executables to find the shared libraries.
-         Typically this requires configuring the operating system's
-         dynamic linker to search the library directory; see
-         <xref linkend="install-post-shlibs"/> for more detail.
+         N'indique pas aux exécutables de <productname>PostgreSQL</productname>
+         qu'ils doivent chercher les bibliothèques partagées dans le
+         répertoire des bibliothèques de l'installation
+         (voir <option>--libdir</option>).
+         Sur la plupart des plateformes, cette indication utilise un
+         chemin absolu vers le répertoire des bibliothèques,
+         et sera inutile si vous déplacez l'installation plus tard.
+         Cependant, vous devrez alors fournir aux exécutables
+         un autre moyen pour trouver les bibliothèques partagées.
+         Typiquement, cela implique de configurer l'éditeur de liens
+         du système d'exploitation pour les rechercher&nbsp;;
+         voir <xref linkend="install-post-shlibs"/> pour plus de détails.
         </para>
        </listitem>
       </varlistentry>
@@ -1384,42 +1401,43 @@ build-postgresql:
    </sect3>
 
    <sect3 id="configure-options-misc">
-    <title>Miscellaneous</title>
+    <title>Divers</title>
 
     <para>
-     It's fairly common, particularly for test builds, to adjust the
-     default port number with <option>--with-pgport</option>.
-     The other options in this section are recommended only for advanced
-     users.
+     Il est assez courant, particulièrement pour les compilations de test,
+     de modifier le numéro de port avec l'option <option>--with-pgport</option>.
+     Les autres options de cette section ne sont recommandées que pour
+     les utilisateurs avancés.
     </para>
 
      <variablelist>
 
       <varlistentry>
-       <term><option>--with-pgport=<replaceable>NUMBER</replaceable></option></term>
+       <term><option>--with-pgport=<replaceable>PORT</replaceable></option></term>
        <listitem>
         <para>
-         Set <replaceable>NUMBER</replaceable> as the default port number for
-         server and clients. The default is 5432. The port can always
-         be changed later on, but if you specify it here then both
-         server and clients will have the same default compiled in,
-         which can be very convenient.  Usually the only good reason
-         to select a non-default value is if you intend to run multiple
-         <productname>PostgreSQL</productname> servers on the same machine.
+         Positionne <replaceable>PORT</replaceable> comme numéro de port
+         pour les serveurs et les clients. Le défaut est 5432.
+         Le port peut toujours être changé plus tard&nbsp;; mais, si vous le
+         spécifiez ici, serveur et clients auront le même défaut dès la
+         compilation, ce qui peut être très pratique.
+         D'habitude, la seule bonne raison de sélectionner une autre valeur
+         que le défaut est si vous avez l'intention de faire
+         tourner plusieurs serveurs <productname>PostgreSQL</productname>
+         sur la même machine.
         </para>
        </listitem>
       </varlistentry>
 
       <varlistentry>
-       <term><option>--with-krb-srvnam=<replaceable>NAME</replaceable></option></term>
+       <term><option>--with-krb-srvnam=<replaceable>NOM</replaceable></option></term>
        <listitem>
         <para>
-         The default name of the Kerberos service principal used
-         by GSSAPI.
-         <literal>postgres</literal> is the default. There's usually no
-         reason to change this unless you are building for a Windows
-         environment, in which case it must be set to upper case
-         <literal>POSTGRES</literal>.
+         Le nom par défaut du service principal Kerberos utilisé par GSSAPI.
+         <literal>postgres</literal> est le défaut.
+         D'habitude, il n'y a aucune raison de changer cela, à moins que
+         vous ne compiliez pour un environnement Windows&nbsp; auquel cas
+         ce doit être, en majuscules, <literal>POSTGRES</literal>.
         </para>
        </listitem>
       </varlistentry>
@@ -1428,55 +1446,66 @@ build-postgresql:
        <term><option>--with-segsize=<replaceable>SEGSIZE</replaceable></option></term>
        <listitem>
         <para>
-         Set the <firstterm>segment size</firstterm>, in gigabytes.  Large tables are
-         divided into multiple operating-system files, each of size equal
-         to the segment size.  This avoids problems with file size limits
-         that exist on many platforms.  The default segment size, 1 gigabyte,
-         is safe on all supported platforms.  If your operating system has
-         <quote>largefile</quote> support (which most do, nowadays), you can use
-         a larger segment size.  This can be helpful to reduce the number of
-         file descriptors consumed when working with very large tables.
-         But be careful not to select a value larger than is supported
-         by your platform and the file systems you intend to use.  Other
-         tools you might wish to use, such as <application>tar</application>, could
-         also set limits on the usable file size.
-         It is recommended, though not absolutely required, that this value
-         be a power of 2.
-         Note that changing this value breaks on-disk database compatibility,
-         meaning you cannot use <command>pg_upgrade</command> to upgrade to
-         a build with a different segment size.
+         Définit la taille d'un segment (<firstterm>segment size</firstterm>),
+         en gigaoctets.
+         Au niveau du système d'exploitation, les grandes tables sont divisées
+         en plusieurs fichiers, chacun d'une taille égale à la taille d'un segment.
+         Cela évite des problèmes avec les limites de taille de fichiers
+         qui existent sur beaucoup de plateformes.
+         La taille par défaut, 1&nbsp;gigaoctet, est une valeur
+         sûre pour toutes les plateformes supportées.
+         Si votre système d'exploitation supporte les fichiers de
+         grande taille (<quote>largefile</quote>, et la plupart le font, de nos jours,
+         vous pouvez utiliser une plus grande taille de segment.
+         Ce peut être utile pour réduire le nombre de descripteurs de fichiers
+         consommés en travaillant avec de très grandes tables.
+         Mais faites attention à ne pas choisir une valeur plus large que ce
+         qui est supporté par votre plateforme et les systèmes de fichiers
+         que vous voulez utiliser.
+         D'autres outils que vous pourriez vouloir utiliser, comme
+         <application>tar</application>, peuvent aussi poser des limites
+         sur la taille de fichier utilisable.
+         Il est recommandé que cette valeur soit une puissance de 2,
+         même si ce n'est pas absolument nécessaire.
+         Notez que changer cette valeur casse la compatibilité entre bases
+         au niveau fichier, ce qui veut dire que vous ne pouvez pas utiliser
+         <command>pg_upgrade</command> pour mettre à jour vers une
+         version compilée avec une taille de segment différente.
+       </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term><option>--with-blocksize=<replaceable>TAILLEBLOC</replaceable></option></term>
+       <listitem>
+        <para>
+         Définit la taille de bloc (<firstterm>block size</firstterm>), en kilooctets.
+         C'est l'unité de stockage et d'entrée-sortie dans les tables.
+         Le défaut, 8&nbsp;kilooctets, est adéquat pour la plupart des situations&nbsp;;
+         mais d'autres valeurs peuvent être utiles dans certains cas.
+         La valeur peut être une puissance de 2 entre 1 et 32 (kilooctets).
+         Notez que changer cette valeur casse la compatibilité entre bases
+         au niveau fichier, ce qui veut dire que vous ne pouvez pas utiliser
+         <command>pg_upgrade</command> pour mettre à jour vers une
+         version compilée avec une taille de bloc différente.
         </para>
        </listitem>
       </varlistentry>
 
       <varlistentry>
-       <term><option>--with-blocksize=<replaceable>BLOCKSIZE</replaceable></option></term>
+       <term><option>--with-wal-blocksize=<replaceable>TAILLEBLOC</replaceable></option></term>
        <listitem>
         <para>
-         Set the <firstterm>block size</firstterm>, in kilobytes.  This is the unit
-         of storage and I/O within tables.  The default, 8 kilobytes,
-         is suitable for most situations; but other values may be useful
-         in special cases.
-         The value must be a power of 2 between 1 and 32 (kilobytes).
-         Note that changing this value breaks on-disk database compatibility,
-         meaning you cannot use <command>pg_upgrade</command> to upgrade to
-         a build with a different block size.
-        </para>
-       </listitem>
-      </varlistentry>
-
-      <varlistentry>
-       <term><option>--with-wal-blocksize=<replaceable>BLOCKSIZE</replaceable></option></term>
-       <listitem>
-        <para>
-         Set the <firstterm>WAL block size</firstterm>, in kilobytes.  This is the unit
-         of storage and I/O within the WAL log.  The default, 8 kilobytes,
-         is suitable for most situations; but other values may be useful
-         in special cases.
-         The value must be a power of 2 between 1 and 64 (kilobytes).
-         Note that changing this value breaks on-disk database compatibility,
-         meaning you cannot use <command>pg_upgrade</command> to upgrade to
-         a build with a different WAL block size.
+         Définit la taille de bloc dans les journaux de transaction
+         (<firstterm>WAL block size</firstterm>), en kilooctets.
+         C'est l'unité de stockage et d'entrée-sortie en leur sein.
+         Le défaut, 8&nbsp;kilooctets, convient pour la plupart des situations&nbsp;;
+         mais d'autres valeurs peuvent être utiles dans certains cas.
+         La valeur doit être une puissance de 2 entre 1 et 64 (kilooctets).
+         Notez que changer cette valeur casse la compatibilité entre bases
+         au niveau fichier, ce qui veut dire que vous ne pouvez pas utiliser
+         <command>pg_upgrade</command> pour mettre à jour vers une
+         version compilée avec une taille de bloc de WAL différente.
         </para>
        </listitem>
       </varlistentry>
@@ -1486,23 +1515,24 @@ build-postgresql:
    </sect3>
 
    <sect3 id="configure-options-devel">
-    <title>Developer Options</title>
+    <title>Options pour les développeurs</title>
 
     <para>
-     Most of the options in this section are only of interest for
-     developing or debugging <productname>PostgreSQL</productname>.
-     They are not recommended for production builds, except
-     for <option>--enable-debug</option>, which can be useful to enable
-     detailed bug reports in the unlucky event that you encounter a bug.
-     On platforms supporting DTrace, <option>--enable-dtrace</option>
-     may also be reasonable to use in production.
+     La plupart des options de cette section n'ont d'intérêt
+     que pour développer ou déboguer <productname>PostgreSQL</productname>.
+     Elles ne sont pas recommandés pour la production, sauf
+     <option>--enable-debug</option>, qui peut être utile pour
+     obtenir des rapports de bugs détaillés, dans l'éventualité
+     malheureuse où vous rencontriez un bug.
+     Sur les plateformes supportant DTrace, <option>--enable-dtrace</option>
+     peut raisonnablement être utilisé en production.
     </para>
 
     <para>
-     When building an installation that will be used to develop code inside
-     the server, it is recommended to use at least the
-     options <option>--enable-debug</option>
-     and <option>--enable-cassert</option>.
+     Pour compiler une installation destinée à développer du code
+     au sein du serveur, il est recommandé d'utiliser au moins
+     les options <option>--enable-debug</option>
+     et <option>--enable-cassert</option>.
     </para>
 
      <variablelist>
@@ -1511,16 +1541,17 @@ build-postgresql:
      <term><option>--enable-debug</option></term>
      <listitem>
       <para>
-       Compile tous les programmes et bibliothèques en mode de débogage.
-       Cela signifie que vous pouvez exécuter les programmes via un
-       débogueur pour analyser les problèmes. Cela grossit considérablement
+       Compile tous les programmes et bibliothèques
+       avec les symboles de débogage.
+       Cela signifie que vous pouvez exécuter les programmes au sein d'un
+       débogueur pour analyser les problèmes. Cela augmente considérablement
        la taille des exécutables et, avec des compilateurs autres que GCC,
-       habituellement, cela désactive les optimisations du compilateur,
-       provoquant des ralentissements. Cependant, mettre ce mode en place est
-       extrêmement utile pour repérer les problèmes. Actuellement, cette
-       option est recommandée pour les installations en production seulement
-       si vous utilisez GCC. Néanmoins, vous devriez l'utiliser si vous
-       développez ou si vous utilisez une version béta.
+       désactive habituellement les optimisations du compilateur,
+       provoquant des ralentissements. Cependant, avoir les symboles en place est
+       extrêmement utile pour traiter d'éventuels problèmes. Actuellement, cette
+       option n'est recommandée pour les installations en production que
+       si vous utilisez GCC. Néanmoins, vous devriez toujours l'utiliser si vous
+       développez, ou si vous utilisez une version bêta.
       </para>
      </listitem>
     </varlistentry>
@@ -1529,17 +1560,18 @@ build-postgresql:
        <term><option>--enable-cassert</option></term>
        <listitem>
         <para>
-         Enables <firstterm>assertion</firstterm> checks in the server, which test for
-         many <quote>cannot happen</quote> conditions.  This is invaluable for
-         code development purposes, but the tests can slow down the
-         server significantly.
-         Also, having the tests turned on won't necessarily enhance the
-         stability of your server!  The assertion checks are not categorized
-         for severity, and so what might be a relatively harmless bug will
-         still lead to server restarts if it triggers an assertion
-         failure.  This option is not recommended for production use, but
-         you should have it on for development work or when running a beta
-         version.
+         Active les vérifications des assertions (<firstterm>assertion</firstterm>)
+         dans le serveur, qui testent de nombreuses conditions qui
+         <quote>ne peuvent pas arriver</quote>.
+         C'est inestimable pour le développement du code, mais les tests
+         peuvent ralentir le serveur considérablement.
+         Activer ces tests ne va pas améliorer la stabilité de votre
+         serveur&nbsp;! Les tests des assertions ne sont pas triés par
+         sévérité, et un petit bug relativement inoffensif,
+         s'il déclenche un échec d'assertion,
+         peut mener à des redémarrages du serveur&nbsp;!
+         Cette option n'est pas recommandée en production, mais vous devriez
+         l'avoir en développement, ou en utilisant une version bêta.
         </para>
        </listitem>
       </varlistentry>
@@ -1548,9 +1580,11 @@ build-postgresql:
        <term><option>--enable-tap-tests</option></term>
        <listitem>
         <para>
-         Enable tests using the Perl TAP tools.  This requires a Perl
-         installation and the Perl module <literal>IPC::Run</literal>.
-         <phrase condition="standalone-ignore">See <xref linkend="regress-tap"/> for more information.</phrase>
+         Active les tests avec les outils TAP de Perl.
+         Cela nécessite une installation de Perl et de son module
+         <literal>IPC::Run</literal>.
+         <phrase condition="standalone-ignore">Voir <xref linkend="regress-tap"/>
+         pour plus d'information.</phrase>
         </para>
        </listitem>
       </varlistentry>
@@ -1559,12 +1593,14 @@ build-postgresql:
        <term><option>--enable-depend</option></term>
        <listitem>
         <para>
-         Enables automatic dependency tracking.  With this option, the
-         makefiles are set up so that all affected object files will
-         be rebuilt when any header file is changed.  This is useful
-         if you are doing development work, but is just wasted overhead
-         if you intend only to compile once and install.  At present,
-         this option only works with GCC.
+         Active le suivi automatique des dépendances.
+         Avec cette option, les makefiles sont conçus pour que
+         tous les fichiers objets soient recompilés si n'importe
+         quel fichier d'en-tête change.
+         C'est utile si vous faites du développement, mais n'est que
+         gaspillage si vous ne devez compiler qu'une fois pour
+         installer.
+         Pour le moment, cette option ne fonctionne qu'avec GCC.
         </para>
        </listitem>
       </varlistentry>
@@ -1573,13 +1609,13 @@ build-postgresql:
      <term><option>--enable-coverage</option></term>
      <listitem>
       <para>
-       Si vous utilisez GCC, les programmes et bibliothèques sont compilés avec
+       Si vous utilisez GCC, tous les programmes et bibliothèques sont compilés avec
        de l'instrumentation de test de couverture de code. Quand ils sont exécutés,
        ils génèrent des fichiers dans le répertoire de compilation avec des
        métriques de couverture de code.
        Voir <xref linkend="regress-coverage"/> pour davantage
        d'informations. Cette option ne doit être utilisée qu'avec GCC
-       et uniquement en phase de développement.
+       et en développement.
       </para>
      </listitem>
     </varlistentry>
@@ -1589,10 +1625,10 @@ build-postgresql:
      <listitem>
       <para>
        En cas d'utilisation de GCC, tous les programmes et bibliothèques
-       sont compilés pour qu'elles puissent être profilées. À la sortie du
+       sont compilés pour pouvoir être profilés. À la sortie du
        processus serveur, un sous-répertoire sera créé pour contenir le
        fichier <filename>gmon.out</filename> contenant les données de profilage.
-       Cette option est à utiliser uniquement avec GCC lors d'un développement.
+       Cette option n'est à utiliser qu'avec GCC et en développement.
       </para>
      </listitem>
     </varlistentry>
@@ -1606,30 +1642,32 @@ build-postgresql:
        </indexterm>
        Compile <productname>PostgreSQL</productname> avec le support de l'outil
        de trace dynamique, DTrace.
-       Voir <xref linkend="dynamic-trace"/>
-        pour plus d'informations.
+       <phrase condition="standalone-ignore">
+       Voir <xref linkend="dynamic-trace"/> pour plus d'informations.
+       </phrase>
       </para>
 
       <para>
        Pour pointer vers le programme <command>dtrace</command>, la variable
-       d'environnement <envar>DTRACE</envar> doit être configurée. Ceci sera
-       souvent nécessaire car <command>dtrace</command> est typiquement
-       installé sous <filename>/usr/sbin</filename>, qui pourrait ne pas être
+       d'environnement <envar>DTRACE</envar> peut être configurée. Ce sera
+       souvent nécessaire, car <command>dtrace</command> est typiquement
+       installé sous <filename>/usr/sbin</filename>, qui peut ne pas être
        dans votre <envar>PATH</envar>.
       </para>
 
       <para>
        Des options supplémentaires en ligne de commande
+       pour <command>dtrace</command>
        peuvent être indiquées dans la variable d'environnement
        <envar>DTRACEFLAGS</envar> pour le programme <command>dtrace</command>.
-       Sur Solaris, pour inclure le support de DTrace dans un exécutable 64-bit, ajoutez
+       Sur Solaris, pour inclure le support de DTrace dans un exécutable 64 bits, ajoutez
        l'option <literal>DTRACEFLAGS="-64"</literal>. Par
        exemple, en utilisant le compilateur GCC&nbsp;:
-       <screen>./configure CC='gcc -m64' --enable-dtrace DTRACEFLAGS='-64' ...
-       </screen>
+<screen>./configure CC='gcc -m64' --enable-dtrace DTRACEFLAGS='-64' ...
+</screen>
        En utilisant le compilateur de Sun&nbsp;:
-       <screen>./configure CC='/opt/SUNWspro/bin/cc -xtarget=native64' --enable-dtrace DTRACEFLAGS='-64' ...
-       </screen>
+<screen>./configure CC='/opt/SUNWspro/bin/cc -xtarget=native64' --enable-dtrace DTRACEFLAGS='-64' ...
+</screen>
       </para>
      </listitem>
     </varlistentry>
@@ -1638,43 +1676,43 @@ build-postgresql:
  </sect2>
 
  <sect2 id="configure-envvars">
-  <title><filename>configure</filename> Environment Variables</title>
+  <title>Variables d'environnement de <filename>configure</filename></title>
 
   <indexterm zone="configure-envvars">
    <primary>configure environment variables</primary>
   </indexterm>
 
   <para>
-   In addition to the ordinary command-line options described above,
-   <filename>configure</filename> responds to a number of environment
-   variables.
-   You can specify environment variables on the
-   <filename>configure</filename> command line, for example:
+    En plus des options de ligne de commande ordinaires décrites
+    plus haut, <filename>configure</filename> répond à nombre
+    de variables d'environnement.
+    Vous pouvez les spécifier sur la ligne de commande de
+    <filename>configure</filename>, par exemple ainsi&nbsp;:
 <screen>
 <userinput>./configure CC=/opt/bin/gcc CFLAGS='-O2 -pipe'</userinput>
 </screen>
-   In this usage an environment variable is little different from a
-   command-line option.
-   You can also set such variables beforehand:
+    Dans ce cas une variable d'environnement est peu différente d'une
+    option de ligne de commande.
+    Vous pouvez aussi les placer au préalable&nbsp;:
 <screen>
 <userinput>export CC=/opt/bin/gcc</userinput>
 <userinput>export CFLAGS='-O2 -pipe'</userinput>
 <userinput>./configure</userinput>
 </screen>
-   This usage can be convenient because many programs' configuration
-   scripts respond to these variables in similar ways.
+    Cette utilisation peut être pratique parce que les scripts de
+    configuration de beaucoup de programmes répondent à ces
+    variables de manière similaire.
   </para>
  
   <para>
-   The most commonly used of these environment variables are
-   <envar>CC</envar> and <envar>CFLAGS</envar>.
-   Si vous préférez utiliser un compilateur C différent de ceux listés par
+   Les plus utilisées de ces variables d'environnement sont
+   <envar>CC</envar> et <envar>CFLAGS</envar>.
+   Si vous préférez utiliser un compilateur C différent de celui choisi par
    <filename>configure</filename>, positionnez la variable
-   <envar>CC</envar> pour qu'elle pointe sur le compilateur de
-   votre choix.
-   Par défaut, <filename>configure</filename> pointe sur
-   <filename>gcc</filename> s'il est disponible, sinon il utilise celui par
-   défaut de la plateforme (habituellement <filename>cc</filename>).
+   <envar>CC</envar> vers le compilateur de votre choix.
+   Par défaut, <filename>configure</filename> choisira
+   <filename>gcc</filename> s'il est disponible, et sinon celui par
+   défaut sur la plateforme (habituellement <filename>cc</filename>).
    De façon similaire, vous pouvez repositionner les options par défaut du
    compilateur à l'aide de la variable <envar>CFLAGS</envar>.
   </para>
@@ -1718,8 +1756,8 @@ build-postgresql:
        <listitem>
         <para>
          chemin vers le programme <command>clang</command> utilisé pour
-		 l'optimisation inline du code source lors de la compilation avec
-		 <literal>--with-llvm</literal>
+         optimiser le code source lors de la compilation avec
+         <literal>--with-llvm</literal>
         </para>
        </listitem>
       </varlistentry>
@@ -1855,8 +1893,7 @@ build-postgresql:
          déterminer les dépendances pour la construction de PL/Python. De
          plus, si Python 2 ou 3 est spécifié ici (ou implicitement choisi), il
          détermine la variante de PL/Python qui devient disponible.
-         Voir <xref linkend="regress-tap"/>
-         pour plus d'informations.
+         Voir <xref linkend="regress-tap"/> pour plus d'informations.
         </para>
        </listitem>
       </varlistentry>
@@ -2017,10 +2054,9 @@ build-postgresql:
          déterminer les dépendances pour la construction de PL/Python. De
          plus, si Python 2 ou 3 est spécifié ici (ou implicitement choisi), il
          détermine la variante de PL/Python qui devient disponible. Voir
-         <xref linkend="plpython-python23"/> pour plus
-         d'informations. Si cette variable n'est pas configurée, les suivantes
-         sont testées dans cet ordre&nbsp;: <literal>python python3
-         python2</literal>.
+         <xref linkend="plpython-python23"/> pour plus d'informations.
+         Si ce paramètre n'est pas en place, seront testés dans cet ordre&nbsp;:
+         <literal>python python3 python2</literal>.
         </para>
        </listitem>
       </varlistentry>
@@ -2031,8 +2067,8 @@ build-postgresql:
         <para>
          programme interpréteur Tcl. Il sera utilisé pour déterminer
          les dépendances pour la construction de PL/Tcl.
-         If this is not set, the following are probed in this
-         order: <literal>tclsh tcl tclsh8.6 tclsh86 tclsh8.5 tclsh85
+         Si ce paramètre n'est pas en place, seront testés dans cet ordre&nbsp;:
+         <literal>tclsh tcl tclsh8.6 tclsh86 tclsh8.5 tclsh85
          tclsh8.4 tclsh84</literal>.
         </para>
        </listitem>
@@ -2042,8 +2078,8 @@ build-postgresql:
        <term><envar>XML2_CONFIG</envar></term>
        <listitem>
         <para>
-         programme <command>xml2-config</command> utilisé pour localiser
-         l'installation de libxml2.
+         programme <command>xml2-config</command> utilisé pour trouver
+         l'emplacement de l'installation de libxml2.
         </para>
        </listitem>
       </varlistentry>
@@ -2051,51 +2087,52 @@ build-postgresql:
     </para>
 
     <para>
-     Il est parfois utile d'ajouter des options de compilation à l'ensemble
-     choisi par <filename>configure</filename> après coup. Un exemple parlant
+     Parfois, ajouter des options de compilation après coup à celles
+     choisies par <filename>configure</filename> peut se révéler utile.
+     Un exemple parlant
      concerne l'option <option>-Werror</option> de
-     <application>gcc</application> qui ne peut pas être incluse dans la
+     <application>gcc</application>, qui ne peut pas être incluse dans la
      variable <envar>CFLAGS</envar> passée à <filename>configure</filename>,
-     car il cassera un grand nombre de tests internes de
-     <filename>configure</filename>. Pour ajouter de telles options, incluez-
-     les dans la variable d'environnement <envar>COPT</envar> lors de
-     l'exécution de <filename>gmake</filename>. Le contenu de
+     car elle casserait un grand nombre de tests internes de
+     <filename>configure</filename>. Pour ajouter de telles options, incluez-les
+     dans la variable d'environnement <envar>COPT</envar> lors de
+     l'exécution de <filename>make</filename>. Le contenu de
      <envar>COPT</envar> est ajouté aux variables <envar>CFLAGS</envar> et
      <envar>LDFLAGS</envar> configurées par <filename>configure</filename>.
      Par exemple, vous pouvez faire&nbsp;:
 <screen>
-<userinput>gmake COPT='-Werror'</userinput>
+<userinput>make COPT='-Werror'</userinput>
 </screen>
      ou
 <screen>
 <userinput>export COPT='-Werror'</userinput>
-<userinput>gmake</userinput>
+<userinput>make</userinput>
 </screen>
     </para>
 
     <note>
      <para>
-      Si vous utilisez GCC, il est préférable de construire avec un niveau
-      d'optimisation d'au moins <option>-O1</option> parce que désactiver
-      toute optimisation (<option>-O0</option>) désactive aussi certains
+      Si vous utilisez GCC, il est préférable de compiler avec un niveau
+      d'optimisation d'au moins <option>-O1</option>, parce l'absence
+      d'optimisation (<option>-O0</option>) désactive aussi certains
       messages importants du compilateur (comme l'utilisation de variables
       non initialisées). Néanmoins, les niveaux d'optimisations peuvent
-      compliquer le débuggage parce que faire du pas-à-pas sur le code
-      compilé ne correspondra pas forcément aux lignes de code une-à-une.
-      Si vous avez du mal à débugger du code optimisé, recompilez les fichiers
-      intéressants avec <option>-O0</option>. Une façon simple de le faire est
+      compliquer le débogage&nbsp;: un pas-à-pas sur le code
+      compilé ne correspondra pas forcément directement aux lignes de code.
+      Si vous avez du mal à déboguer du code optimisé, recompilez les fichiers
+      qui vous intéressent avec <option>-O0</option>.
+      Une façon simple de le faire est
       de passer une option à <application>make</application>:
       <command>make PROFILE=-O0 file.o</command>.
      </para>
 
      <para>
-      Les variables d'environnement <envar>COPT</envar> et
-      <envar>PROFILE</envar> sont gérées de façon identique par les fichiers
-      makefile de <productname>PostgreSQL</productname>. Laquelle utiliser est
-      une affaire de préférence, mais un usage commun parmi les développeurs
-      est d'utiliser <envar>PROFILE</envar> pour les ajustements inhabituels
-      alors que <envar>COPT</envar> servirait aux variables à configurer à
-      chaque fois.
+      En fait, les variables d'environnement <envar>COPT</envar> et
+      <envar>PROFILE</envar> sont gérées de façon identique par les
+      makefiles de <productname>PostgreSQL</productname>. Laquelle utiliser est
+      une affaire de préférence, mais l'usage parmi les développeurs
+      est d'utiliser <envar>PROFILE</envar> pour les ajustements ponctuels,
+      alors que <envar>COPT</envar> peut être conservé en permanence.
      </para>
     </note>
   </sect2>
@@ -2244,17 +2281,17 @@ export MANPATH</programlisting>
 
   <para>
    Une plateforme (c'est-à-dire une combinaison d'un processeur et d'un système
-   d'exploitation) est considérée supportée par la communauté de développeur de
+   d'exploitation) est considérée comme supportée par la communauté des développeurs de
    <productname>PostgreSQL</productname> si le code permet le fonctionnement
-   sur cette plateforme et que la construction et les tests de régression
-   ont été récemment vérifiés sur cette plateforme. Actuellement, la plupart
+   sur cette plateforme, et que la compilation et les tests de régression
+   ont été récemment validés sur cette plateforme. Actuellement, la plupart
    des tests de compatibilité de plateforme se font automatiquement par des
    machines de tests dans la <ulink
-   url="https://buildfarm.postgresql.org/">ferme de construction de
-   PostgreSQL</ulink>. Si vous êtes intéressés par l'utilisation de
+   url="https://buildfarm.postgresql.org/">ferme de compilation de
+   PostgreSQL</ulink>. Si vous êtes intéressé par l'utilisation de
    <productname>PostgreSQL</productname> sur une plateforme qui n'est pas
    représentée dans la ferme de construction, mais pour laquelle le code
-   fonctionne ou peut fonctionner, nous vous suggérons fortement de construire
+   fonctionne ou peut fonctionner, nous vous suggérons fortement de monter
    une machine qui sera membre de la ferme pour que la compatibilité puisse
    être assurée dans la durée.
   </para>
@@ -2274,7 +2311,7 @@ export MANPATH</programlisting>
   <para>
    <productname>PostgreSQL</productname> doit fonctionner sur les systèmes
    d'exploitation suivants&nbsp;: Linux (toutes les distributions récentes),
-   Windows (XP et ultérieures), FreeBSD, OpenBSD, NetBSD, macOS,
+   Windows (XP et ultérieurs), FreeBSD, OpenBSD, NetBSD, macOS,
    AIX, HP/UX et Solaris. D'autres systèmes style
    Unix peuvent aussi fonctionner mais n'ont pas été récemment testés. Dans
    la plupart des cas, toutes les architectures processeurs supportées par


### PR DESCRIPTION
Traduction des nouveaux morceaux  d'installation.sgml + relecture complète

Pas mal de morceaux (options de configure...) avaient été déplacés plus que supprimés. Pour éviter des erreurs en comparant, j'ai retraduit de zéro tout ce qui était en anglais, puis revérifié quand je trouvais une ancienne traduction sur le site.

J'ai remplacé systématiquement "Construction" (jamais entendu en français) par "Compilation".

Quelques tentatives de reformulation pour alléger et des typos occasionnelles.