### PR TITLE
corrections au chapitre "Protocole client/serveur"

### DIFF
--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -8,7 +8,7 @@
  </indexterm>
 
  <para>
-  <productname>postgresql</productname> utilise un protocole messages pour la
+  <productname>PostgreSQL</productname> utilise un protocole messages pour la
   communication entre les clients et les serveurs (<quote>frontend</quote> et
   <quote>backend</quote>). Le protocole est supporté par <acronym>TCP/IP</acronym>
   et par les sockets de domaine Unix. Le numéro de port 5432 a été enregistré
@@ -19,9 +19,9 @@
 
  <para>
   Ce document décrit la version 3.0 de ce protocole, telle qu'implantée dans
-  <productname>postgresql</productname> depuis la version 7.4. Pour obtenir la
+  <productname>PostgreSQL</productname> depuis la version 7.4. Pour obtenir la
   description des versions précédentes du protocole, il faudra se reporter aux
-  versions antérieures de la documentation de <productname>postgresql</productname>. Un
+  versions antérieures de la documentation de <productname>PostgreSQL</productname>. Un
   même serveur peut prendre en charge plusieurs versions du protocole. Lors de l'établissement
   de la communication, le client indique au serveur la version du protocole qu'il
   souhaite utiliser. Si la version majeure demandée par le client n'est pas
@@ -1437,12 +1437,12 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
    <title>Chiffrement <acronym>ssl</acronym> de session</title>
 
    <para>
-    Si <productname>postgresql</productname> a été construit avec le support de
+    Si <productname>PostgreSQL</productname> a été construit avec le support de
     <acronym>ssl</acronym>, les communications client/serveur peuvent être chiffrées
     en l'utilisant. Ce chiffrement assure la sécurité de la communication
     dans les environnements où des agresseurs pourraient capturer le trafic
     de la session. Pour plus d'informations sur le cryptage des sessions
-    <productname>postgresql</productname> avec <acronym>ssl</acronym>, voir
+    <productname>PostgreSQL</productname> avec <acronym>ssl</acronym>, voir
     <xref linkend="ssl-tcp"/>.
    </para>
 

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -19,9 +19,9 @@
 
  <para>
   Ce document décrit la version 3.0 de ce protocole, telle qu'implantée dans
-  <productname>postgresql</productname> depuis la version 7.4. pour obtenir la
+  <productname>postgresql</productname> depuis la version 7.4. Pour obtenir la
   description des versions précédentes du protocole, il faudra se reporter aux
-  versions antérieures de la documentation de <productname>postgresql</productname>. un
+  versions antérieures de la documentation de <productname>postgresql</productname>. Un
   même serveur peut prendre en charge plusieurs versions du protocole. Lors de l'établissement
   de la communication, le client indique au serveur la version du protocole qu'il
   souhaite utiliser. Si la version majeure demandée par le client n'est pas
@@ -140,9 +140,9 @@
     <firstterm>paramètres</firstterm>. Un portail représente une instruction prête à être
     exécutée ou déjà partiellement exécutée, dont toutes les valeurs de
     paramètres manquants sont données (pour les instructions
-    <command>select</command>, un portail est équivalent à un curseur ouvert. il est
+    <command>select</command>, un portail est équivalent à un curseur ouvert. Il est
     choisi d'utiliser un terme différent, car les curseurs ne gèrent pas les
-    instructions autres que <command>select</command>)
+    instructions autres que <command>select</command>).
    </para>
 
    <para>
@@ -178,7 +178,7 @@
     différents <firstterm>formats</firstterm>. Depuis <productname>PostgreSQL</productname> 7.4, les
     seuls formats supportés sont le <quote>texte</quote> et le <quote>binaire</quote> mais
     le protocole prévoit des extensions futures. Le format souhaité pour toute valeur
-    est spécifié par un <firstterm>code de format</firstterm>. les clients peuvent spécifier
+    est spécifié par un <firstterm>code de format</firstterm>. Les clients peuvent spécifier
     un code de format pour chaque valeur de paramètre transmise et pour chaque
     colonne du résultat d'une requête. Une donnée de type texte a comme code
     de format zéro (0) et une donnée de type binaire a comme code de format un (1).
@@ -212,7 +212,7 @@
   <para>
    Cette section décrit le flux des messages et la sémantique de chaque type
    de message (les détails concernant la représentation exacte de chaque message
-   apparaissent dans <xref linkend="protocol-message-formats"/>). il existe
+   apparaissent dans <xref linkend="protocol-message-formats"/>). Il existe
    différents sous-protocoles en fonction de l'état de la connexion&nbsp;: lancement,
    requête, appel de fonction, COPY et clôture. Il existe aussi des provisions
    spéciales pour les opérations asynchrones (incluant les
@@ -241,9 +241,9 @@
     d'authentification adapté (tel un mot de passe). Pour toutes les méthodes
     d'authentification, sauf GSSAPI, SSPI et SASL, il y a au maximum une requête et
     une réponse. Avec certaines méthodes, aucune réponse du client n'est
-    nécessaire&nbsp; aucune demande d'authentification n'est alors effectuée.
+    nécessaire, et aucune demande d'authentification n'est alors effectuée.
     Pour GSSAPI, SSPI et SASL, plusieurs échanges de paquets peuvent être
-    nécessaire pour terminer l'authentification.
+    nécessaires pour terminer l'authentification.
    </para>
 
    <para>
@@ -443,7 +443,7 @@
     Après la réception du message AuthenticationOk, le client attend d'autres
     messages du serveur. Au cours de cette phase, un processus serveur est lancé
     et le client est simplement en attente. Il est encore possible que la tentative de
-    lancement échoue (ErrorResponse) ou que le serveur décline le supporte de
+    lancement échoue (ErrorResponse) ou que le serveur décline le support de
     la version mineure du protocole demandée (NegotiateProtocolVersion) mais,
     dans la plupart des cas, le serveur enverra les messages ParameterStatus,
     BackendKeyData et enfin ReadyForQuery.
@@ -478,9 +478,9 @@
        <para>
         Ce message informe le client de la configuration actuelle (initiale)
         des paramètres du serveur, tels <varname>client_encoding</varname> ou
-        <varname>datestyle</varname>. le client peut ignorer ce message ou enregistrer
+        <varname>datestyle</varname>. Le client peut ignorer ce message ou enregistrer
         la configuration pour ses besoins futurs&nbsp;; voir
-        <xref linkend="protocol-async"/> pour plus de détails. le client ne
+        <xref linkend="protocol-async"/> pour plus de détails. Le client ne
         devrait pas répondre à ce message mais continuer à attendre un message
         ReadyForQuery.
        </para>
@@ -558,7 +558,7 @@
       <term>copyinresponse</term>
       <listitem>
        <para>
-        Le serveur est prêt à copier des données du client vers une table&nbsp;
+        Le serveur est prêt à copier des données du client vers une table&nbsp;;
         voir <xref linkend="protocol-copy"/>.
        </para>
       </listitem>
@@ -676,7 +676,7 @@
    <para>
     En mode de requêtage simple, les valeurs récupérées sont toujours au format
     texte, sauf si la commande est un <command>fetch</command> sur un curseur déclaré
-    avec l'option <literal>binary</literal>. dans ce cas, les valeurs récupérées sont
+    avec l'option <literal>binary</literal>. Dans ce cas, les valeurs récupérées sont
     au format binaire. Les codes de format donnés dans le message RowDescription
     indiquent le format utilisé.
    </para>
@@ -742,7 +742,7 @@
 
     <para>
      Lorsqu'un simple message de requête contient plus d'une instruction SQL
-     (séparés par des points-virgules), ces instructions sont exécutés comme une
+     (séparées par des points-virgules), ces instructions sont exécutées comme une
      seule transaction à moins que des commandes explicites de contrôle des
      transactions ne soient incluses pour forcer un comportement différent.
      Par exemple, si le message contient&nbsp;:
@@ -766,7 +766,7 @@ COMMIT;
 INSERT INTO mytable VALUES(2);
 SELECT 1/0;
 </programlisting>
-     Alors le premier <command>INSERT</command> est validée par la commande
+     Alors le premier <command>INSERT</command> est validé par la commande
      <command>COMMIT</command> explicite. Le second <command>INSERT</command>
      et le <command>SELECT</command> sont toujours traités comme une seule
      transaction, de sorte que l'échec de la division par zéro fera annuler
@@ -800,7 +800,7 @@ SELECT 1/0;
      de transaction normal qui ne sera terminé que par un <command>COMMIT</command>
      ou un <command>ROLLBACK</command> explicite&nbsp;; que celui-ci apparaisse dans
      ce message de requête ou dans un autre. Si le <command>BEGIN</command>
-     suit certaines instructions qui ont été exécutés comme un bloc de transaction
+     suit certaines instructions qui ont été exécutées comme un bloc de transaction
      implicite, ces instructions ne sont pas immédiatement validées&nbsp;; en fait,
      ils sont inclus rétroactivement dans le nouveau bloc de transaction normal.
     </para>
@@ -824,7 +824,7 @@ SELECT 1/0;
     <para>
      N'oubliez pas que, quelle que soit la commande de contrôle de transaction
      présente, l'exécution du message de requête s'arrête dès la première erreur.
-     Par exemple, si pour un message de requête unique l'on donne&nbsp;:
+     Par exemple, si pour un message de requête simple l'on donne&nbsp;:
 <programlisting>
 BEGIN;
 SELECT 1/0;
@@ -894,7 +894,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      à O, ou en créant un tableau d'OID de type plus court que le nombre de
      paramètres (<literal>$</literal><replaceable>n</replaceable>) utilisés
      dans la chaîne de requête.
-     Un autre cas spécial est d'utiliser <type>void</type> comme type de
+     Un autre cas particulier est d'utiliser <type>void</type> comme type de
      paramètre (c'est à dire l'OID du pseudo-type <type>void</type>). Cela
      permet d'utiliser des paramètres dans des fonctions en tant qu'argument
      OUT.
@@ -949,7 +949,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
    <note>
     <para>
      Le choix entre sortie texte et binaire est déterminé par les codes
-     de format donnés dans Bind, quel que soit la commande SQL impliquée.
+     de format donnés dans Bind, quelle que soit la commande SQL impliquée.
      L'attribut <literal>BINARY</literal> dans les déclarations du curseur n'est pas
      pertinent lors de l'utilisation du protocole de requête étendue.
     </para>
@@ -957,13 +957,13 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
    <para>
     La planification de la requête survient généralement quand le message
-    Bind est traité. Si la requête préparée n'a pas de paramètres ou
+    Bind est traité. Si la requête préparée n'a pas de paramètre ou
     si elle est exécutée de façon répétée, le serveur peut sauvegarder le
     plan créé et le ré-utiliser lors des appels suivants à Bind pour la
     même requête préparée. Néanmoins, il ne le fera que s'il estime qu'un
     plan générique peut être créé en étant pratiquement aussi efficace
     qu'un plan dépendant des valeurs des paramètres. Cela arrive de façon
-    transparente en ce qui concerne le protocole
+    transparente en ce qui concerne le protocole.
    </para>
 
    <para>
@@ -983,11 +983,11 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     Dès lors qu'un portail existe, il peut être exécuté à l'aide d'un message
     Execute. Ce message spécifie le nom du portail (une chaîne vide désigne le
     portail non nommé) et un nombre maximum de lignes de résultat (zéro
-    signifiant la <quote>récupération de toutes les lignes</quote>). le nombre de lignes
+    signifiant la <quote>récupération de toutes les lignes</quote>). Le nombre de lignes
     de résultat a seulement un sens pour les portails contenant des commandes
     qui renvoient des ensembles de lignes&nbsp;; dans les autres cas, la
     commande est toujours exécutée jusqu'à la fin et le nombre de lignes est
