### PR TITLE
Ambiguite foreign data foreign key

### DIFF
--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -651,7 +651,7 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
    <para>
     <productname>PostgreSQL</productname> considère les collations comme des
     objets distincts et incompatibles entre eux, même si elles possèdent des
-    propriétés identiques. Ainsi, par exemle,
+    propriétés identiques. Ainsi, par exemple,
     <programlisting>
 SELECT a COLLATE "C" &lt; b COLLATE "POSIX" FROM test1;
     </programlisting>
@@ -839,7 +839,7 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
       <listitem>
        <para>
         Trie les lettres majuscules avant les lettres minuscules. (La valeur
-        par défaut est les mniscules avant).
+        par défaut est les minuscules avant).
 	   </para>
       </listitem>
      </varlistentry>

--- a/postgresql/ddl.xml
+++ b/postgresql/ddl.xml
@@ -5057,9 +5057,11 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
  <productname>PostgreSQL</productname> implémente des portions de la norme
  SQL/MED, vous permettant d'accéder à des données qui résident en dehors
  de PostgreSQL en utilisant des requêtes SQL standards. On utilise le terme
- de <firstterm>données distantes</firstterm> pour de telles données. (Notez
- que cet usage ne doit pas être confondu avec les clés étrangères qui sont
- un type de contrainte à l'intérieur d'une base de données.)
+ de <firstterm>données distantes</firstterm> pour de telles données.
+ (Notez qu'en anglais il y a ambiguïté&nbsp;: les données
+ distantes (<foreignphrase>foreign data</foreignphrase>) n'ont rien à voir
+ avec les clés étrangères (<foreignphrase>foreign keys</foreignphrase>),
+ qui sont un type de contrainte à l'intérieur de la base de données.)
 </para>
 
 <para>


### PR DESCRIPTION
L'avertissement porte sur foreign keys et foreign data, mais depuis que l'on
parle en français de tables étrangères, ça n'a plus de sens.
La reformation précise donc "en anglais" et s'écarte de la VO.

Plus 2 typos  dans charset.xml