### PR TITLE
pg_basebackup : traduction vs 13β2 + relecture complète

### DIFF
--- a/postgresql/ref/pg_basebackup.xml
+++ b/postgresql/ref/pg_basebackup.xml
@@ -27,65 +27,65 @@
   <title>Description</title>
 
   <para>
-   <application>pg_basebackup</application> est utilisé pour prendre une
-   sauvegarde de base d'une instance <productname>PostgreSQL</productname> en
+   <application>pg_basebackup</application> est utilisé pour effectuer des
+   sauvegardes de base d'une instance <productname>PostgreSQL</productname> en
    cours d'exécution. Elles se font sans affecter les autres clients du
-   serveur de bases de données et peuvent être utilisées pour une restauration
-   jusqu'à un certain point dans le temps (voir <xref
-   linkend="continuous-archiving"/>) ou comme le point de départ d'un serveur
-   en standby, par exemple avec la réplication en flux (voir <xref
+   serveur de bases de données, et peuvent être utilisées pour une restauration
+   à un certain point dans le temps (PITR, voir <xref
+   linkend="continuous-archiving"/>) ou comme point de départ pour un serveur
+   secondaire, par exemple avec la réplication par streaming (voir <xref
    linkend="warm-standby"/>).
   </para>
 
   <para>
    <application>pg_basebackup</application> fait une copie binaire des
-   fichiers de l'instance en s'assurant que le système est mis en mode
-   sauvegarde puis en est sorti. Les sauvegardes sont toujours faites sur
-   l'ensemble de l'instance, il n'est donc pas possible de sauvegarder une
-   base individuelle ou des objets d'une base. Pour les sauvegardes de ce
-   type, un outil comme <xref linkend="app-pgdump"/> doit être utilisé.
+   fichiers de l'instance, en s'assurant que le système entre et sort
+   du mode sauvegarde automatiquement. Les sauvegardes sont toujours faites sur
+   l'ensemble de l'instance &nbsp;; il n'est donc pas possible de sauvegarder une
+   base individuelle ou des objets d'une base.
+   Pour de telles sauvegardes, utiliser un outil comme <xref linkend="app-pgdump"/>.
   </para>
 
   <para>
    La sauvegarde se fait via une connexion
-   <productname>PostgreSQL</productname> standard et utilise le protocole de
+   <productname>PostgreSQL</productname> standard, et utilise le protocole de
    réplication. La connexion doit se faire avec un utilisateur doté de
    l'attribut <literal>REPLICATION</literal> ou <literal>SUPERUSER</literal>
    (voir <xref linkend="role-attributes"/>), et
    <filename>pg_hba.conf</filename> doit explicitement permettre la connexion
    de réplication. Le serveur doit aussi être configuré avec un <xref
    linkend="guc-max-wal-senders"/> suffisamment élevé pour laisser au moins
-   une connexion disponible pour la sauvegarde et une pour le transfert par
-   flux des WAL (si utilisé).
+   une connexion disponible pour la sauvegarde, et une pour le transfert par
+   streaming des WAL (si utilisé).
   </para>
 
   <para>
-   Plusieurs commandes <command>pg_basebackup</command> peuvent être exécutées
-   en même temps mais il est préférable pour les performances de n'en faire
-   qu'une seule et de copier le résultat.
+   Plusieurs commandes <command>pg_basebackup</command> peuvent tourner
+   en même temps, mais, du point de vue des performances,
+   il est préférable de n'en faire qu'une seule, puis de faire une copie du résultat.
   </para>
 
   <para>
    <application>pg_basebackup</application> peut effectuer une sauvegarde non
-   seulement à partir du serveur maître mais aussi du serveur esclave. Pour
-   effectuer une sauvegarde à partir de l'esclave, paramétrer l'esclave de
-   manière à ce qu'il accepte les connexions pour réplication (c'est-à-dire
-   définir les paramètres <varname>max_wal_senders</varname> et <xref
-   linkend="guc-hot-standby"/>, et configurer <link
-   linkend="auth-pg-hba-conf">l'authentification du client</link>). Il sera
+   seulement à partir du serveur maître, mais aussi d'un serveur secondaire.
+   Pour cela, paramétrez le secondaire
+   pour accepter les connexions pour réplication (c'est-à-dire
+   configurez les paramètres <varname>max_wal_senders</varname> et <xref
+   linkend="guc-hot-standby"/>, et configurez <link
+   linkend="auth-pg-hba-conf"> l'authentification du client</link>). Il sera
    aussi nécessaire d'activer <xref linkend="guc-full-page-writes"/> sur le
    maître.
   </para>
 
   <para>
    À noter qu'il existe des limites à la sauvegarde à chaud depuis un serveur
-   esclave&nbsp;:
+   secondaire&nbsp;:
 
    <itemizedlist>
     <listitem>
      <para>
       Le fichier d'historique de la sauvegarde n'est pas créé dans l'instance
-      de la base qui a été sauvegardée.
+      sauvegardée.
      </para>
     </listitem>
 
@@ -99,8 +99,8 @@
 
     <listitem>
      <para>
-      Si le serveur esclave est promu maître durant la sauvegarde à chaud, la
-      sauvegarde échouera.
+      Si le serveur esclave est promu en tant que maître durant la sauvegarde à chaud,
+      celle-ci échouera.
      </para>
     </listitem>
 
@@ -118,10 +118,10 @@
   </para>
 
   <para>
-   Whenever <application>pg_basebackup</application> is taking a base
-   backup, the <structname>pg_stat_progress_basebackup</structname>
-   view will report the progress of the backup.
-   See <xref linkend="basebackup-progress-reporting"/> for details.
+   La vue <structname>pg_stat_progress_basebackup</structname>
+   permet de suivre la progression d'une sauvegarde de base
+   effectuée avec <application>pg_basebackup</application>.
+   Voir <xref linkend="basebackup-progress-reporting"/> pour les détails.
   </para>
  </refsect1>
 
@@ -129,8 +129,8 @@
   <title>Options</title>
 
   <para>
-   Les options suivantes en ligne de commande contrôlent l'emplacement et le
-   format de la sortie.
+   Les options de ligne de commande suivantes contrôlent l'emplacement et le
+   format du résultat.
 
    <variablelist>
     <varlistentry>
@@ -138,20 +138,20 @@
      <term><option>--pgdata=<replaceable class="parameter">répertoire</replaceable></option></term>
      <listitem>
       <para>
-       Répertoire où sera écrit la sortie.
-       <application>pg_basebackup</application> créera le répertoire et tous
-       les sous-répertoires si nécessaire. Le répertoire peut déjà exister
+       Répertoire où sera écrite la sauvegarde.
+       <application>pg_basebackup</application> créera le répertoire et
+       les répertoires parents si nécessaire. Le répertoire peut déjà exister,
        mais doit être vide. Dans le cas contraire, une erreur est renvoyée.
       </para>
 
       <para>
-       Quand la sauvegarde est en mode tar et que le répertoire est spécifié
+       Si la sauvegarde est en mode tar et que le répertoire est spécifié
        avec un tiret (<literal>-</literal>), le fichier tar sera écrit sur
        <literal>stdout</literal>.
       </para>
 
       <para>
-       Cette option est requise.
+       Cette option est obligatoire.
       </para>
      </listitem>
     </varlistentry>
@@ -170,10 +170,10 @@
          <term><literal>plain</literal></term>
          <listitem>
           <para>
-           Écrit des fichiers standards, avec le même emplacement que le
-           répertoire des données et les tablespaces d'origine. Quand
-           l'instance n'a pas de tablespace supplémentaire, toute la base de
-           données sera placée dans le répertoire cible. Si l'instance
+           Écrit des fichiers standards, avec l'agencement d'origine du
+           répertoire des données et des tablespaces.
+           Si l'instance n'a pas de tablespace supplémentaire,
+           toute l'instance sera placée dans le répertoire cible. Si l'instance
            contient des tablespaces supplémentaires, le répertoire principal
            des données sera placé dans le répertoire cible mais les autres
            tablespaces seront placés dans le même chemin absolu que celui
@@ -193,17 +193,17 @@
           <para>
            Écrit des fichiers tar dans le répertoire cible. Le répertoire
            principal de données sera écrit sous la forme d'un fichier nommé
-           <filename>base.tar</filename> et tous les autres tablespaces seront
+           <filename>base.tar</filename>, et tous les autres tablespaces seront
            nommés d'après l'OID du tablespace.
           </para>
 
           <para>
            Si la valeur <literal>-</literal> (tiret) est indiquée comme
            répertoire cible, le contenu du tar sera écrit sur la sortie
-           standard, ce qui est intéressant pour une compression directe via
-           un tube. Ceci est seulement possible si l'instance n'a pas de
-           tablespace supplémentaire et le le transfert des WAL par flux n'est
-           pas utilisé.
+           standard, ce qui est permet de l'envoyer par un tube vers gzip, par exemple.
+           Ce n'est pas possible si l'instance a des
+           tablespaces supplémentaires, ou que le transfert des WAL par streaming est
+           utilisé.
           </para>
          </listitem>
         </varlistentry>
@@ -218,20 +218,20 @@
      <listitem>
       <para>
        Le taux maximum de transfert de données avec le serveur. Les valeurs
-       sont en kilo-octets par seconde. Le suffixe <literal>M</literal>
-       indique des méga-octets par seconde. Un suffixe <literal>k</literal>
-       est aussi accepté mais n'a pas d'effet supplémentaire. Les valeurs
-       valides vont de 32 ko/s à 1024 Mo/s.
+       sont en kilooctets par seconde. Le suffixe <literal>M</literal>
+       indique des mégaoctets par seconde. Un suffixe <literal>k</literal>
+       est aussi accepté, mais n'a pas d'effet supplémentaire. Les valeurs
+       valides vont de 32&nbsp;ko/s à 1024&nbsp;Mo/s.
       </para>
 
       <para>
        Le but est de limiter l'impact de
-       <application>pg_basebackup</application> sur le serveur.
+       <application>pg_basebackup</application> sur le serveur pendant son fonctionnement.
       </para>
 
       <para>
-       Cette option affecte le transfert du répertoire de données. Le
-       transfert des journaux de transactions est seulement affecté si la
+       Cette option concerne le transfert du répertoire de données. Le
+       transfert des journaux de transactions n'est affecté que si la
        méthode de récupération est <literal>fetch</literal>.
       </para>
      </listitem>
@@ -245,12 +245,12 @@
        Crée le fichier <filename>standby.signal</filename> et ajoute les
        paramètres de connexion dans<filename>postgresql.auto.conf</filename>
        dans le répertoire en sortie (ou dans le fichier d'archive du
-       répertoire principal des données lors de l'utilisation du format tar)
-       pour faciliter la configuration d'un serveur standby. Le fichier
+       répertoire principal des données si l'on utilise le format tar),
+       afin de faciliter la configuration d'un serveur secondaire. Le fichier
        <filename>postgresql.auto.conf</filename> enregistrera les paramètres
        de connexion et, si indiqué, le slot de réplication utilisé par
        <application>pg_basebackup</application>, pour que la réplication en
-       flux utilise la même configuration.
+       streaming utilise plus tard la même configuration.
       </para>
      </listitem>
     </varlistentry>
@@ -260,7 +260,7 @@
      <term><option>--tablespace-mapping=<replaceable class="parameter">ancien_repertoire</replaceable>=<replaceable class="parameter">nouveau_repertoire</replaceable></option></term>
      <listitem>
       <para>
-       Transfère le tablespace du répertoire
+       Déplace le tablespace du répertoire
        <replaceable>ancien_repertoire</replaceable> vers le répertoire
        <replaceable>nouveau_repertoire</replaceable> pendant la sauvegarde.
        Pour bien fonctionner, <replaceable>ancien_repertoire</replaceable>
@@ -268,18 +268,19 @@
        est actuellement défini. (Mais il n'y a pas d'erreur s'il n'y a aucun
        tablespace dans <replaceable>ancien_repertoire</replaceable> contenu
        dans la sauvegarde.) <replaceable>ancien_repertoire</replaceable> et
-       <replaceable>nouveau_repertoire</replaceable> doivent être des chemins
-       absolus. Si un chemin survient pour contenir un signe
-       <literal>=</literal>, échappez-le avec un anti-slash. Cette option peut
+       <replaceable>nouveau_repertoire</replaceable> doivent tous deux
+       être des chemins absolus. S'il se trouve qu'un chemin contient un signe
+       <literal>=</literal>, échappez-le avec un anti-slash (\). Cette option peut
        être spécifiée plusieurs fois pour différents tablespaces. Voir les
-       exemples ci-dessus.
+       exemples ci-dessous.
       </para>
 
       <para>
-       Si un tablespace est transféré de cette façon, les liens symboliques à
+       Si un tablespace est déplacé de cette façon, les liens symboliques à
        l'intérieur du répertoire de données principal sont mis à jour pour
        pointer vers le nouvel emplacement. Du coup, le nouveau répertoire de
-       données est prêt à être utilisé sur la nouvelle instance.
+       données est prêt à être utilisé sur la nouvelle instance
+       avec les nouveaux chemins.
       </para>
      </listitem>
     </varlistentry>
@@ -289,9 +290,8 @@
      <listitem>
       <para>
        Indique l'emplacement du répertoire des journaux de transactions.
-       <replaceable>rep_wal</replaceable> doit être un chemin absolu. Le
-       répertoire des journaux de transactions peut seulement être spécifié
-       quand la sauvegarde est en mode plain.
+       <replaceable>rep_wal</replaceable> doit être un chemin absolu.
+       Ce ne peut être spécifié que si la sauvegarde est en mode plain.
       </para>
      </listitem>
     </varlistentry>
@@ -304,7 +304,7 @@
        Inclut les journaux de transactions requis (fichiers WAL) dans la
        sauvegarde. Cela inclura toutes les transactions intervenues pendant la
        sauvegarde. À moins que la méthode <literal>none</literal> ne soit
-       spécifiée, il est possible de lancer un postmaster directement sur le
+       spécifiée, il est possible de démarrer un postmaster directement sur le
        répertoire extrait sans avoir besoin de consulter les archives des
        journaux, ce qui rend la sauvegarde complètement autonome.
       </para>
@@ -319,7 +319,7 @@
          <term><literal>none</literal></term>
          <listitem>
           <para>
-           N'inclue pas les journaux de transactions dans la sauvegarde.
+           N'inclut pas les journaux de transactions dans la sauvegarde.
           </para>
          </listitem>
         </varlistentry>
@@ -330,17 +330,17 @@
          <listitem>
           <para>
            Les journaux de transactions sont récupérés à la fin de la
-           sauvegarde. Cela étant, il est nécessaire de définir le paramètre
-           <xref linkend="guc-wal-keep-segments"/> à une valeur suffisamment
-           élevée pour que le journal ne soit pas supprimé avant la fin de la
-           sauvegarde. Si le journal est l'objet d'une rotation au moment où
-           il doit être transféré, la sauvegarde échouera et sera
+           sauvegarde. Il est donc nécessaire de définir le paramètre
+           <xref linkend="guc-wal-keep-segments"/> suffisamment
+           haut pour qu'ils ne soient pas supprimés avant la fin de la
+           sauvegarde. Si un journal est recyclé alors
+           qu'il doit être transféré, la sauvegarde échouera et sera
            inutilisable.
           </para>
 
           <para>
-           Quand le format tar est utilisé, les journaux de transactions
-           seront écrit dans le fichier <filename>base.tar</filename>.
+           Si le format tar est utilisé, les journaux de transactions
+           seront écrits dans le fichier <filename>base.tar</filename>.
           </para>
          </listitem>
         </varlistentry>
@@ -350,19 +350,19 @@
          <term><literal>stream</literal></term>
          <listitem>
           <para>
-           Envoie le journal de transactions tandis que la sauvegarde se
+           Envoie le journal de transactions pendant que la sauvegarde se
            réalise. Cette option ouvre une seconde connexion sur le serveur et
-           commence l'envoi du journal de transactions en parallèle tout en
-           effectuant la sauvegarde. À cet effet, ce mécanisme s'appuie sur
+           entame l'envoi du journal de transactions en parallèle
+           de la sauvegarde. À cet effet, ce mécanisme consommera
            deux connexions configurées par le paramètre <xref
            linkend="guc-max-wal-senders"/>. Ce mode permet de ne pas avoir à
            sauvegarder des journaux de transactions additionnels sur le
            serveur maître, aussi longtemps que le client pourra suivre le flux
-           du journal de transactions.
+           des journaux de transactions.
           </para>
 
           <para>
-           Quand le format tar est utilisé, les journaux de transactions
+           Si le format tar est utilisé, les journaux de transactions
            seront écrits dans un fichier séparé nommé
            <filename>pg_wal.tar</filename> (si le serveur est d'une version
            antérieure à la version 10, le fichier sera nommé
@@ -385,8 +385,8 @@
      <listitem>
       <para>
        Active la compression gzip de l'archive tar en sortie, avec le niveau
-       de compression par défaut. La compression est disponible seulement lors
-       de l'utilisation du format tar, et le suffixe <filename>.gz</filename>
+       de compression par défaut. La compression n'est disponible
+       qu'avec le format tar, et le suffixe <filename>.gz</filename>
        sera automatiquement ajouté à tous les noms de fichier tar.
       </para>
      </listitem>
@@ -398,9 +398,9 @@
      <listitem>
       <para>
        Active la compression gzip du fichier tar en sortie, et précise le
-       niveau de compression (de 0 à 9, 0 pour sans compression, 9
-       correspondant à la meilleure compression). La compression est seulement
-       disponible lors de l'utilisation du format tar, et le suffixe
+       niveau de compression (de 0 à 9, 0 étant sans compression,
+       et 9 la meilleure). La compression n'est
+       disponible qu'avec le format tar, et le suffixe
        <filename>.gz</filename> sera automatiquement ajouté à tous les noms de
        fichier tar.
       </para>
@@ -410,7 +410,7 @@
   </para>
 
   <para>
-   Les options suivantes en ligne de commande contrôlent la génération de la
+   Les options de ligne de commande suivantes contrôlent la génération de la
    sauvegarde et l'exécution du programme.
 
    <variablelist>
@@ -419,7 +419,7 @@
      <term><option>--checkpoint=<replaceable class="parameter">fast|spread</replaceable></option></term>
      <listitem>
       <para>
-       Configure le mode du checkpoint à immédiat (fast) ou en attente
+       Configure le mode du checkpoint à immédiat (fast) ou étalé
        (spread, la valeur par défaut). Voir <xref
        linkend="backup-lowlevel-base-backup"/>.
       </para>
@@ -431,9 +431,9 @@
      <term><option>--create-slot</option></term>
      <listitem>
       <para>
-       Cette option cause la création d'un slot de réplication nommé par
-       l'option <literal>--slot</literal> avant le début de la sauvegarde.
-       Dans ce cas, une erreur est levée si le slot existe déjà.
+       Cette option entraîne la création d'un slot de réplication, nommé par
+       l'option <literal>--slot</literal>, avant le début de la sauvegarde.
+       Une erreur est levée si le slot existe déjà.
       </para>
      </listitem>
     </varlistentry>
@@ -443,8 +443,8 @@
      <term><option>--label=<replaceable class="parameter">label</replaceable></option></term>
      <listitem>
       <para>
-       Configure le label de la sauvegarde. Sans indication, une valeur par
-       défaut, <quote><literal>pg_basebackup base backup</literal></quote>
+       Définit un nom pour la sauvegarde. Sans indication, la valeur par
+       défaut, <quote><literal>pg_basebackup base backup</literal></quote>,
        sera utilisée.
       </para>
      </listitem>
@@ -455,15 +455,15 @@
       <term><option>--no-clean</option></term>
       <listitem>
        <para>
-        Par défaut, quand <command>pg_basebackup</command> échoue en erreur,
-        il supprime tout répertoire qu'il aurait pu créer avant de découvrir
+        Par défaut, quand <command>pg_basebackup</command> échoue avec une erreur,
+        il supprime tous les répertoires qu'il aurait pu créer avant de découvrir
         qu'il ne peut pas terminer le travail (par exemple, le répertoire de
         données et le répertoire des journaux de transactions).  Cette option
-        empêche le nettoyage et est donc pratique pour le débogage.
+        désactive le nettoyage, et est donc pratique pour le débogage.
        </para>
 
        <para>
-        Remarquez que les répertoires des tablespaces ne sont pas supprimés
+        Notez que les répertoires des tablespaces ne sont pas supprimés
         non plus.
        </para>
       </listitem>
@@ -477,11 +477,11 @@
        <para>
         Par défaut, <command>pg_basebackup</command> attendra que tous les
         fichiers soient écrits de manière sûre sur disque. Cette option
-        demande à <command>pg_basebackup</command> de renvoyer la main sans
+        demande à <command>pg_basebackup</command> de rendre la main sans
         attendre, ce qui est plus rapide, mais signifie qu'un arrêt brutal du
-        serveur survenant après la sauvegarde peut laisser la sauvegarde des
-        bases dans un état corrompu. De manière générale, cette option est
-        utile durant les tests mais ne devrait pas être utilisée dans un
+        serveur après la sauvegarde peut laisser la sauvegarde de
+        base dans un état corrompu. De manière générale, cette option est
+        utile durant les tests, mais ne devrait pas être utilisée dans un
         environnement de production.
        </para>
       </listitem>
@@ -494,13 +494,13 @@
       <para>
        Active l'indicateur de progression. Activer cette option donnera un
        rapport de progression approximatif lors de la sauvegarde. Comme la
-       base de données peut changer pendant la sauvegarde, ceci est seulement
-       une approximation et pourrait ne pas se terminer à exactement
+       base de données peut changer pendant la sauvegarde, ce n'est
+       qu'une approximation, et peut ne pas se terminer à exactement
        <literal>100%</literal>. En particulier, lorsque les journaux de
        transactions sont inclus dans la sauvegarde, la quantité totale de
        données ne peut pas être estimée à l'avance et, dans ce cas, la taille
-       cible estimée va augmenter quand il dépasse l'estimation totale sans
-       les journaux de transactions.
+       cible estimée va augmenter une fois dépassée l'estimation totale sans
+       les journaux.
       </para>
      </listitem>
     </varlistentry>
@@ -510,27 +510,28 @@
      <term><option>--slot=<replaceable class="parameter">nom_slot</replaceable></option></term>
      <listitem>
       <para>
-       Cette option peut seulement être utilisée avec l'option <literal>-X
-       stream</literal>. Elle fait en sorte que l'envoi des journaux dans le
-       flux de réplication utilise le slot de réplication indiqué. Si la
-       sauvegarde de base doit être utilisée pour un serveur standby avec un
-       slot de réplication, elle devrait alors utiliser le même nom pour le
-       slot de réplication dans le paramètre <xref
-       linkend="guc-primary-slot-name"/>. Ainsi, il est certain que le serveur
+       Cette option ne peut être utilisée qu'avec l'option <literal>-X
+       stream</literal>.
+       Elle entraîne l'utilisation du slot de réplication indiqué
+       par le flux de réplication des journaux. Si la
+       sauvegarde de base doit être utilisée pour un serveur secondaire
+       avec un slot, elle devrait alors utiliser le même nom de slot
+       dans <xref linkend="guc-primary-slot-name"/>.
+       Ainsi, on s'assure que le serveur
        ne supprimera pas les journaux nécessaires entre la fin de la
-       sauvegarde et le début du lancement de la réplication en flux.
+       sauvegarde et le début du lancement de la réplication par streaming.
       </para>
 
       <para>
-       Le slot de réplication spécifié doit exister sauf si l'option
+       Le slot de réplication spécifié doit exister, sauf si l'option
        <option>-C</option> est aussi utilisée.
       </para>
 
       <para>
-       Si cette option n'est pas spécifiée et que le serveur supporte les
-       slots de réplication temporaires (version 10 et supérieures), alors un
+       Si cette option n'est pas spécifiée, et que le serveur supporte les
+       slots de réplication temporaires (versions 10 et supérieures), alors un
        slot de réplication temporaire sera automatiquement utilisé pour le
-       transfert des WAL par flux.
+       transfert des WAL par streaming.
       </para>
      </listitem>
     </varlistentry>
@@ -540,10 +541,10 @@
      <term><option>--verbose</option></term>
      <listitem>
       <para>
-       Active le mode verbeux, qui affichera les étapes supplémentaires
-       pendant le démarrage et l'arrêt ainsi que le nom de fichier
-       exact qui est en cours de traitement si le rapport de
-       progression est aussi activé.
+       Active le mode verbeux. Il affichera des étapes supplémentaires
+       pendant le démarrage et l'arrêt, ainsi que, si le rapport de
+       progression est aussi activé, le nom exact du fichier
+       en cours de traitement.
       </para>
      </listitem>
     </varlistentry>
@@ -552,36 +553,41 @@
      <term><option>--manifest-checksums=<replaceable class="parameter">algorithm</replaceable></option></term>
      <listitem>
       <para>
-       Specifies the checksum algorithm that should be applied to each file
-       included in the backup manifest. Currently, the available
-       algorithms are <literal>NONE</literal>, <literal>CRC32C</literal>,
+       Spécifie l'algorithme à utiliser dans le manifeste de la sauvegarde
+       pour les sommes de contrôle appliquées à chaque fichier.
+       Les algorithmes disponibles sont actuellement
+       <literal>NONE</literal>, <literal>CRC32C</literal>,
        <literal>SHA224</literal>, <literal>SHA256</literal>,
-       <literal>SHA384</literal>, and <literal>SHA512</literal>.
-       The default is <literal>CRC32C</literal>.
+       <literal>SHA384</literal> et <literal>SHA512</literal>.
+       Le défaut est <literal>CRC32C</literal>.
       </para>
       <para>
-       If <literal>NONE</literal> is selected, the backup manifest will
-       not contain any checksums. Otherwise, it will contain a checksum
-       of each file in the backup using the specified algorithm. In addition,
-       the manifest will always contain a <literal>SHA256</literal>
-       checksum of its own contents. The <literal>SHA</literal> algorithms
-       are significantly more CPU-intensive than <literal>CRC32C</literal>,
-       so selecting one of them may increase the time required to complete
-       the backup.
+       Si <literal>NONE</literal> est choisi, le manifeste ne contiendra
+       aucune somme de contrôle. Sinon, il y en aura une pour chaque
+       fichier de la sauvegarde, avec l'algorithme indiqué.
+       De plus, le manifeste contiendra toujours une somme de contrôle
+       <literal>SHA256</literal> de son propre contenu.
+       Les algorithmes <literal>SHA</literal> sont significativement plus
+       consommateurs de CPU que <literal>CRC32C</literal>&nbsp;;
+       choisir l'un d'eux peut donc augmenter la durée nécessaire à la
+       sauvegarde.
       </para>
       <para>
-       Using a SHA hash function provides a cryptographically secure digest
-       of each file for users who wish to verify that the backup has not been
-       tampered with, while the CRC32C algorithm provides a checksum which is
-       much faster to calculate and good at catching errors due to accidental
-       changes but is not resistant to targeted modifications.  Note that, to
-       be useful against an adversary who has access to the backup, the backup
-       manifest would need to be stored securely elsewhere or otherwise
-       verified not to have been modified since the backup was taken.
+       Une fonction de hachage SHA fournit un résumé
+       cryptographiquement sûr de chaque fichier, pour les utilisateurs voulant
+       vérifier que la sauvegarde n'a pas été modifiée&nbsp;;
+       alors que l'algorithme CRC32C fournit une somme de contrôle
+       bien plus rapide à calculer, bonne pour déceler des erreurs dues
+       à des changements accidentels, mais vulnérable à des modifications
+       ciblées.
+       Notez que, pour qu'il serve face à un adversaire avec un accès à la
+       sauvegarde, il faut stocker de manière sécurisée, ailleurs, le fichier
+       manifeste, ou vérifier d'une manière ou d'une autre qu'il n'a pas été
+       modifié depuis le moment de la sauvegarde.
       </para>
       <para>
-       <xref linkend="app-pgverifybackup" /> can be used to check the
-       integrity of a backup against the backup manifest.
+       <xref linkend="app-pgverifybackup" /> peut être utilisé pour vérifier
+       l'intégrité d'une sauvegarde grâce à son manifeste.
       </para>
      </listitem>
     </varlistentry>
@@ -590,12 +596,51 @@
      <term><option>--manifest-force-encode</option></term>
      <listitem>
       <para>
-       Forces all filenames in the backup manifest to be hex-encoded.
-       If this option is not specified, only non-UTF8 filenames are
-       hex-encoded. This option is mostly intended to test that tools which
-       read a backup manifest file properly handle this case.
+       Dans le manifeste de la sauvegarde, force l'encodage hexadécimal de
+       tous les noms de fichiers. Sans cette option, seuls les noms de
+       fichiers non-UTF8 sont ainsi encodés. Cette option est surtout
+       destinée à tester que les outils qui lisent un manifeste de
+       sauvegarde traitent correctement ce cas.
       </para>
      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <term><option>--no-estimate-size</option></term>
+      <listitem>
+       <para>
+        Cette option interdit au serveur d'estimer la taille totale
+        de la sauvegarde qui sera renvoyée, et entraînera une valeur
+        <literal>NULL</literal> pour la colonne
+        <literal>backup_total</literal> de
+        <structname>pg_stat_progress_basebackup</structname>.
+       </para>
+       <para>
+        Sans cette option, la sauvegarde commencera par calculer la
+        taille de toute l'instance, puis procédera à l'envoi du contenu.
+        Cela peut allonger légèrement la sauvegarde, en particulier
+        avant l'envoi des premières données. Si cela est trop long,
+        cette option permet de l'éviter.
+       </para>
+       <para>
+        Cette option n'est pas autorisée si l'on utilise <option>--progress</option>.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
+      <term><option>--no-manifest</option></term>
+      <listitem>
+       <para>
+        Désactive la génération du fichier manifeste de la sauvegarde.
+        Sans cette option, le serveur générera et enverra un manifeste,
+        contrôlable avec <xref linkend="app-pgverifybackup" />.
+        Ce manifeste est une liste de tous les fichiers présent dans la
+        sauvegarde, à l'exception d'éventuels fichiers WAL.
+        Pour chaque fichier, il stocke aussi la taille, le moment de
+        la dernière modification et, optionnellement, une somme de contrôle.
+       </para>
+      </listitem>
     </varlistentry>
 
     <varlistentry>
@@ -603,21 +648,19 @@
      <listitem>
       <para>
        Cette option empêche la création d'un slot de réplication temporaire
-       pendant la sauvegarde même si cela est supporté par le serveur.
+       pendant la sauvegarde, même si cela est supporté par le serveur.
       </para>
-
       <para>
        Les slots de réplication temporaires sont crées par défaut si aucun nom
-       de slot n'est précisé avec l'option <option>-S</option> quand l'envoi
-       des journaux de transactions par flux est utilisé.
+       de slot n'est précisé avec l'option <option>-S</option> lors de l'envoi
+       des journaux de transactions par streaming.
       </para>
-
       <para>
-       Le but principal de cette option est d'autoriser la réalisation d'une
-       sauvegarde des bases quand le serveur ne dispose plus de slot de
-       réplication libre.  Utiliser les slots de réplication est presque
+       Le but principal de cette option est de permettre de prendre une
+       sauvegarde de base même si le serveur est à cours de slots de
+       réplication. Utiliser les slots est presque
        toujours la meilleure solution, car cela empêche le serveur de
-       supprimer pendant la sauvegarde les WAL nécessaires.
+       supprimer les WAL nécessaires pendant la sauvegarde.
       </para>
      </listitem>
     </varlistentry>
@@ -632,50 +675,12 @@
        </para>
 
        <para>
-        Par défaut, les sommes de contrôles sont vérifiées et les erreurs
+        Par défaut, les sommes de contrôles sont vérifiées, et les erreurs
         produiront un code de sortie différent de zéro. Cependant, la
-        sauvegarde ne sera pas supprimée même dans ce cas, comme si l'option
-        <option>--no-clean</option> avait été utilisée. Checksum verifications
-        failures will also be reported in the <xref
-        linkend="pg-stat-database-view"/> view.
-       </para>
-      </listitem>
-     </varlistentry>
-
-     <varlistentry>
-      <term><option>--no-estimate-size</option></term>
-      <listitem>
-       <para>
-        This option prevents the server from estimating the total
-        amount of backup data that will be streamed, resulting in the
-        <literal>backup_total</literal> column in the
-        <structname>pg_stat_progress_basebackup</structname>
-        to be <literal>NULL</literal>.
-       </para>
-       <para>
-        Without this option, the backup will start by enumerating
-        the size of the entire database, and then go back and send
-        the actual contents. This may make the backup take slightly
-        longer, and in particular it will take longer before the first
-        data is sent. This option is useful to avoid such estimation
-        time if it's too long.
-       </para>
-       <para>
-        This option is not allowed when using <option>--progress</option>.
-       </para>
-      </listitem>
-     </varlistentry>
-
-     <varlistentry>
-      <term><option>--no-manifest</option></term>
-      <listitem>
-       <para>
-        Disables generation of a backup manifest. If this option is not
-        specified, the server will generate and send a backup manifest
-        which can be verified using <xref linkend="app-pgverifybackup" />.
-        The manifest is a list of every file present in the backup with the
-        exception of any WAL files that may be included. It also stores the
-        size, last modification time, and an optional checksum for each file.
+        sauvegarde ne sera pas supprimée, comme si l'option
+        <option>--no-clean</option> avait été utilisée. Les échecs de
+        vérification des sommes de contrôle seront aussi rapportés dans
+        la vue <xref linkend="pg-stat-database-view"/>.
        </para>
       </listitem>
      </varlistentry>
@@ -684,7 +689,7 @@
   </para>
 
   <para>
-   Les options suivantes en ligne de commande contrôlent les paramètres de
+   Les options de ligne de commande suivantes contrôlent les paramètres de
    connexion à la base de données.
 
    <variablelist>
@@ -700,7 +705,7 @@
 
       <para>
        Cette option est appelée <literal>--dbname</literal> par cohérence avec
-       les autres applications clientes mais comme
+       les autres applications clientes, mais comme
        <application>pg_basebackup</application> ne se connecte à aucune base
        de données particulière dans l'instance, le nom de la base de données
        dans la chaîne de connexion est ignorée.
@@ -715,9 +720,9 @@
       <para>
        Indique le nom d'hôte de la machine sur laquelle le serveur de bases de
        données est exécuté. Si la valeur commence par une barre oblique (/),
-       elle est utilisée comme répertoire pour le socket de domaine Unix. La
+       elle est interprétée comme le répertoire de socket de domaine Unix. La
        valeur par défaut est fournie par la variable d'environnement
-       <envar>PGHOST</envar>, si elle est initialisée. Dans le cas contraire,
+       <envar>PGHOST</envar>, si elle est en place&nbsp;; sinon
        une connexion sur la socket de domaine Unix est tentée.
       </para>
      </listitem>
@@ -731,7 +736,7 @@
        Indique le port TCP ou l'extension du fichier local de socket de
        domaine Unix sur lequel le serveur écoute les connexions. La valeur par
        défaut est fournie par la variable d'environnement
-       <envar>PGPORT</envar>, si elle est initialisée. Dans le cas contraire,
+       <envar>PGPORT</envar>, si elle est en place&nbsp;; sinon
        il s'agit de la valeur fournie à la compilation.
       </para>
      </listitem>
@@ -742,11 +747,11 @@
      <term><option>--status-interval=<replaceable class="parameter">interval</replaceable></option></term>
      <listitem>
       <para>
-       Spécifie le rythme en secondes de l'envoi des paquets au serveur
+       Spécifie le nombre de secondes entre les envois au serveur des paquets
        informant de l'état en cours. Ceci permet une supervision plus facile
-       du progrès à partir du serveur. Une valeur de zéro désactive
-       complètement les mises à jour périodiques de statut, bien qu'une mise à
-       jour sera toujours envoyée lorsqu'elle est demandée par le serveur,
+       du progrès sur le serveur. Une valeur de zéro désactive
+       complètement les mises à jour de statut périodiques, bien qu'une mise à
+       jour sera toujours envoyée sur demande du serveur,
        pour éviter une déconnexion suite au dépassement d'un délai. La valeur
        par défaut est de 10 secondes.
       </para>
@@ -758,7 +763,7 @@
      <term><option>--username=<replaceable class="parameter">nom_utilisateur</replaceable></option></term>
      <listitem>
       <para>
-       Le nom d'utilisateur utilisé pour la connexion.
+       Nom d'utilisateur utilisé pour la connexion.
       </para>
      </listitem>
     </varlistentry>
@@ -768,12 +773,12 @@
      <term><option>--no-password</option></term>
      <listitem>
       <para>
-       Ne demande jamais un mot de passe. Si le serveur en réclame un pour
-       l'authentification et qu'un mot de passe n'est pas disponible d'une
+       Ne demande jamais de mot de passe. Si le serveur en réclame un pour
+       l'authentification, et qu'un mot de passe n'est pas disponible d'une
        autre façon (par exemple avec le fichier <filename>.pgpass</filename>),
-       la tentative de connexion échouera. Cette option peut être utile pour
-       les scripts où aucun utilisateur n'est présent pour saisir un mot de
-       passe.
+       la tentative de connexion échouera. Cette option peut être utile dans
+       les batchs et les scripts où aucun utilisateur n'est présent pour saisir
+       un mot de passe.
       </para>
      </listitem>
     </varlistentry>
@@ -788,11 +793,11 @@
       </para>
 
       <para>
-       Cette option n'est jamais nécessaire car
-       <application>pg_basebackup</application> demande automatiquement un mot
-       de passe si le serveur exige une authentification par mot de passe.
-       Néanmoins, <application>pg_basebackup</application> perd une tentative
-       de connexion pour tester si le serveur demande un mot de passe. Dans
+       Cette option n'est jamais nécessaire, car
+       <application>pg_basebackup</application> demandera automatiquement un mot
+       de passe si le serveur exige une telle authentification.
+       Néanmoins, <application>pg_basebackup</application> gaspillera une tentative
+       de connexion pour découvrir que le serveur veut ce mot de passe. Dans
        certains cas, il est préférable d'ajouter l'option <option>-W</option>
        pour éviter la tentative de connexion.
       </para>
@@ -810,8 +815,8 @@
      <term><option>--version</option></term>
      <listitem>
       <para>
-       Affiche la version de <application>pg_basebackup</application> puis
-       quitte.
+       Affiche la version de <application>pg_basebackup</application>,
+       puis quitte.
       </para>
      </listitem>
     </varlistentry>
@@ -822,7 +827,7 @@
      <listitem>
       <para>
        Affiche l'aide sur les arguments en ligne de commande de
-       <application>pg_basebackup</application>, puis quitte
+       <application>pg_basebackup</application>, puis quitte.
       </para>
      </listitem>
     </varlistentry>
@@ -855,58 +860,59 @@
 
   <para>
    Au début d'une sauvegarde, un checkpoint doit être écrit sur le serveur où
-   est réalisé la sauvegarde. Tout spécialement si l'option
-   <literal>--checkpoint=fast</literal> n'est pas utilisée, ceci peut prendre
-   du temps pendant lequel <application>pg_basebackup</application> semblera
-   inoccupé.
+   est réalisée la sauvegarde. Ceci peut prendre un certain temps,
+   tout spécialement sans l'option <literal>--checkpoint=fast</literal>.
+   Pendant ce temps,
+   <application>pg_basebackup</application> semblera inactif.
   </para>
 
   <para>
    La sauvegarde inclura tous les fichiers du répertoire de données et des
-   tablespaces, ceci incluant les fichiers de configuration et tout fichier
-   supplémentaire placé dans le répertoire par d'autres personnes, à
-   l'exception de certains fichiers temporaires générés par PostgreSQL. Seuls
-   les fichiers réguliers et les répertoires sont copiés, à l'exception des
-   liens symboliques utilisés pour les tablespaces qui sont préservés.  Les
+   tablespaces, dont les fichiers de configuration, et aussi tout autre fichier
+   placé dans le répertoire par d'autres personnes, à
+   l'exception de certains fichiers temporaires gérés par PostgreSQL. Seuls
+   les fichiers normaux et les répertoires sont cependant copiés.
+   les liens symboliques utilisés pour les tablespaces sont aussi préservés. Les
    liens symboliques pointant vers certains répertoires connus de PostgreSQL
-   sont copiés comme de nouveaux répertoires. Les autres liens symboliques et
+   sont copiés en tant que répertoires vides. Les autres liens symboliques et
    les fichiers de périphérique spéciaux sont ignorés. Voir <xref
    linkend="protocol-replication"/> pour des détails précis.
   </para>
 
   <para>
-   Les tablespaces seront en format plain par défaut et seront sauvegardés
+   Les tablespaces seront sauvegardés par défaut en format plain,
    avec le même chemin que sur le serveur, sauf si l'option
-   <literal>--tablespace-mapping</literal> est utilisée. Sans cette option,
-   lancer une sauvegarde de format plain sur le même serveur ne fonctionnera
-   pas si les tablespaces sont utilisés car la sauvegarde devra écrire dans
+   <literal>--tablespace-mapping</literal> est utilisée. Sans elle,
+   restaurer et lancer une sauvegarde de format plain sur le même serveur
+   ne fonctionnera pas si les tablespaces sont utilisés,
+   car la sauvegarde devra écrire dans
    les mêmes répertoires que ceux des tablespaces originaux.
   </para>
 
   <para>
-   Quand le format tar est utilisé, c'est de la responsabilité de
-   l'utilisateur de déballer chaque archive tar avant de démarrer le serveur
+   Quand le format tar est utilisé, il est de la responsabilité de
+   l'utilisateur de décompresser chaque archive tar avant de démarrer le serveur
    PostgreSQL. S'il existe des tablespaces supplémentaires, les archives tar
-   les concernant doivent être déballés au même emplacement. Dans ce cas, les
-   liens symboliques pour ces tablespaces seront créés par le serveur suivant
-   le contenu du fichier <filename>tablespace_map</filename> qui est inclus
+   les concernant doivent être décompressés au même emplacement. Dans ce cas, les
+   liens symboliques pour ces tablespaces seront créés par le serveur, suivant
+   le contenu du fichier <filename>tablespace_map</filename> inclus
    dans le fichier <filename>base.tar</filename>.
   </para>
 
   <para>
    <application>pg_basebackup</application> fonctionne sur les serveurs de
-   même version ou de versions plus anciennes (donc de version supérieure ou
-   égale à la 9.1). Néanmoins, le mode de flux de journaux (option
-   <literal>-X</literal>) fonctionne seulement avec les serveurs en version
-   9.3 et ultérieures, et le format tar (<literal>--format=tar</literal>) de
-   la version actuelle fonctionne seulement avec les serveurs en version 9.5
-   et ultérieures.
+   même version, ou de version plus ancienne jusque 9.1.
+   Néanmoins, le streaming des WAL (option
+   <literal>-X</literal>) ne fonctionne qu'avec un serveur en version
+   9.3 ou ultérieure, et le format tar (<literal>--format=tar</literal>) de
+   la version actuelle ne fonctionne qu'avec les serveurs de version 9.5
+   ou ultérieure.
   </para>
 
   <para>
-   <application>pg_basebackup</application> conservera les droits du groupe
-   avec les formats <literal>plain</literal> et <literal>tar</literal> si les
-   droits du groupe sont activés sur l'instance source.
+   <application>pg_basebackup</application> conservera les droits de groupe
+   avec les formats <literal>plain</literal> et <literal>tar</literal> si ces
+   droits sont activés sur l'instance source.
   </para>
 
  </refsect1>
@@ -935,16 +941,15 @@
 
   <para>
    Pour créer une sauvegarde d'une base de données locale avec un seul
-   tablespace et la compresser avec <productname>bzip2</productname>&nbsp;:
+   tablespace, et la compresser avec <productname>bzip2</productname>&nbsp;:
    <screen>
 <prompt>$</prompt> <userinput>pg_basebackup -D - -Ft -X fetch | bzip2 &gt; backup.tar.bz2</userinput>
    </screen>
-   (cette commande échouera s'il existe plusieurs tablespaces pour cette
-   instance)
+   (Cette commande échouera s'il existe plusieurs tablespaces dans l'instance.)
   </para>
 
   <para>
-   Pour créer une sauvegarde d'une base locale où le tablespace situé dans
+   Pour créer une sauvegarde d'une base locale, où le tablespace situé dans
    <filename>/opt/ts</filename> doit être déplacé vers
    <filename>./backup/ts</filename>&nbsp;:
    <screen>


### PR DESCRIPTION
Traduction vs 13 bêta 2
  * NB : 2 nouveaux paragraphes étaient collés au mauvais endroit.

Relecture complète
  * nombreuses tentatives d'allègement de formulation
  * 2 ou 3 erreurs
  * remplacé systématiquement flux par streaming, standby par secondaire