-    ignoré. Les réponses possibles d'Execute sont les même que celles
+    ignoré. Les réponses possibles d'Execute sont les mêmes que celles
     décrites ci-dessus pour les requêtes lancées via le protocole de requête
     simple, si ce n'est qu'Execute ne cause pas l'envoi de ReadyForQuery ou de
     RowDescription.
@@ -1017,14 +1017,14 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     serveur lance ErrorResponse, puis lit et annule les messages jusqu'à ce
     qu'un Sync soit atteint. Il envoie ensuite ReadyForQuery et retourne au
     traitement normal des messages. Aucun échappement n'est réalisé si une erreur
-    est détectée <emphasis>lors</emphasis> du traitement de sync &mdash; l'unicité du
+    est détectée <emphasis>lors</emphasis> du traitement de Sync &mdash; l'unicité du
     ReadyForQuery envoyé pour chaque Sync est ainsi assurée.
    </para>
 
    <note>
     <para>
      Sync n'impose pas la fermeture d'un bloc de transactions ouvert avec
-     <command>begin</command>. cette situation est détectable car le message
+     <command>begin</command>. Cette situation est détectable car le message
      ReadyForQuery inclut le statut de la transaction.
     </para>
    </note>
@@ -1039,7 +1039,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     existant (ou une chaîne vide pour le portail non nommé). La réponse est un
     message RowDescription décrivant les lignes qui seront renvoyées par
     l'exécution du portail&nbsp;; ou un message NoData si le portail ne contient
-    pas de requête renvoyant des lignes&nbsp;; ou ErrorResponse le portail
+    pas de requête renvoyant des lignes&nbsp;; ou ErrorResponse si le portail
     n'existe pas.
    </para>
 
@@ -1087,7 +1087,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
    <note>
     <para>
-     Le message Query simple est approximativement équivalent aux séries Parse,
+     Le message Query simple est approximativement équivalent à la séquence Parse,
      Bind, Describe sur un portail, Execute, Close, Sync utilisant les
      objets de l'instruction préparée ou du portail, non nommés et sans
      paramètres. Une différence est l'acceptation de plusieurs instructions SQL
@@ -1114,7 +1114,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      Le sous-protocole d'appel de fonction est une fonctionnalité qu'il vaudrait
      probablement mieux éviter dans tout nouveau code. Des résultats similaires
      peuvent être obtenus en initialisant une instruction préparée qui lance
-     <literal>select function($1, ...)</literal>. le cycle de l'appel de fonction peut
+     <literal>select function($1, ...)</literal>. Le cycle de l'appel de fonction peut
      alors être remplacé par Bind/Execute.
     </para>
    </note>
@@ -1190,7 +1190,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
    <para>
     Le mode Copy-in (transfert de données vers le serveur) est initié quand le
-    serveur exécute une instruction SQL <command>copy from stdin</command>. le serveur
+    serveur exécute une instruction SQL <command>copy from stdin</command>. Le serveur
     envoie une message CopyInResponse au client. Le client peut alors envoyer
     zéro (ou plusieurs) message(s) CopyData, formant un flux de données en
     entrée (il n'est pas nécessaire que les limites du message aient un
@@ -1199,12 +1199,12 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     message CopyDone (permettant une fin avec succès) ou un message CopyFail
     (qui causera l'échec de l'instruction SQL <command>copy</command> avec une erreur).
     Le serveur retourne alors au mode de traitement de la commande précédant le
-    début de <command>copy</command>, protocole de requête simple ou étendu. il
+    début de <command>copy</command>, protocole de requête simple ou étendu. Il
     enverra enfin CommandComplete (en cas de succès) ou ErrorResponse (sinon).
    </para>
 
    <para>
-    Si le serveur détecte un erreur en mode copy-in (ce qui inclut la
+    Si le serveur détecte une erreur en mode copy-in (ce qui inclut la
     réception d'un message CopyFail), il enverra un message ErrorResponse.
     Si la commande <command>copy</command> a été lancée à l'aide d'un message de
     requête étendue, le serveur annulera les messages du client jusqu'à
@@ -1313,11 +1313,11 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     Des messages ParameterStatus seront engendrés à chaque fois que la valeur
     active d'un paramètre est modifiée, et cela pour tout paramètre que le
     serveur pense utile au client. Cela survient plus généralement en réponse à
-    une commande SQL <command>set</command> exécutée par le client. ce cas est en fait
+    une commande SQL <command>set</command> exécutée par le client. Ce cas est en fait
     synchrone &mdash; mais il est possible aussi que le changement de statut d'un
     paramètre survienne à la suite d'une modification par l'administrateur des
     fichiers de configuration&nbsp;; changements suivis de l'envoi du signal
-    <systemitem>sighup</systemitem> au postmaster. de plus, si une commande set
+    <systemitem>sighup</systemitem> au postmaster. De plus, si une commande set
     est annulée, un message ParameterStatus approprié sera engendré pour
     rapporter la valeur effective.
    </para>
@@ -1494,9 +1494,9 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     Le client peut alors clore la connexion s'il n'est pas satisfait de la
     réponse. Pour continuer après un <literal>s</literal>, il faut échanger une poignée
     de main <acronym>ssl</acronym> (handshake) (non décrite ici car faisant partie de
-    la spécification <acronym>ssl</acronym>) avec le serveur. en cas de succès, le
+    la spécification <acronym>ssl</acronym>) avec le serveur. En cas de succès, le
     StartupMessage habituel est envoyé. Dans ce cas, StartupMessage et toutes
-    les données suivantes seront chiffrées avec <acronym>ssl</acronym>. pour continuer
+    les données suivantes seront chiffrées avec <acronym>ssl</acronym>. Pour continuer
     après un <literal>n</literal>, il suffit d'envoyer le startupmessage habituel et
     de continuer sans chiffrage.
    </para>
@@ -1788,7 +1788,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      </term>
      <listitem>
       <para>
-       Exactement <replaceable>n</replaceable> octets. si la largeur
+       Exactement <replaceable>n</replaceable> octets. Si la largeur
        <replaceable>n</replaceable> du champ n'est pas une constante,
        elle peut toujours être déterminée à partir d'un champ précédent
        du message. Si <replaceable>c</replaceable> est spécifié, c'est
@@ -3806,7 +3806,7 @@ Bind (F)
         <listitem>
          <para>
           Nombre de codes de format des colonnes de résultat qui
-          suivent (noté <replaceable>r</replaceable> ci-dessous). peut valoir zéro
+          suivent (noté <replaceable>r</replaceable> ci-dessous). Peut valoir zéro
           pour indiquer qu'il n'y a pas de colonnes de résultat ou que les
           colonnes de résultat utilisent le format par défaut
           (texte)&nbsp;; ou une, auquel cas le code de format spécifié est
@@ -4143,7 +4143,7 @@ Bind (F)
         <listitem>
          <para>
           Données formant une partie d'un flux de données
-          <command>copy</command>. les messages envoyés depuis le serveur
+          <command>copy</command>. Les messages envoyés depuis le serveur
           correspondront toujours à des lignes uniques de données, mais
           les messages envoyés par les clients peuvent diviser le flux de
           données de façon arbitraire.
@@ -6228,7 +6228,7 @@ Bind (F)
     <listitem>
      <para>
       Code&nbsp;: code SQLSTATE de l'erreur (voir
-      <xref linkend="errcodes-appendix"/>). non internationalisable.
+      <xref linkend="errcodes-appendix"/>). Non internationalisable.
       Toujours présent.
      </para>
     </listitem>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -940,10 +940,12 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     du portail destination (une chaîne vide désigne le portail non nommé) et les
     valeurs à utiliser pour tout emplacement de paramètres présent dans
     l'instruction préparée. L'ensemble des paramètres fournis doit
