### PR TITLE
datatype.xml: corrige paragraphe en doublon

### DIFF
--- a/postgresql/datatype.xml
+++ b/postgresql/datatype.xml
@@ -4334,12 +4334,6 @@ a0ee-bc99-9c0b-4ef8-bb6d-6bb9-bd38-0a11
       linkend="xml-limits-conformance"/>.
      </para>
 
-     <para>
-      Les limites et notes de compatibilité pour le type de données
-      <type>xml</type> sont disponibles dans <xref
-      linkend="xml-limits-conformance"/>.
-     </para>
-
      <sect2>
       <title>Créer des valeurs XML</title>
       <para>


### PR DESCRIPTION
Correction d'un texte en doublon dans https://docs.postgresql.fr/13/datatype-xml.html  (juste avant le 8.13.1)