-    correspondre à ceux nécessaires à l'instruction préparée. Bind spécifie aussi
-    le format à utiliser pour toutes les données renvoyées par la requête&nbsp;;
-    le format peut être spécifié complètement ou par colonne. La réponse est, soit
-    BindComplete, soit ErrorResponse.
+    correspondre à ceux nécessaires à l'instruction préparée. (Si des
+    paramètres sont déclarés à <type>void</type> dans le message Parse,
+    il faut passer NULL comme valeur associée dans le message Bind.)
+    Bind spécifie aussi le format à utiliser pour toutes les données
+    renvoyées par la requête&nbsp;; le format peut être spécifié globalement
+    ou par colonne. La réponse est, soit BindComplete, soit ErrorResponse.
    </para>
 
    <note>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1561,207 +1561,6 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
   </sect2>
 </sect1>
 
-<sect1 id="protocol-logical-replication">
- <title>Protocole de réplication logique en flux</title>
-
- <para>
-  Cette section décrit le protocole de réplication logique, qui correspond au
-  flot de messages lancé par la commande de réplication
-  <literal>START_REPLICATION</literal> <literal>SLOT</literal> <replaceable
-  class="parameter">nom_slot</replaceable> <literal>LOGICAL</literal>.
- </para>
-
- <para>
-  Le protocole de réplication logique en flux est construit sur les primitives
-  du protocole de réplication physique en flux.
- </para>
-
- <sect2 id="protocol-logical-replication-params">
-  <title>Paramètres de la réplication logique en flux</title>
-
-  <para>
-   La commande <literal>START_REPLICATION</literal> de réplication logique
-   accepte les paramètres suivants&nbsp;:
-
-   <variablelist>
-    <varlistentry>
-     <term>
-      proto_version
-     </term>
-     <listitem>
-      <para>
-       Version du protocole. Actuellement, seule la version <literal>1</literal>
-       est supportée.
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term>
-      publication_names
-     </term>
-     <listitem>
-      <para>
-       Liste de noms de publications, séparés par des virgules, pour
-       souscription (récupération des modifications). Les noms de publication
-       individuels sont traités comme des noms d'objet standard et peuvent
-       être mis entre guillemets si nécessaire.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-
-  </para>
- </sect2>
-
- <sect2 id="protocol-logical-messages">
-  <title>Messages du protocole de réplication logique</title>
-
-  <para>
-   Les messages individuels du protocole de réplication sont discutés dans les
-   sous-sections suivantes. Les messages individuels sont décrits dans <xref
-   linkend="protocol-logicalrep-message-formats"/>.
-  </para>
-
-  <para>
-   Tous les messages de niveau supérieur commencent avec un octet de type de
-   message. Bien qu'ils soient représentés dans le code comme un caractère, il
-   s'agit d'un octet signé sans encodage associé.
-  </para>
-
-  <para>
-   Comme le protocole de réplication en flux fournit une longueur de message,
-   il n'est pas nécessaire que les messages de niveau supérieur embarquent une
-   longueur dans leur en-tête.
-  </para>
-
- </sect2>
-
- <sect2 id="protocol-logical-messages-flow">
-  <title>Flot des messages du protocole de réplication logique</title>
-
-  <para>
-   À l'exception de la commande <literal>START_REPLICATION</literal> et des
-   messages de progression du rejeu, toutes les informations passent du
-   serveur vers le client.
-  </para>
-
-  <para>
-   Le protocole de réplication logique envoie les transactions individuelles
-   une par une. Cela signifie que tous les messages entre une paire de
-   messages Begin et Commit appartiennent à la même transaction.
-  </para>
-
-  <para>
-   Chaque transaction envoyée contient zéro ou plusieurs messages DML (Insert,
-   Update, Delete). Dans le cas d'une configuration en cascade, elle peut
-   aussi contenir des messages Origin. Le message d'origine indiquait que la
-   transaction avait pour origine un nœud de réplication différent. Comme le
-   nœud de réplication dans le cas d'une réplication logique peut provenir de
-   n'importe où, le seul identificateur est le nom de l'origine. C'est de la
-   responsabilité du receveur de gérer cette information si nécessaire. Le
-   message Origin est toujours envoyé avant tout message DML dans la
-   transaction.
-  </para>
-
-  <para>
-   Chaque message DML contient un identifiant arbitraire de relation qui peut
-   être mis en relation avec un identifiant dans les messages Relation. Les
-   messages Relation décrivent le schéma de la relation donnée. Le message
-   Relation est envoyé pour une certaine relation soit parce que c'est la
-   première fois qu'un message DML est envoyé pour cette relation dans la
-   session courante soit parce que la définition de la relation a changé
-   depuis le dernier message Relation. Le protocole suppose que le client est
-   capable de mettre en cache les méta-données pour autant de relations que
-   nécessaire.
-  </para>
- </sect2>
-</sect1>
-
- <sect1 id="protocol-message-types">
-  <title>Types de données des messages</title>
-
-  <para>
-   Cette section décrit les types de données basiques utilisés dans les messages.
-
-   <variablelist>
-
-    <varlistentry>
-     <term>
-      Int<replaceable>n</replaceable>(<replaceable>i</replaceable>)
-     </term>
-     <listitem>
-      <para>
-       Un entier sur <replaceable>n</replaceable> bits dans l'ordre des
-       octets réseau (octet le plus significatif en premier). Si
-       <replaceable>i</replaceable> est spécifié, c'est exactement
-       la valeur qui apparaîtra, sinon la valeur est
-       variable, par exemple Int16, Int32(42).
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term>
-      Int<replaceable>n</replaceable>[<replaceable>k</replaceable>]
-     </term>
-     <listitem>
-      <para>
-       Un tableau de <replaceable>k</replaceable> entiers sur
-       <replaceable>n</replaceable> bits, tous dans l'ordre des octets
-       réseau. La longueur <replaceable>k</replaceable> du tableau est
-       toujours déterminée par un champ précédent du message, par
-       exemple, Int16[M].
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term>
-      String(<replaceable>s</replaceable>)
-     </term>
-     <listitem>
-      <para>
-       Une chaîne terminée par un octet nul (chaîne style C). Il n'y
-       a pas de limitation sur la longueur des chaînes. Si
-       <replaceable>s</replaceable> est spécifié, c'est la valeur exacte
-       qui apparaîtra, sinon la valeur est variable. Par exemple,
-       String("utilisateur").
-      </para>
-
-      <note>
-       <para>
-        <emphasis>Il n'y a aucune limite prédéfinie</emphasis> à la longueur d'une
-        chaîne retournée par le serveur. Une bonne stratégie de codage
-        de client consiste à utiliser un tampon dont la taille peut croître pour que
-        tout ce qui tient en mémoire puisse être accepté. Si cela n'est pas
-        faisable, il faudra lire la chaîne complète et supprimer les caractères
-        qui ne tiennent pas dans le tampon de taille fixe.
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term>
-      Byte<replaceable>n</replaceable>(<replaceable>c</replaceable>)
-     </term>
-     <listitem>
-      <para>
-       Exactement <replaceable>n</replaceable> octets. Si la largeur
-       <replaceable>n</replaceable> du champ n'est pas une constante,
-       elle peut toujours être déterminée à partir d'un champ précédent
-       du message. Si <replaceable>c</replaceable> est spécifié, c'est
-       la valeur exacte. Par exemple, Byte2, Byte1('\n').
-      </para>
-     </listitem>
-    </varlistentry>
-
-   </variablelist>
-  </para>
-
- </sect1>
-
 <sect1 id="sasl-authentication">
 <title>Authentification SASL</title>
 
@@ -3013,6 +2812,207 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
     </varlistentry>
    </variablelist>
 
+  </para>
+
+ </sect1>
+
+<sect1 id="protocol-logical-replication">
+ <title>Protocole de réplication logique en flux</title>
+
+ <para>
+  Cette section décrit le protocole de réplication logique, qui correspond au
+  flot de messages lancé par la commande de réplication
+  <literal>START_REPLICATION</literal> <literal>SLOT</literal> <replaceable
+  class="parameter">nom_slot</replaceable> <literal>LOGICAL</literal>.
+ </para>
+
+ <para>
+  Le protocole de réplication logique en flux est construit sur les primitives
+  du protocole de réplication physique en flux.
+ </para>
+
+ <sect2 id="protocol-logical-replication-params">
+  <title>Paramètres de la réplication logique en flux</title>
+
+  <para>
+   La commande <literal>START_REPLICATION</literal> de réplication logique
+   accepte les paramètres suivants&nbsp;:
+
+   <variablelist>
+    <varlistentry>
+     <term>
+      proto_version
+     </term>
+     <listitem>
+      <para>
+       Version du protocole. Actuellement, seule la version <literal>1</literal>
+       est supportée.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term>
+      publication_names
+     </term>
+     <listitem>
+      <para>
+       Liste de noms de publications, séparés par des virgules, pour
+       souscription (récupération des modifications). Les noms de publication
+       individuels sont traités comme des noms d'objet standard et peuvent
+       être mis entre guillemets si nécessaire.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+
+  </para>
+ </sect2>
+
+ <sect2 id="protocol-logical-messages">
+  <title>Messages du protocole de réplication logique</title>
+
+  <para>
+   Les messages individuels du protocole de réplication sont discutés dans les
+   sous-sections suivantes. Les messages individuels sont décrits dans <xref
+   linkend="protocol-logicalrep-message-formats"/>.
+  </para>
+
+  <para>
+   Tous les messages de niveau supérieur commencent avec un octet de type de
+   message. Bien qu'ils soient représentés dans le code comme un caractère, il
+   s'agit d'un octet signé sans encodage associé.
+  </para>
+
+  <para>
+   Comme le protocole de réplication en flux fournit une longueur de message,
+   il n'est pas nécessaire que les messages de niveau supérieur embarquent une
+   longueur dans leur en-tête.
+  </para>
+
+ </sect2>
+
+ <sect2 id="protocol-logical-messages-flow">
+  <title>Flot des messages du protocole de réplication logique</title>
+
+  <para>
+   À l'exception de la commande <literal>START_REPLICATION</literal> et des
+   messages de progression du rejeu, toutes les informations passent du
+   serveur vers le client.
+  </para>
+
+  <para>
+   Le protocole de réplication logique envoie les transactions individuelles
+   une par une. Cela signifie que tous les messages entre une paire de
+   messages Begin et Commit appartiennent à la même transaction.
+  </para>
+
+  <para>
+   Chaque transaction envoyée contient zéro ou plusieurs messages DML (Insert,
+   Update, Delete). Dans le cas d'une configuration en cascade, elle peut
+   aussi contenir des messages Origin. Le message d'origine indiquait que la
+   transaction avait pour origine un nœud de réplication différent. Comme le
+   nœud de réplication dans le cas d'une réplication logique peut provenir de
+   n'importe où, le seul identificateur est le nom de l'origine. C'est de la
+   responsabilité du receveur de gérer cette information si nécessaire. Le
+   message Origin est toujours envoyé avant tout message DML dans la
+   transaction.
+  </para>
+
+  <para>
+   Chaque message DML contient un identifiant arbitraire de relation qui peut
+   être mis en relation avec un identifiant dans les messages Relation. Les
+   messages Relation décrivent le schéma de la relation donnée. Le message
+   Relation est envoyé pour une certaine relation soit parce que c'est la
+   première fois qu'un message DML est envoyé pour cette relation dans la
+   session courante soit parce que la définition de la relation a changé
+   depuis le dernier message Relation. Le protocole suppose que le client est
+   capable de mettre en cache les méta-données pour autant de relations que
+   nécessaire.
+  </para>
+ </sect2>
+</sect1>
+
+ <sect1 id="protocol-message-types">
+  <title>Types de données des messages</title>
+
+  <para>
+   Cette section décrit les types de données basiques utilisés dans les messages.
+
+   <variablelist>
+
+    <varlistentry>
+     <term>
+      Int<replaceable>n</replaceable>(<replaceable>i</replaceable>)
+     </term>
+     <listitem>
+      <para>
+       Un entier sur <replaceable>n</replaceable> bits dans l'ordre des
+       octets réseau (octet le plus significatif en premier). Si
+       <replaceable>i</replaceable> est spécifié, c'est exactement
+       la valeur qui apparaîtra, sinon la valeur est
+       variable, par exemple Int16, Int32(42).
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term>
+      Int<replaceable>n</replaceable>[<replaceable>k</replaceable>]
+     </term>
+     <listitem>
+      <para>
+       Un tableau de <replaceable>k</replaceable> entiers sur
+       <replaceable>n</replaceable> bits, tous dans l'ordre des octets
+       réseau. La longueur <replaceable>k</replaceable> du tableau est
+       toujours déterminée par un champ précédent du message, par
+       exemple, Int16[M].
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term>
+      String(<replaceable>s</replaceable>)
+     </term>
+     <listitem>
+      <para>
+       Une chaîne terminée par un octet nul (chaîne style C). Il n'y
+       a pas de limitation sur la longueur des chaînes. Si
+       <replaceable>s</replaceable> est spécifié, c'est la valeur exacte
+       qui apparaîtra, sinon la valeur est variable. Par exemple,
+       String("utilisateur").
+      </para>
+
+      <note>
+       <para>
+        <emphasis>Il n'y a aucune limite prédéfinie</emphasis> à la longueur d'une
+        chaîne retournée par le serveur. Une bonne stratégie de codage
+        de client consiste à utiliser un tampon dont la taille peut croître pour que
+        tout ce qui tient en mémoire puisse être accepté. Si cela n'est pas
+        faisable, il faudra lire la chaîne complète et supprimer les caractères
+        qui ne tiennent pas dans le tampon de taille fixe.
+       </para>
+      </note>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term>
+      Byte<replaceable>n</replaceable>(<replaceable>c</replaceable>)
+     </term>
+     <listitem>
+      <para>
+       Exactement <replaceable>n</replaceable> octets. Si la largeur
+       <replaceable>n</replaceable> du champ n'est pas une constante,
+       elle peut toujours être déterminée à partir d'un champ précédent
+       du message. Si <replaceable>c</replaceable> est spécifié, c'est
+       la valeur exacte. Par exemple, Byte2, Byte1('\n').
+      </para>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
   </para>
 
  </sect1>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1277,9 +1277,9 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     synchrone &mdash; mais il est possible aussi que le changement de statut d'un
     paramètre survienne à la suite d'une modification par l'administrateur des
     fichiers de configuration&nbsp;; changements suivis de l'envoi du signal
-    <systemitem>SIGHUP</systemitem> au postmaster. De plus, si une commande set
-    est annulée, un message ParameterStatus approprié sera engendré pour
-    rapporter la valeur effective.
+    <systemitem>SIGHUP</systemitem> au postmaster. De plus, si une commande
+    <command>SET</command> est annulée, un message ParameterStatus approprié
+    sera engendré pour rapporter la valeur effective.
    </para>
 
    <para>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1434,40 +1434,40 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
   </sect2>
 
   <sect2>
-   <title>Chiffrement <acronym>ssl</acronym> de session</title>
+   <title>Chiffrement <acronym>SSL</acronym> de session</title>
 
    <para>
     Si <productname>PostgreSQL</productname> a été construit avec le support de
-    <acronym>ssl</acronym>, les communications client/serveur peuvent être chiffrées
+    <acronym>SSL</acronym>, les communications client/serveur peuvent être chiffrées
     en l'utilisant. Ce chiffrement assure la sécurité de la communication
     dans les environnements où des agresseurs pourraient capturer le trafic
     de la session. Pour plus d'informations sur le cryptage des sessions
-    <productname>PostgreSQL</productname> avec <acronym>ssl</acronym>, voir
+    <productname>PostgreSQL</productname> avec <acronym>SSL</acronym>, voir
     <xref linkend="ssl-tcp"/>.
    </para>
 
    <para>
-    Pour initier une connexion chiffrée par <acronym>ssl</acronym>, le client envoie
+    Pour initier une connexion chiffrée par <acronym>SSL</acronym>, le client envoie
     initialement un message SSLRequest à la place d'un StartupMessage. Le
-    serveur répond avec un seul octet contenant <literal>s</literal> ou <literal>n</literal>
-    indiquant respectivement s'il souhaite ou non utiliser le <acronym>ssl</acronym>.
+    serveur répond avec un seul octet contenant <literal>S</literal> ou <literal>N</literal>
+    indiquant respectivement s'il souhaite ou non utiliser le <acronym>SSL</acronym>.
     Le client peut alors clore la connexion s'il n'est pas satisfait de la
-    réponse. Pour continuer après un <literal>s</literal>, il faut échanger une poignée
-    de main <acronym>ssl</acronym> (handshake) (non décrite ici car faisant partie de
-    la spécification <acronym>ssl</acronym>) avec le serveur. En cas de succès, le
+    réponse. Pour continuer après un <literal>S</literal>, il faut échanger une poignée
+    de main <acronym>SSL</acronym> (handshake) (non décrite ici car faisant partie de
+    la spécification <acronym>SSL</acronym>) avec le serveur. En cas de succès, le
     StartupMessage habituel est envoyé. Dans ce cas, StartupMessage et toutes
-    les données suivantes seront chiffrées avec <acronym>ssl</acronym>. Pour continuer
-    après un <literal>n</literal>, il suffit d'envoyer le startupmessage habituel et
+    les données suivantes seront chiffrées avec <acronym>SSL</acronym>. Pour continuer
+    après un <literal>N</literal>, il suffit d'envoyer le startupmessage habituel et
     de continuer sans chiffrage.
    </para>
 
    <para>
     Le client doit être préparé à gérer une réponse ErrorMessage à un SSLRequest
     émanant du serveur. Ceci ne peut survenir que si le serveur ne dispose pas
-    du support de <acronym>ssl</acronym>. (De tels servers sont maintenant
+    du support de <acronym>SSL</acronym>. (De tels servers sont maintenant
     très anciens, et ne doivent certainement plus exister.) Dans ce cas, la
     connexion doit être fermée, mais le client peut choisir d'ouvrir une
-    nouvelle connexion et procéder sans <acronym>ssl</acronym>.
+    nouvelle connexion et procéder sans <acronym>SSL</acronym>.
    </para>
 
    <para>
@@ -1477,7 +1477,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
    <para>
     Alors que le protocole lui-même ne fournit pas au serveur de moyen de
-    forcer le chiffrage <acronym>ssl</acronym>, l'administrateur peut configurer le
+    forcer le chiffrage <acronym>SSL</acronym>, l'administrateur peut configurer le
     serveur pour rejeter les sessions non chiffrées, ce qui est une autre
     façon de vérifier l'authentification.
    </para>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -78,10 +78,10 @@
 
   <para>
    En mode opérationnel normal, les commandes SQL peuvent être exécutées
-   via deux sous-protocoles. Dans le protocole des <quote>requêtes simples</quote>,
+   via deux sous-protocoles. Dans le protocole <quote>Simple Query</quote>,
    le client envoie juste une chaîne, la requête, qui est analysée et exécutée
-   immédiatement par le serveur. Dans le protocole des <quote>requêtes
-    étendues</quote>, le traitement des requêtes est découpé en de nombreuses
+   immédiatement par le serveur. Dans le protocole <quote>Extended Query</quote>,
+   le traitement des requêtes est découpé en de nombreuses
    étapes&nbsp;: l'analyse, le lien avec les valeurs de paramètres et
    l'exécution. Ceci offre flexibilité et gains en performances
    au prix d'une complexité supplémentaire.
@@ -127,10 +127,10 @@
   </sect2>
 
   <sect2 id="protocol-query-concepts">
-   <title>Aperçu des requêtes étendues</title>
+   <title>Aperçu du protocole Extended Query</title>
 
    <para>
-    Dans le protocole des requêtes étendues, l'exécution de commandes SQL est
+    Dans le protocole Extended Query, l'exécution de commandes SQL est
     scindée en plusieurs étapes. L'état retenu entre les étapes est représenté
     par deux types d'objets&nbsp;: les <firstterm>instructions préparées</firstterm> et
     les <firstterm>portails</firstterm>. Une instruction préparée représente le résultat
@@ -527,10 +527,10 @@
   </sect2>
 
   <sect2>
-   <title>Requête simple</title>
+   <title>Protocole Simple Query</title>
 
    <para>
-    Un cycle de requête simple est initié par le client qui envoie un message
+    En protocole Simple Query, un cycle est initié par le client qui envoie un message
     Query au serveur. Le message inclut une commande SQL (ou plusieurs) exprimée
     comme une chaîne texte. Le serveur envoie, alors, un ou plusieurs messages
     de réponse dépendant du contenu de la chaîne représentant la requête et
@@ -674,7 +674,7 @@
    </para>
 
    <para>
-    En mode de requêtage simple, les valeurs récupérées sont toujours au format
+    En mode Simple Query, les valeurs récupérées sont toujours au format
     texte, sauf si la commande est un <command>fetch</command> sur un curseur déclaré
     avec l'option <literal>binary</literal>. Dans ce cas, les valeurs récupérées sont
     au format binaire. Les codes de format donnés dans le message RowDescription
@@ -696,10 +696,10 @@
    </para>
 
    <sect3 id="protocol-flow-multi-statement">
-    <title>Plusieurs instructions dans une requête simple</title>
+    <title>Plusieurs instructions dans une message Simple Query</title>
 
     <para>
-     Lorsqu'un simple message de requête contient plus d'une instruction SQL
+     Lorsqu'un message Simple Query contient plus d'une instruction SQL
      (séparées par des points-virgules), ces instructions sont exécutées comme une
      seule transaction à moins que des commandes explicites de contrôle des
      transactions ne soient incluses pour forcer un comportement différent.
@@ -782,7 +782,7 @@ SELECT 1/0;
     <para>
      N'oubliez pas que, quelle que soit la commande de contrôle de transaction
      présente, l'exécution du message de requête s'arrête dès la première erreur.
-     Par exemple, si pour un message de requête simple l'on donne&nbsp;:
+     Par exemple, si pour un message Simple Query l'on donne&nbsp;:
 <programlisting>
 BEGIN;
 SELECT 1/0;
@@ -823,10 +823,10 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
   </sect2>
 
   <sect2 id="protocol-flow-ext-query">
-   <title>Requête étendue</title>
+   <title>Protocole Extended Query</title>
 
    <para>
-    Le protocole de requête étendu divise le protocole de requêtage simple décrit
+    Le protocole Extended Query divise le protocole Simple Query décrit
     ci-dessus en plusieurs étapes. Les résultats des étapes de préparation
     peuvent être réutilisés plusieurs fois pour plus d'efficacité. De plus,
     des fonctionnalités supplémentaires sont disponibles, telles que la
@@ -870,7 +870,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     <para>
      La chaîne contenue dans un message Parse ne peut pas inclure plus d'une
      instruction SQL, sinon une erreur de syntaxe est rapportée. Cette
-     restriction n'existe pas dans le protocole de requête simple, mais est
+     restriction n'existe pas dans le protocole Simple Query, mais est
      présente dans le protocole étendu. En effet, permettre aux instructions
      préparées ou aux portails de contenir de multiples commandes compliquerait
      inutilement le protocole.
@@ -882,7 +882,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     jusqu'à la fin de la session courante, sauf si elle est détruite
     explicitement. Une instruction préparée non nommée ne dure que jusqu'à
     la prochaine instruction Parse spécifiant l'instruction non nommée comme
-    destination. Un simple message Query détruit également l'instruction non
+    destination. Un message Simple Query détruit également l'instruction non
     nommée. Les instructions préparées nommées doivent être explicitement
     closes avant de pouvoir être redéfinies par un autre message Parse. Ce n'est
     pas obligatoire pour une instruction non nommée. Il est également possible
@@ -911,7 +911,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      Le choix entre sortie texte et binaire est déterminé par les codes
      de format donnés dans Bind, quelle que soit la commande SQL impliquée.
      L'attribut <literal>BINARY</literal> dans les déclarations du curseur n'est pas
-     pertinent lors de l'utilisation du protocole de requête étendue.
+     pertinent lors de l'utilisation du protocole Extended Query.
     </para>
    </note>
 
@@ -931,7 +931,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     de la transaction courante sauf s'il est explicitement détruit. Un
     portail non nommé est détruit à la fin de la transaction ou dès la prochaine
     instruction Bind spécifiant le portail non nommé comme destination.
-    Un simple message Query détruit également le portail non nommé. Les
+    (À noter qu'un message Simple Query détruit également le portail non nommé.) Les
     portails nommés doivent être explicitement fermés avant de pouvoir être
     redéfinis par un autre message Bind. Cela n'est pas obligatoire pour le portail non
     nommé. Il est également possible de créer des portails nommés, et d'y
@@ -948,8 +948,8 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     qui renvoient des ensembles de lignes&nbsp;; dans les autres cas, la
     commande est toujours exécutée jusqu'à la fin et le nombre de lignes est
     ignoré. Les réponses possibles d'Execute sont les mêmes que celles
-    décrites ci-dessus pour les requêtes lancées via le protocole de requête
-    simple, si ce n'est qu'Execute ne cause pas l'envoi de ReadyForQuery ou de
+    décrites ci-dessus pour les requêtes lancées via le protocole Simple
+    Query, si ce n'est qu'Execute ne cause pas l'envoi de ReadyForQuery ou de
     RowDescription.
    </para>
 
@@ -966,14 +966,14 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
    </para>
 
    <para>
-    À la réalisation complète de chaque série de messages de requêtes étendues,
+    À la réalisation complète de chaque série de messages Extended Query,
     le client doit lancer un message Sync. Ce message sans paramètre oblige
     le serveur à fermer la transaction courante si elle n'est pas à l'intérieur
     d'un bloc de transaction <command>begin</command>/<command>commit</command>
     (<quote>fermer</quote> signifiant valider en l'absence d'erreur ou annuler sinon).
     Une réponse ReadyForQuery est alors envoyée. Le but de Sync est de fournir
     un point de resynchronisation pour les récupérations d'erreurs. Quand une
-    erreur est détectée lors du traitement d'un message de requête étendue, le
+    erreur est détectée lors du traitement d'un message Extended Query, le
     serveur lance ErrorResponse, puis lit et annule les messages jusqu'à ce
     qu'un Sync soit atteint. Il envoie ensuite ReadyForQuery et retourne au
     traitement normal des messages. Aucun échappement n'est réalisé si une erreur
@@ -991,7 +991,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
    <para>
     En plus de ces opérations fondamentales, requises, il y a plusieurs opérations
-    optionnelles qui peuvent être utilisées avec le protocole de requête étendue.
+    optionnelles qui peuvent être utilisées avec le protocole Extended Query.
    </para>
 
    <para>
@@ -1038,7 +1038,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
    <para>
     Le message Flush n'engendre pas de sortie spécifique, mais
     force le serveur à délivrer toute donnée restante dans les tampons de
-    sortie. Un Flush doit être envoyé après toute commande de requête étendue,
+    sortie. Un Flush doit être envoyé après toute commande Extended Query,
     à l'exception de Sync, si le client souhaite examiner le résultat de cette
     commande avant de lancer d'autres commandes. Sans Flush, les messages
     retournés par le serveur seront combinés en un nombre minimum de paquets
@@ -1047,7 +1047,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
    <note>
     <para>
-     Le message Query simple est approximativement équivalent à la séquence Parse,
+     Le message Simple Query est approximativement équivalent à la séquence Parse,
      Bind, Describe sur un portail, Execute, Close, Sync utilisant les
      objets de l'instruction préparée ou du portail, non nommés et sans
      paramètres. Une différence est l'acceptation de plusieurs instructions SQL
@@ -1159,19 +1159,19 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     message CopyDone (permettant une fin avec succès) ou un message CopyFail
     (qui causera l'échec de l'instruction SQL <command>copy</command> avec une erreur).
     Le serveur retourne alors au mode de traitement de la commande précédant le
-    début de <command>copy</command>, protocole de requête simple ou étendu. Il
+    début de <command>copy</command>, soit les protocoles Simple Query ou Extended Query. Il
     enverra enfin CommandComplete (en cas de succès) ou ErrorResponse (sinon).
    </para>
 
    <para>
     Si le serveur détecte une erreur en mode copy-in (ce qui inclut la
     réception d'un message CopyFail), il enverra un message ErrorResponse.
-    Si la commande <command>copy</command> a été lancée à l'aide d'un message de
-    requête étendue, le serveur annulera les messages du client jusqu'à
+    Si la commande <command>copy</command> a été lancée à l'aide d'un message
+    Extended Query, le serveur annulera les messages du client jusqu'à
     ce qu'un message Sync soit reçu. Il enverra alors un message ReadyForQuery
     et retournera dans le mode de fonctionnement normal. Si la commande
     <command>copy</command> a été lancée dans un message
-    simple Query, le reste de ce message est annulé et ReadyForQuery est envoyé.
+    Simple Query, le reste de ce message est annulé et ReadyForQuery est envoyé.
     Dans tous les cas, les messages CopyData, CopyDone ou CopyFail suivants
     envoyés par l'interface seront simplement annulés.
    </para>
@@ -1763,7 +1763,7 @@ peut envoyer un message ErrorMessage.
 
   <para>
    En mode <literal>walsender</literal> pour la réplication physique ou pour la
-   réplication logique, seul le protocole de messages Query simple peut être utilisé.
+   réplication logique, seul le protocole de messages Simple Query peut être utilisé.
   </para>
 
   <para>
@@ -7217,7 +7217,7 @@ TupleData
   </para>
 
   <para>
-   Il existe un nouveau sous-protocole pour les <quote>requêtes étendues</quote> qui
+   Il existe un nouveau sous-protocole <quote>Extended Query</quote> qui
    ajoute les types de messages client Parse, Bind, Execute, Describe, Close,
    Flush et Sync et les types de messages serveur ParseComplete, BindComplete,
    PortalSuspended, ParameterDescription, NoData et CloseComplete. Les clients

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -6147,15 +6147,15 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>s</literal>
+     <literal>S</literal>
     </term>
     <listitem>
      <para>
       Gravité (Severity)&nbsp;: le contenu du champ peut être
-      <literal>error</literal>, <literal>fatal</literal> ou
-      <literal>panic</literal> dans un message d'erreur,
-      <literal>warning</literal>, <literal>notice</literal>, <literal>debug</literal>,
-      <literal>info</literal> ou <literal>log</literal> dans un message d'avertissement,
+      <literal>ERROR</literal>, <literal>FATAL</literal> ou
+      <literal>PANIC</literal> dans un message d'erreur,
+      <literal>WARNING</literal>, <literal>NOTICE</literal>, <literal>DEBUG</literal>,
+      <literal>INFO</literal> ou <literal>LOG</literal> dans un message d'avertissement,
       ou la traduction régionale de l'un d'eux. Toujours présent.
      </para>
     </listitem>
@@ -6181,7 +6181,7 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>c</literal>
+     <literal>C</literal>
     </term>
     <listitem>
      <para>
@@ -6194,7 +6194,7 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>m</literal>
+     <literal>M</literal>
     </term>
     <listitem>
      <para>
@@ -6206,7 +6206,7 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>d</literal>
+     <literal>D</literal>
     </term>
     <listitem>
      <para>
@@ -6219,7 +6219,7 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>h</literal>
+     <literal>H</literal>
     </term>
     <listitem>
      <para>
@@ -6233,7 +6233,7 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>p</literal>
+     <literal>P</literal>
     </term>
     <listitem>
      <para>
@@ -6252,7 +6252,7 @@ Bind (F)
     <listitem>
      <para>
       Position interne&nbsp;: ceci est défini de la même façon que le champ
-      <literal>p</literal> mais c'est utilisé quand la position du curseur se réfère
+      <literal>P</literal> mais c'est utilisé quand la position du curseur se réfère
       à une commande générée en interne plutôt qu'une soumise par le client.
       Le champ <literal>q</literal> apparaîtra toujours quand ce champ apparaît.
      </para>
@@ -6273,7 +6273,7 @@ Bind (F)
 
    <varlistentry>
     <term>
-     <literal>w</literal>
+     <literal>W</literal>
     </term>
     <listitem>
      <para>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -4342,76 +4342,6 @@ Bind (F)
     </listitem>
    </varlistentry>
 
-
-   <varlistentry>
-    <term>
-     NegotiateProtocolVersion (B)
-    </term>
-    <listitem>
-     <para>
-
-      <variablelist>
-       <varlistentry>
-        <term>
-         Byte1('v')
-        </term>
-        <listitem>
-         <para>
-          Identifie le message comme un message de négociation de la version
-          du protocole.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>
-         Int32
-        </term>
-        <listitem>
-         <para>
-          Longueur du contenu du message en octets, incluant la longueur
-          elle-même.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>
-         Int32
-        </term>
-        <listitem>
-         <para>
-          Plus récente version mineure supportée par le serveur pour la
-          version majeure du protocole demandée par le client.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>
-         Int32
-        </term>
-        <listitem>
-         <para>
-          Nombre d'options du protocole non reconnues par le serveur.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-      Puis, pour chaque option du protocole non reconnue par le serveur&nbsp;:
-      <variablelist>
-       <varlistentry>
-        <term>
-         String
-        </term>
-        <listitem>
-         <para>
-          Nom de l'option.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </para>
-    </listitem>
-   </varlistentry>
-
    <varlistentry>
     <term>
      CopyBothResponse (B)
@@ -5038,6 +4968,74 @@ Bind (F)
     </listitem>
    </varlistentry>
 
+   <varlistentry>
+    <term>
+     NegotiateProtocolVersion (B)
+    </term>
+    <listitem>
+     <para>
+
+      <variablelist>
+       <varlistentry>
+        <term>
+         Byte1('v')
+        </term>
+        <listitem>
+         <para>
+          Identifie le message comme un message de négociation de la version
+          du protocole.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Int32
+        </term>
+        <listitem>
+         <para>
+          Longueur du contenu du message en octets, incluant la longueur
+          elle-même.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Int32
+        </term>
+        <listitem>
+         <para>
+          Plus récente version mineure supportée par le serveur pour la
+          version majeure du protocole demandée par le client.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Int32
+        </term>
+        <listitem>
+         <para>
+          Nombre d'options du protocole non reconnues par le serveur.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+      Puis, pour chaque option du protocole non reconnue par le serveur&nbsp;:
+      <variablelist>
+       <varlistentry>
+        <term>
+         String
+        </term>
+        <listitem>
+         <para>
+          Nom de l'option.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </para>
+    </listitem>
+   </varlistentry>
 
    <varlistentry>
     <term>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -3547,33 +3547,32 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
         </term>
         <listitem>
          <para>
-          Indique que l'authentification SASL est terminée.
+          Taille du message en octets, y compris la taille elle-même.
          </para>
         </listitem>
        </varlistentry>
        <varlistentry>
         <term>
-         Int16
+         Int32(12)
         </term>
         <listitem>
          <para>
-          Nombre de valeurs de paramètres qui suivent (peut valoir zéro).
-          Cela doit correspondre au nombre de paramètres nécessaires à la
-          requête.
+          Indique que l'authentification SASL est terminée.
          </para>
         </listitem>
        </varlistentry>
-<varlistentry>
-<term>
-        Byte<replaceable>n</replaceable>
-</term>
-<listitem>
-<para>
-                Données supplémentaires pour SASL, spécifique au mécanisme SASL utilisé.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+
+       <varlistentry>
+        <term>
+         Byte<replaceable>n</replaceable>
+        </term>
+        <listitem>
+         <para>
+          Données supplémentaires pour SASL, spécifique au mécanisme SASL utilisé.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
 
 </para>
 </listitem>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -174,7 +174,7 @@
    <title>Formats et codes de format</title>
 
    <para>
-    Les données d'un type particulier pouvaient être transmises sous
+    Les données d'un type particulier peuvent être transmises sous
     différents <firstterm>formats</firstterm>. Depuis <productname>PostgreSQL</productname> 7.4, les
     seuls formats supportés sont le <quote>texte</quote> et le <quote>binaire</quote> mais
     le protocole prévoit des extensions futures. Le format souhaité pour toute valeur

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -165,7 +165,7 @@
     à la création. De plus, il existe une instruction préparée et un portail
     <quote>non nommés</quote>. Bien qu'ils se comportent comme des objets
     nommés, les opérations y sont optimisées en vue d'une exécution unique
-    de la requête avant son annulation puis est annulée. En revanche, les
+    de la requête puis de son abandon. En revanche, les
     opérations sur les objets nommés sont optimisées pour des utilisations multiples.
    </para>
   </sect2>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -6446,16 +6446,6 @@ Begin
 </varlistentry>
 <varlistentry>
 <term>
-        Int8
-</term>
-<listitem>
-<para>
-                Options&nbsp;; actuellement inutilisé (doit valoir 0).
-</para>
-</listitem>
-</varlistentry>
-<varlistentry>
-<term>
         Int64
 </term>
 <listitem>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -256,7 +256,7 @@
 
     <variablelist>
      <varlistentry>
-      <term>errorresponse</term>
+      <term>ErrorResponse</term>
       <listitem>
        <para>
         La tentative de connexion a été rejetée.
@@ -266,7 +266,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>authenticationok</term>
+      <term>AuthenticationOk</term>
       <listitem>
        <para>
         L'échange d'authentification s'est terminé avec succès.
@@ -275,7 +275,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>authenticationkerberosv5</term>
+      <term>AuthenticationKerberosV5</term>
       <listitem>
        <para>
         Le client doit alors prendre part à un dialogue
@@ -287,7 +287,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>authenticationcleartextpassword</term>
+      <term>AuthenticationCleartextPassword</term>
       <listitem>
        <para>
         Le client doit alors envoyer un PasswordMessage contenant le mot
@@ -298,7 +298,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>authenticationmd5password</term>
+      <term>AuthenticationMD5Password</term>
       <listitem>
        <para>
         Le client doit envoyer un PasswordMessage contenant le mot de passe
@@ -316,7 +316,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>authenticationscmcredential</term>
+      <term>AuthenticationSCMCredential</term>
       <listitem>
        <para>
         Cette réponse est possible uniquement pour les connexions locales de
@@ -461,7 +461,7 @@
 
     <variablelist>
      <varlistentry>
-      <term>backendkeydata</term>
+      <term>BackendKeyData</term>
       <listitem>
        <para>
         Ce message fournit une clé secrète que le client doit conserver s'il
@@ -473,7 +473,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>parameterstatus</term>
+      <term>ParameterStatus</term>
       <listitem>
        <para>
         Ce message informe le client de la configuration actuelle (initiale)
@@ -488,7 +488,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>readyforquery</term>
+      <term>ReadyForQuery</term>
       <listitem>
        <para>
         Le lancement est terminé. Le client peut dès lors envoyer des commandes.
@@ -497,7 +497,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>errorresponse</term>
+      <term>ErrorResponse</term>
       <listitem>
        <para>
         Le lancement a échoué. La connexion est fermée après l'envoi de ce
@@ -507,7 +507,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>noticeresponse</term>
+      <term>NoticeResponse</term>
       <listitem>
        <para>
         Un message d'avertissement a été envoyé. Le client devrait afficher ce
@@ -546,7 +546,7 @@
 
     <variablelist>
      <varlistentry>
-      <term>commandcomplete</term>
+      <term>CommandComplete</term>
       <listitem>
        <para>
         Commande SQL terminée normalement.
@@ -555,7 +555,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>copyinresponse</term>
+      <term>CopyInResponse</term>
       <listitem>
        <para>
         Le serveur est prêt à copier des données du client vers une table&nbsp;;
@@ -565,7 +565,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>copyoutresponse</term>
+      <term>CopyOutResponse</term>
       <listitem>
        <para>
         Le serveur est prêt à copier des données d'une table vers le client&nbsp;;
@@ -575,7 +575,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>rowdescription</term>
+      <term>RowDescription</term>
       <listitem>
        <para>
         Indique que des lignes vont être envoyées en réponse à une
@@ -588,7 +588,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>datarow</term>
+      <term>DataRow</term>
       <listitem>
        <para>
         Un des ensembles de lignes retournés par une requête
@@ -598,7 +598,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>emptyqueryresponse</term>
+      <term>EmptyQueryResponse</term>
       <listitem>
        <para>
         Une chaîne de requête vide a été reconnue.
@@ -607,7 +607,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>errorresponse</term>
+      <term>ErrorResponse</term>
       <listitem>
        <para>
         Une erreur est survenue.
@@ -616,7 +616,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>readyforquery</term>
+      <term>ReadyForQuery</term>
       <listitem>
        <para>
         Le traitement d'une requête est terminé. Un message séparé est envoyé
@@ -629,7 +629,7 @@
      </varlistentry>
 
      <varlistentry>
-      <term>noticeresponse</term>
+      <term>NoticeResponse</term>
       <listitem>
        <para>
         Un message d'avertissement concernant la requête a été envoyé. Les
@@ -1133,7 +1133,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
 
     <variablelist>
      <varlistentry>
-      <term>errorresponse</term>
+      <term>ErrorResponse</term>
       <listitem>
        <para>
         Une erreur est survenue.
@@ -1142,7 +1142,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      </varlistentry>
 
      <varlistentry>
-      <term>functioncallresponse</term>
+      <term>FunctionCallResponse</term>
       <listitem>
        <para>
         L'appel de la fonction est terminé et a retourné le résultat
@@ -1154,7 +1154,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      </varlistentry>
 
      <varlistentry>
-      <term>readyforquery</term>
+      <term>ReadyForQuery</term>
       <listitem>
        <para>
         Le traitement de l'appel de fonction est terminé. ReadyForQuery sera
@@ -1165,7 +1165,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
      </varlistentry>
 
      <varlistentry>
-      <term>noticeresponse</term>
+      <term>NoticeResponse</term>
       <listitem>
        <para>
         Un message d'avertissement relatif à l'appel de fonction a été retourné.

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -681,48 +681,6 @@
     indiquent le format utilisé.
    </para>
 
-   <para>
-    La planification de requêtes pour des instructions préparées survient
-    lorsque le message Parse est reçu. Si une requête sera exécuté de façon
-    répété avec différents paramètres, il pourrait être bénéfique d'envoyer un
-    seul message Parse contenant une requête avec paramètres, suivie de
-    plusieurs messages Bind et Execute. Ceci évitera de planifier de nouveau
-    la requête pour chaque exécution.
-   </para>
-
-   <para>
-    L'instruction préparée non nommée est planifiée lors du traitement de Parse
-    si le message Parse ne définit aucun paramètre. Mais s'il existe des
-    paramètres, la planification de la requête est repoussée jusqu'à ce que le
-    premier message Bind de cette instruction est reçu. Le planificateur
-    considérera les valeurs réelles des paramètres fournies dans le message
-    Bind lors de la planification de la requête.
-   </para>
-
-   <note>
-    <para>
-     Les plans de requêtes générés à partir d'une requête avec paramètres
-     pourraient être moins efficaces que les plans de requêtes générés à partir
-     d'une requête équivalente dont les valeurs de paramètres réelles ont été
-     placées. Le planificateur de requêtes ne peut pas prendre les décisions
-     suivant les valeurs réelles des paramètres (par exemple, la sélectivité
-     de l'index) lors de la planification d'une requête avec paramètres affectée
-     à un objet instruction préparée nommée. La pénalité possible est évitée
-     lors de l'utilisation d'une instruction non nommée car elle n'est pas
-     planifiée jusqu'à ce que des valeurs réelles de paramètres soient
-     disponibles.
-    </para>
-
-    <para>
-     Si un autre Bind référençant l'objet instruction préparée non nommée est
-     reçu, la requête n'est pas de nouveau planifiée. Les valeurs de paramètres
-     utilisées dans le premier message Bind pourrait produire un plan de requête
-     qui est seulement efficace pour un sous-ensemble des valeurs de paramètres
-     possibles. Pour forcer une nouvelle planification de la requête pour un
-     ensemble nouveau de paramètres, envoyez un autre message Parse pour
-     remplacer l'objet instruction préparée non nommée.
-    </para>
-   </note>
 
    <para>
     Un client doit être préparé à accepter des messages ErrorResponse et

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1191,7 +1191,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     Le moteur envoie un message CopyOutResponse au client suivi de zéro (ou
     plusieurs) message(s) CopyData (un par ligne), suivi de CopyDone.
     Le serveur retourne ensuite au mode de traitement de commande dans lequel il
-    se trouvait avant le lancement de <command>copy</command> et envoie commandcomplete.
+    se trouvait avant le lancement de <command>copy</command> et envoie CommandComplete.
     Le client ne peut pas annuler le transfert (sauf en fermant la connexion ou en
     lançant une requête d'annulation, Cancel), mais il peut ignorer les messages
     CopyData et CopyDone non souhaités.
@@ -1277,7 +1277,7 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     synchrone &mdash; mais il est possible aussi que le changement de statut d'un
     paramètre survienne à la suite d'une modification par l'administrateur des
     fichiers de configuration&nbsp;; changements suivis de l'envoi du signal
-    <systemitem>sighup</systemitem> au postmaster. De plus, si une commande set
+    <systemitem>SIGHUP</systemitem> au postmaster. De plus, si une commande set
     est annulée, un message ParameterStatus approprié sera engendré pour
     rapporter la valeur effective.
    </para>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1749,8 +1749,7 @@ peut envoyer un message ErrorMessage.
    <literal>yes</literal>, <literal>1</literal>) indique au processus serveur
    de basculer en mode walsender pour la réplication physique, où un petit
    ensemble de commandes de réplication, montré ci-dessous, peut être exécuté
-   à la place de requêtes SQL. Seul le protocole simple de requêtes peut être
-   utilisé dans le mode walsender.
+   à la place de requêtes SQL.
   </para>
 
   <para>
@@ -1764,7 +1763,7 @@ peut envoyer un message ErrorMessage.
 
   <para>
    En mode <literal>walsender</literal> pour la réplication physique ou pour la
-   réplication logique, seul le protocole d'interrogation simple peut être utilisé.
+   réplication logique, seul le protocole de messages Query simple peut être utilisé.
   </para>
 
   <para>

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -1290,13 +1290,13 @@ SELCT 1/0;<!-- l'erreur est intentionnelle -->
     <varname>client_encoding</varname>,
     <varname>application_name</varname>,
     <varname>is_superuser</varname>,
-    <varname>session_authorization</varname> et
     <varname>session_authorization</varname>,
     <varname>DateStyle</varname>,
     <varname>IntervalStyle</varname>,
-    <varname>TimeZone</varname> et
-    <varname>integer_datetimes</varname>
-    (<varname>server_encoding</varname>, <varname>timezone</varname> et
+    <varname>TimeZone</varname>,
+    <varname>integer_datetimes</varname>, et
+    <varname>standard_conforming_strings</varname>.
+    (<varname>server_encoding</varname>, <varname>TimeZone</varname> et
     <varname>integer_datetimes</varname> n'ont pas été reportés par les
     sorties avant la 8.0&nbsp;; <varname>standard_conforming_strings</varname>
     n'a pas été reporté par les sorties avant la 8.1&nbsp;;

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -3475,7 +3475,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
 
    <varlistentry>
     <term>
-     Bind (F)
+     AuthenticationSASLContinue (B)
     </term>
     <listitem>
      <para>
@@ -3483,11 +3483,11 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
       <variablelist>
        <varlistentry>
         <term>
-         Byte1('B')
+         Byte1('R')
         </term>
         <listitem>
          <para>
-          Marqueur de commande Bind.
+          Identifie le message comme une demande d'authentification.
          </para>
         </listitem>
        </varlistentry>


### PR DESCRIPTION
Quelques corrections au fil de la lecture (pas terminée) ; voir les différents commits pour les explications si besoin.

Au passage, j'ai été un peu perturbé par des variations de terminologie dans la traduction du terme "simple query" (le protocole). On trouve parfois "requête simple" (sans trop savoir si on parle d'une requête simple littéralement ou si on parle du protocole) et parfois on trouve "message Query simple" et peut-être d'autres formules. Si on voulait uniformiser, que choisirait-on ?