### PR TITLE
ddl.xml : relecture de la partie sur le partitionnement, de 5.11.2 à la fin

### DIFF
--- a/postgresql/ddl.xml
+++ b/postgresql/ddl.xml
@@ -4053,13 +4053,13 @@ CREATE TABLE measurement_y2006m02 PARTITION OF measurement
 
     <para>
       Normalement, l'ensemble des partitions établies lors de la définition
-      initiale de la table n'a pas vocation à demeurer statique.  Il est normal
-      de vouloir supprimer d'anciennes partitions de données et périodiquement
-      ajouter de nouvelles partitions pour les nouvelles données. Un des
+      initiale de la table n'a pas vocation à demeurer statique. Il est courant
+      de vouloir supprimer d'anciennes partitions de données et d'ajouter
+      périodiquement de nouvelles partitions pour de nouvelles données. Un des
       avantages les plus importants du partitionnement est précisément qu'il
-      permet d'exécuter cette tâche de maintenance normalement pénible
-      instantanément en manipulant la structure de la partition, plutôt que de
-      physiquement bouger de grands ensembles de données.
+      permet d'exécuter instantanément cette tâche de maintenance normalement pénible,
+      en manipulant la structure partitionnée, plutôt que de
+      bouger physiquement de grands ensembles de données.
     </para>
 
     <para>
@@ -4076,26 +4076,27 @@ DROP TABLE measurement_y2006m02;
    </para>
 
    <para>
-    Une autre possibilité, qui est généralement préférable, est de ne pas supprimer la
-    partition de la table partitionnée, mais de la conserver en tant que table&nbsp;:
+    Une autre possibilité, généralement préférable, est de ne pas supprimer la
+    partition de la table partitionnée, mais de la conserver en tant que table
+    à part entière&nbsp;:
 
     <programlisting>
 ALTER TABLE measurement DETACH PARTITION measurement_y2006m02;
     </programlisting>
 
     Cela permet d'effectuer ensuite d'autres opérations sur les données avant
-    la suppression. Par exemple, il s'agit souvent du moment idéal pour
+    la suppression. Par exemple, c'est souvent le moment idéal pour
     sauvegarder les données en utilisant <command>COPY</command>,
-    <application>pg_dump</application>, ou des outils similaires.  Cela
-    pourrait également être le bon moment pour agréger les données dans un
-    format moins volumineux, effectuer d'autres manipulations de données ou
+    <application>pg_dump</application>, ou des outils similaires.
+    Ce peut aussi être le bon moment pour agréger les données dans un
+    format moins volumineux, effectuer d'autres manipulations des données, ou
     lancer des rapports.
    </para>
 
    <para>
     De la même manière, nous pouvons ajouter une nouvelle partition pour gérer
     les nouvelles données. Nous pouvons créer une partition vide dans la
-    table partitionnée exactement comme la première partition a été créée
+    table partitionnée exactement comme les partitions originales ont été créées
     précédemment&nbsp;:
 
     <programlisting>
@@ -4105,9 +4106,9 @@ CREATE TABLE measurement_y2008m02 PARTITION OF measurement
     </programlisting>
 
     De manière alternative, il est parfois plus pratique de créer la nouvelle
-    table en dehors de la structure de la partition, et d'en faire une
-    vraie partition plus tard.  Cela permet de charger des données, les vérifier et
-    effectuer des transformations avant que les données apparaissent dans la
+    table en dehors de la structure partitionnée, et d'en faire une
+    vraie partition plus tard. Cela permet de charger des données, les vérifier et
+    effectuer des transformations avant qu'elles apparaissent dans la
     table partitionnée&nbsp;:
 
     <programlisting>
@@ -4129,15 +4130,15 @@ ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
    <para>
     Avant d'exécuter une commande <command>ATTACH PARTITION</command>, il est
     recommandé de créer une contrainte <literal>CHECK</literal> sur la table
-    à attacher décrivant la contrainte de partition désirée. De
+    à attacher, correspondant à la contrainte de partition désirée. De
     cette manière, le système n'aura pas besoin d'effectuer un parcours de la
-    table qui est habituellement nécessaire pour valider la contrainte de
+    table, qui est habituellement nécessaire pour valider la contrainte de
     partition implicite. Sans la
     contrainte <literal>CHECK</literal>, la table sera parcourue pour valider
-    la contrainte de partition tout en ayant un verrou de niveau
-    <literal>ACCESS EXCLUSIVE</literal> sur la table parente. Vous pouvez
+    la contrainte de partition, alors qu'elle aura pris un verrou de niveau
+    <literal>ACCESS EXCLUSIVE</literal> sur la table parente. Vous pourrez
     alors supprimer la contrainte <literal>CHECK</literal> redondante après
-    que <command>ATTACH PARTITION</command> soit fini.
+    la fin d'<command>ATTACH PARTITION</command>.
    </para>
 
    <para>
@@ -4182,46 +4183,6 @@ ALTER INDEX measurement_city_id_logdate_key
     </programlisting>
    </para>
 
-   <para>
-    Comme expliqué ci-dessus, il est possible de créer des index sur les
-    tables partitionnées, et ils seront automatiquement appliqués à la
-    hiérarchie complète. Ceci est très pratique car, non seulement les
-    partitions existantes seront indexées, mais aussi toute nouvelle
-    partition le sera. La seule limitation est qu'il n'est pas possible
-    d'utiliser la clause <literal>CONCURRENTLY</literal> lors de la création
-    d'un tel index partitionné. Pour éviter de longues périodes de verrous,
-    il est possible d'utiliser <command>CREATE INDEX ON ONLY</command> sur la
-    table partitionnée&nbsp;; un tel index est marqué invalide et les
-    partitions l'obtiennent pas automatiquement l'index. Les index sur les
-    partitions peuvent être créés séparément en utilisant
-    <literal>CONCURRENTLY</literal>, puis être
-    <firstterm>attachés</firstterm> à l'index sur le parent en utilisant
-    <command>ALTER INDEX .. ATTACH PARTITION</command>. Une fois que les
-    index des partitions sont attachés à l'index parent, l'index parent est
-    marqué valide automatiquement. Par exemple&nbsp;:
-    <programlisting>
-CREATE INDEX measurement_usls_idx ON ONLY measurement (unitsales);
-
-CREATE INDEX measurement_usls_200602_idx
-    ON measurement_y2006m02 (unitsales);
-ALTER INDEX measurement_usls_idx
-    ATTACH PARTITION measurement_usls_200602_idx;
-...
-    </programlisting>
-
-    Cette technique peut aussi être utilisée avec les contraintes
-    <literal>UNIQUE</literal> et <literal>PRIMARY KEY</literal>&nbsp;; les
-    index sont créés implicitement quand la contrainte est créer. Par
-    exemple&nbsp;:
-    <programlisting>
-ALTER TABLE ONLY measurement ADD UNIQUE (city_id, logdate);
-
-ALTER TABLE measurement_y2006m02 ADD UNIQUE (city_id, logdate);
-ALTER INDEX measurement_city_id_logdate_key
-    ATTACH PARTITION measurement_y2006m02_city_id_logdate_key;
-...
-    </programlisting>
-   </para>
   </sect3>
 
   <sect3 id="ddl-partitioning-declarative-limitations">
@@ -4241,16 +4202,16 @@ ALTER INDEX measurement_city_id_logdate_key
 
      <listitem>
       <para>
-       Les contraintes d'unicité sur les tables partitionnées doivent
+       Les contraintes d'unicité (et donc les clés primaires) sur les tables partitionnées doivent
        inclure toutes les colonnes de la clé de partitionnement. Cette
-       limitation existe parce que <productname>PostgreSQL</productname> peut
-       seulement garantir l'unicité dans chaque partition individuelle.
+       limitation existe parce que <productname>PostgreSQL</productname> ne peut
+       garantir l'unicité que dans chaque partition individuellement.
       </para>
      </listitem>
 
      <listitem>
       <para>
-       les triggers <literal>BEFORE ROW</literal> ne peuvent pas changer la
+       Les triggers <literal>BEFORE ROW</literal> ne peuvent pas changer la
        partition de destination d'une nouvelle ligne.
       </para>
      </listitem>
@@ -4276,9 +4237,9 @@ ALTER INDEX measurement_city_id_logdate_key
   <para>
    Bien que le partitionnement déclaratif natif soit adapté pour la plupart
    des cas d'usage courant, il y a certains cas où une approche plus
-   flexible pourrait être utile. Le partitionnement peut être implémenté en
-   utilisant l'héritage de table, ce qui permet plusieurs autres
-   fonctionnalités qui ne sont pas supportées par le partitionnement
+   flexible peut être utile. Le partitionnement peut être implémenté en
+   utilisant l'héritage de table, ce qui permet d'autres
+   fonctionnalités non supportées par le partitionnement
    déclaratif, comme&nbsp;:
 
    <itemizedlist>
@@ -4293,7 +4254,7 @@ ALTER INDEX measurement_city_id_logdate_key
 
     <listitem>
      <para>
-      L'héritage de table permet de multiples héritages.
+      L'héritage de table permet l'héritage multiple.
      </para>
     </listitem>
 
@@ -4303,7 +4264,7 @@ ALTER INDEX measurement_city_id_logdate_key
       par intervalle, par liste et par hachage, tandis que l'héritage de table
       permet de diviser les données de la manière choisie par l'utilisateur.
       (Notez, cependant, que si l'exclusion de contrainte n'est pas en mesure
-      de tailler efficacement les tables filles, la performance de la requête
+      d'élaguer efficacement les tables filles, la performance de la requête
       peut être faible).
      </para>
     </listitem>
@@ -4327,14 +4288,14 @@ ALTER INDEX measurement_city_id_logdate_key
 
    <para>
     Nous utilisons la même table <structname>measurement</structname> non
-    partitionnée que nous avons déjà utilisée au-dessus. Pour l'implémenter
-    le partitionnement en utilisant l'héritage, utilisez les étapes
+    partitionnée que ci-dessus. Pour implémenter
+    le partitionnement par héritage, procédez aux étapes
     suivantes&nbsp;:
 
     <orderedlist spacing="compact">
      <listitem>
       <para>
-       Créez la table <quote>master</quote>, à partir de laquelle toutes les
+       Créez la table <quote>master</quote>, de laquelle toutes les
        tables <quote>filles</quote> hériteront. Cette table ne contiendra aucune donnée.
        Ne définissez aucune contrainte de vérification sur cette table, à
        moins que vous n'ayez l'intention de l'appliquer de manière identique
@@ -4347,11 +4308,11 @@ ALTER INDEX measurement_city_id_logdate_key
 
      <listitem>
       <para>
-       Créez plusieurs tables <quote>enfant</quote> qui chacune hérite de la
-       table master. Normalement, ces tables n'auront aucune colonne
-       supplémentaire par rapport à celles héritées de la table master.
-       Tout comme avec le partitionnement déclaratif, ces tables filles ont
-       tous les aspects des tables (ou tables étrangères)
+       Créez plusieurs tables <quote>enfant</quote>, chacune héritant de la
+       table master. Normalement, ces tables n'ajouteront aucune colonne
+       à celles héritées de la table master.
+       Comme avec le partitionnement déclaratif, ces tables filles sont
+       des tables PostgreSQL à part entière (ou des tables étrangères)
        <productname>PostgreSQL</productname> normales.
       </para>
 
@@ -4369,13 +4330,13 @@ CREATE TABLE measurement_y2008m01 () INHERITS (measurement);
 
      <listitem>
       <para>
-       Ajoutez les contraintes de tables qui ne se chevauchent pas sur les
+       Ajoutez les contraintes de tables, sans qu'elles se chevauchent, sur les
        tables filles pour définir les valeurs de clé autorisées dans
-       chaque table fille.
+       chacune.
       </para>
 
       <para>
-       Les exemples typiques seraient&nbsp;:
+       Des exemples typiques seraient&nbsp;:
        <programlisting>
 CHECK ( x = 1 )
 CHECK ( county IN ( 'Oxfordshire', 'Buckinghamshire', 'Warwickshire' ))
@@ -4438,12 +4399,12 @@ CREATE INDEX measurement_y2008m01_logdate ON measurement_y2008m01 (logdate);
      <listitem>
       <para>
        Nous voulons que notre application soit capable de dire
-       <literal>INSERT INTO measurement ...</literal> et d'avoir les données
-       redirigées dans la table fille appropriée.  Nous pouvons
-       réaliser cela en attachant une fonction de déclencheur convenable sur
+       <literal>INSERT INTO measurement ...</literal>, et de voir ses données
+       redirigées dans la table fille appropriée. Nous pouvons
+       réaliser cela en ajoutant un trigger sur
        la table master. Si les données doivent être ajoutées sur la dernière
-       table fille uniquement, nous pouvons utiliser une fonction de
-       déclencheur très simple&nbsp;:
+       table fille uniquement, nous pouvons utiliser un trigger avec une fonction
+       très simple&nbsp;:
 
        <programlisting>
 CREATE OR REPLACE FUNCTION measurement_insert_trigger()
@@ -4458,7 +4419,7 @@ LANGUAGE plpgsql;
       </para>
 
       <para>
-       Après avoir créé la fonction, nous créons un déclencheur qui appelle
+       Après avoir créé la fonction, nous créons le trigger qui appelle
        la fonction de déclencheur&nbsp;:
 
        <programlisting>
@@ -4467,15 +4428,15 @@ CREATE TRIGGER insert_mesure_trigger
     FOR EACH ROW EXECUTE FUNCTION mesure_insert_trigger();
        </programlisting>
 
-       La fonction déclencheur doit être redéfinie chaque mois pour qu'elle
-       pointe toujours sur la table fille active. La définition du déclencheur
+       Une telle fonction doit être redéfinie chaque mois pour toujours
+       pointer sur la table fille active. La définition du trigger
        n'a pas besoin d'être redéfinie.
       </para>
 
       <para>
        Il est également possible de laisser le serveur localiser la table fille
-       dans laquelle doit être insérée la ligne proposée en entrée. Une
-       fonction déclencheur plus complexe peut être utilisée pour cela &nbsp;:
+       dans laquelle doit être insérée la ligne. Une
+       fonction plus complexe peut alors être utilisée&nbsp;:
 
        <programlisting>
 CREATE OR REPLACE FUNCTION mesure_insert_trigger()
@@ -4500,30 +4461,29 @@ $$
 LANGUAGE plpgsql;
        </programlisting>
 
-       La définition du déclencheur ne change pas. Chaque
+       La définition du déclencheur est la même qu'avant. Notez que chaque
        test <literal>IF</literal> doit correspondre exactement à la
-       contrainte <literal>CHECK</literal> de cette table fille.
+       contrainte <literal>CHECK</literal> de la table fille correspondante.
       </para>
 
       <para>
-       Bien que cette fonction soit plus complexe que celle du mois seul,
+       Bien que cette fonction soit plus complexe que celle pour un seul mois,
        il n'est pas nécessaire de l'actualiser aussi fréquemment, les branches
-       pouvant être ajoutées avant d'être utiles.
+       pouvant être ajoutées en avance.
       </para>
 
       <note>
        <para>
-        En pratique, il pourrait être préférable de vérifier prioritairement la
+        En pratique, il vaudrait mieux vérifier d'abord la
         dernière table fille créée si la plupart des insertions lui sont
-        destinées. Pour des raisons de simplicité, les tests du déclencheur
+        destinées. Pour des raisons de simplicité, les tests du trigger
         sont présentés dans le même ordre que les autres parties de l'exemple.
        </para>
       </note>
 
       <para>
-       Une approche différente est de rediriger les insertions dans la table
-       fille appropriée à l'aide de règles, plutôt qu'un déclencheur,
-       sur la table master. Par exemple&nbsp;:
+       Une approche différente du trigger est la redirection des insertions
+       par des règles sur la table master. Par exemple&nbsp;:
 
        <programlisting>
 CREATE RULE measurement_insert_y2006m02 AS
@@ -4539,11 +4499,11 @@ DO INSTEAD
     INSERT INTO measurement_y2008m01 VALUES (NEW.*);
        </programlisting>
 
-       Une règle à un surcoût bien plus important qu'un trigger, mais le
-       surcoût n'est payé qu'une fois par requête plutôt qu'une fois par
-       ligne, cette méthode peut être avantageuse pour les situations
-       d'insertions en masse. Toutefois, dans la plupart des cas, la méthode
-       du déclencheur offrira de meilleures performances.
+       Une règle a un surcoût bien plus important qu'un trigger, mais
+       il n'est payé qu'une fois par requête plutôt qu'une fois par
+       ligne. Cette méthode peut donc être avantageuse pour les
+       insertions en masse. Toutefois, dans la plupart des cas, la méthode
+       du trigger offrira de meilleures performances.
       </para>
 
       <para>
@@ -4552,13 +4512,13 @@ DO INSTEAD
        copier dans la bonne table fille plutôt que dans la table
        master. <command>COPY</command> déclenche les triggers, vous
        pouvez donc l'utiliser normalement si vous utilisez l'approche par
-       déclencheur.
+       trigger.
       </para>
 
       <para>
        Un autre inconvénient à l'approche par règle est qu'il n'y a pas de
        moyen simple de forcer une erreur si l'ensemble de règles ne couvre
-       pas la date d'insertion; les données iront silencieusement dans la
+       pas la date d'insertion&nbsp;; les données iront silencieusement dans la
        table master à la place.
       </para>
      </listitem>
@@ -4567,8 +4527,8 @@ DO INSTEAD
       <para>
        Assurez-vous que le paramètre de configuration <xref
        linkend="guc-constraint-exclusion"/> ne soit pas désactivé dans
-       <filename>postgresql.conf</filename>.  S'il l'est, les requêtes ne
-       seront pas optimisées comme voulu.
+       <filename>postgresql.conf</filename>&nbsp;; sinon il pourrait y avoir
+       des accès inutiles aux autres tables.
       </para>
      </listitem>
     </orderedlist>
@@ -4576,9 +4536,9 @@ DO INSTEAD
 
    <para>
     Comme nous pouvons le voir, une hiérarchie complexe de tables peut
-    nécessiter une quantité de DDL non négligeable. Dans l'exemple du dessus,
+    nécessiter une quantité de DDL non négligeable. Dans l'exemple ci-dessus,
     nous créerions une nouvelle table fille chaque mois, il serait donc sage
-    d'écrire un script qui génère le DDL requis automatiquement.
+    d'écrire un script qui génère le DDL automatiquement.
    </para>
   </sect3>
 
@@ -4592,15 +4552,15 @@ DO INSTEAD
    </para>
 
    <para>
-    Pour supprimer la table fille de la hiérarchie de tables, mais pour garder
-    l'accès à la table en tant que telle&nbsp;:
+    Pour enlever une table fille de la hiérarchie d'héritage, mais en en gardant
+    l'accès en tant que table normale&nbsp;:
     <programlisting>ALTER TABLE mesure_a2006m02 NO INHERIT mesure;
     </programlisting>
    </para>
 
    <para>
     Pour ajouter une nouvelle table fille pour gérer les nouvelles données,
-    créez une table fille vide tout comme les tables filles originales ont été
+    créez une table fille vide, tout comme les tables filles originales ont été
     créées ci-dessus&nbsp;:
 
     <programlisting>
@@ -4610,7 +4570,7 @@ CREATE TABLE mesure_a2008m02 (
     </programlisting>
 
     Une autre alternative est de créer et de remplir la nouvelle table enfant
-    avant de l'ajouter à la hiérarchie de la table. Ceci pourrait permettre aux
+    avant de l'ajouter à la hiérarchie de la table. Ceci permet aux
     données d'être chargées, vérifiées et transformées avant d'être rendues
     visibles aux requêtes sur la table parente.
 
@@ -4638,7 +4598,7 @@ ALTER TABLE mesure_a2008m02 INHERIT mesure;
        Il n'existe pas de moyen automatique de vérifier que toutes les
        contraintes de vérification (<literal>CHECK</literal>) sont
        mutuellement exclusives. Il est plus sûr de créer un code qui fabrique
-       les tables filles et crée et/ou modifie les objets associés plutôt que de
+       les tables filles, et crée et/ou modifie les objets associés plutôt que de
        les créer manuellement&nbsp;;
       </para>
      </listitem>
@@ -4656,10 +4616,10 @@ ALTER TABLE mesure_a2008m02 INHERIT mesure;
        Les schémas montrés ici supposent que les colonnes clés du
        partitionnement d'une ligne ne changent jamais ou, tout du moins, ne
        changent pas suffisamment pour nécessiter un déplacement vers une autre
-       partition. Une commande  <command>UPDATE</command> qui tente de le
-       faire échoue à cause des contraintes <literal>CHECK</literal>. Pour
-       gérer ce type de cas, des déclencheurs peuvent être convenablement
-       positionnés pour la mise à jour sur les tables filles, mais cela
+       partition. Une commande  <command>UPDATE</command> qui tentera de le
+       faire échouera à cause des contraintes <literal>CHECK</literal>. Si vous
+       devez gérer ce type de cas, des triggers sur mise à jour peuvent être
+       placés sur les tables filles, mais cela
        rend la gestion de la structure beaucoup plus complexe.
       </para>
      </listitem>
@@ -4667,31 +4627,31 @@ ALTER TABLE mesure_a2008m02 INHERIT mesure;
      <listitem>
       <para>
        Si <command>VACUUM</command> ou <command>ANALYZE</command> sont lancés
-       manuellement, il est obligatoire de les utiliser sur chaque table fille.
+       manuellement, n'oubliez pas de les lancer sur chaque table fille.
        Une commande comme&nbsp;:
        <programlisting>
 ANALYZE mesure;
        </programlisting>
-       ne traite que la table maître.
+       ne traitera que la table maître.
       </para>
      </listitem>
 
      <listitem>
       <para>
        Les commandes <command>INSERT</command> avec des clauses <literal>ON
-        CONFLICT</literal> ont probablement peu de chances de fonctionner
-       comme attendu, dans la mesure où l'action du <literal>ON
-        CONFLICT</literal> est uniquement effectuée dans le cas de
-       violations qui sont uniques à la table cible, pas à ses tables filles.
+        CONFLICT</literal> ont peu de chances de fonctionner
+       comme attendu, puisque l'action du <literal>ON
+        CONFLICT</literal> n'est effectuée que dans le cas de
+       violations d'unicité dans la table cible, pas dans les filles.
       </para>
      </listitem>
 
      <listitem>
       <para>
-       Les déclencheurs ou les règles seront nécessaires pour rediriger les
+       Des déclencheurs ou des règles seront nécessaires pour rediriger les
        lignes vers la table fille voulue, à moins que l'application ne soit
-       explicitement au courant du schéma de partitionnement.  Les
-       déclencheurs peuvent être plus compliqués à écrire, et seront bien plus
+       explicitement au courant du schéma de partitionnement. Les
+       déclencheurs peuvent être compliqués à écrire, et seront bien plus
        lents que la redirection de ligne effectuée en interne par le
        partitionnement déclaratif.
       </para>
@@ -4712,17 +4672,17 @@ ANALYZE mesure;
    L'<firstterm>élagage des partitions</firstterm> (<literal>Partition pruning</literal>)
    est une technique d'optimisation des requêtes qui vise à améliorer les
    performances des tables à partitionnement déclaratif.
-   A titre d'exemple&nbsp;:
+   À titre d'exemple&nbsp;:
 
-   <programlisting>SET enable_partition_pruning = on;                 -- the default
+   <programlisting>SET enable_partition_pruning = on;                 -- défaut
 SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';</programlisting>
 
-  Sans l'élagage de partition, la requête ci-dessus parcourerait chacune des
+  Sans l'élagage de partition, la requête ci-dessus parcourrait chacune des
   partitions de la table <structname>mesure</structname>. Avec l'élagage de
-  partition activé, le planificateur examinera la définition de chaque partition
-  et montrera qu'il n'est pas nécessaire de la parcourir car elle ne contient
+  partition activé, le planificateur examinera la définition de chaque partition,
+  et montrera qu'il n'est pas nécessaire de la parcourir puisqu'elle ne contient
   aucune ligne respectant la clause WHERE de la requête. Lorsque le
-  planificateur peut le confirmer, il exclut (élague) la partition du plan de recherche.
+  planificateur peut l'établir, il exclut (élague) la partition du plan de recherche.
 
  </para>
 
@@ -4755,10 +4715,9 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
 
    Quelques partitions, voire toutes, peuvent utiliser des parcours d'index
    à la place des parcours séquentiels de la table complète, mais le fait est
-   qu'il n'est pas besoin de parcourir les anciennes partitions pour répondre
-   à cette requête. Lorsque l'exclusion de contrainte est activée,
-   un plan significativement moins coûteux est obtenu, qui délivre la même
-   réponse&nbsp;:
+   qu'il n'est pas besoin de parcourir les plus vieilles partitions pour répondre
+   à cette requête. Lorsque l'élagage de partitions est activée, nous obtenons
+   un plan significativement moins coûteux, pour le même résultat&nbsp;:
 
    <programlisting>SET enable_partition_pruning = on;
 EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
@@ -4773,31 +4732,31 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
    <para>
     Il est à noter que l'élagage des partitions n'est piloté que par les
     contraintes définies implicitement par les clés de partition, et non par
-    la présence d'index&nbsp;: il n'est donc pas nécessaire de définir des index
-    sur les colonnes clés. Pour savoir si un index doit être créé pour une partition donnée,
+    la présence d'index. Il n'est donc pas nécessaire de définir des index
+    sur les colonnes clés. Pour savoir si un index doit être créé sur une partition donnée,
     il vous faut juger si les requêtes sur
-    cette partition en parcourent généralement une grande
-    ou seulement une petite partie. Un index sera utile dans ce dernier
+    cette partition en parcourent généralement une grande partie,
+    ou seulement une petite. Un index sera utile dans ce dernier
     cas, mais pas dans le premier.
    </para>
 
    <para>
     L'élagage des partitions peut être effectué non seulement lors de la
-    planification d'une requête, mais aussi lors de son exécution. Ceci est
-    utile car cela peut permettre d'élaguer plus de partitions lorsque les
-    clauses contiennent des expressions dont les valeurs ne sont pas connues
+    planification d'une requête, mais aussi lors de son exécution. C'est
+    utile pour élaguer plus de partitions lorsque les
+    clauses contiennent des expressions de valeurs inconnues
     au moment de la planification de la requête, par exemple des paramètres
     définis dans une instruction <command>PREPARE</command>, utilisant une
-    valeur obtenue d'une sous-requête, ou utilisant une valeur paramétrée sur
-    la partie interne du n&oelig;ud de boucle imbriqué (<literal>nested loop join</literal>.
-    L'élagage de la partition pendant l'exécution peut être réalisé à l'un des
+    valeur obtenue d'une sous-requête, ou une valeur paramétrée sur
+    la partie interne d'une jointure en boucle imbriquée (<literal>nested loop join</literal>).
+    L'élagage de partition pendant l'exécution peut être réalisé à l'un des
     moments suivant&nbsp;:
 
     <itemizedlist>
      <listitem>
       <para>
        Lors de l'initialisation du plan d'exécution. L'élagage de partition peut
-       être effectué pour les valeurs de paramètres déjà connues à
+       être effectué pour les valeurs de paramètres connues dès
        cette phase. Les partitions élaguées pendant cette étape
        n'apparaîtront pas dans l'<command>EXPLAIN</command> ou l'<command>EXPLAIN
        ANALYZE</command> de la requête. Il est même possible de
@@ -4809,12 +4768,12 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
 
      <listitem>
       <para>
-       Pendant l'exécution réelle du plan d'exécution. L'élagage des partitions
+       Pendant l'exécution effective du plan d'exécution. L'élagage des partitions
        peut également être effectué pour supprimer des partitions en utilisant
        des valeurs qui ne sont connues que pendant l'exécution de la requête.
-       Cela inclut les valeurs des sous-requêtes et les valeurs utilisées
-       pendant la recherche comme lors des n&oelig;uds de boucle imbriqué
-       (<literal>nested loop join</literal>).
+       Cela inclut les valeurs des sous-requêtes et des paramètres issus 
+       de l'exécution, comme des jointures par boucle imbriquée
+       (<literal>nested loop join</literal>) paramétrées.
        Comme la valeur de ces paramètres peut changer plusieurs fois pendant
        l'exécution de la requête, l'élagage de partitions est effectué chaque
        fois que l'un des paramètres d'exécution utilisés pour celui-ci change.
@@ -4832,7 +4791,7 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
    </para>
 
    <para>
-    L'élagage des partitions peut être désactivée à l'aide du paramètre <xref
+    L'élagage des partitions peut être désactivé à l'aide du paramètre <xref
     linkend="guc-enable-partition-pruning"/>.
    </para>
 
@@ -4841,7 +4800,7 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
       L'élagage de partitions au moment de l'exécution survient seulement pour
       les types de n&oelig;ud <literal>Append</literal> et
       <literal>MergeAppend</literal>. Ce n'est pas encore implémenté pour
-      <literal>ModifyTable</literal> mais ceci pourrait changer dans une
+      <literal>ModifyTable</literal>, mais ceci pourrait changer dans une
       prochaine version de <productname>PostgreSQL</productname>.
     </para>
    </note>
@@ -4855,28 +4814,28 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
    </indexterm>
 
    <para>
-    Les <firstterm>contraintes d'exclusion</firstterm> sont une technique
-    d'optimisation de requêtes similaire à l'élagage de partitions. Bien qu'il
-    soit principalement utilisé pour les tables partitionnées à l'aide de la
-    méthode par héritage, il peut être utilisé à d'autres fins, y compris avec
+    Une <firstterm>contrainte d'exclusion</firstterm> est une technique
+    d'optimisation de requêtes similaire à l'élagage de partitions. Bien qu'elle
+    soit principalement utilisé pour les tables partitionnées avec l'ancienne
+    méthode par héritage, elle peut être utilisée à d'autres fins, y compris avec
     le partitionnement déclaratif.
    </para>
 
    <para>
     Les contraintes d'exclusion fonctionnent d'une manière très similaire à
-    l'élagage de partitions, sauf qu'elle utilise les contraintes
-    <literal>CHECK</literal> de chaque table (d'où son nom) alors que l'élagage
-    de partition utilise les limites de partition de la table, qui n'existe que
-    dans le cas d'un partitionnement déclaratif. Une autre différence est que
-    la contrainte d'exclusion n'est appliquée qu'au moment de la planification
-    du plan d'excution&nbsp;; il n'y a donc pas de tentative de suppression de
-    partitions au moment de l'exécution.
+    l'élagage de partitions, sauf qu'elles utilisent les contraintes
+    <literal>CHECK</literal> de chaque table (d'où le nom) alors que l'élagage
+    de partition utilise les limites de partition de la table, qui n'existent que
+    dans le cas d'un partitionnement déclaratif. Une autre différence est qu'une
+    contrainte d'exclusion n'est appliquée qu'à la planification&nbsp;;
+    il n'y a donc pas de tentative d'écarter des
+    partitions dès l'exécution.
    </para>
 
    <para>
-    Du fait que les contraintes d'exclusion utilisent la contrainte
-    <literal>CHECK</literal>, ceci la rend plus lente par rapport à l'élagage
-    de partitions. Néamoins, il peut parfois être utilisé comme un avantage&nbsp;:
+    Le fait que les contraintes d'exclusion utilisent les contraintes
+    <literal>CHECK</literal> les rend plus lentes que l'élagage
+    de partitions, mais peut être un avantage&nbsp;:
     puisque les contraintes peuvent être définies même sur des tables avec
     partitionnement déclaratif, en plus de leurs limites internes, les contraintes
     d'exclusion peuvent être capables de supprimer des partitions supplémentaires
@@ -4887,10 +4846,10 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     La valeur par défaut (et donc recommandée) de <xref
     linkend="guc-constraint-exclusion"/> n'est ni <literal>on</literal> ni
     <literal>off</literal>, mais un état intermédiaire appelé
-    <literal>partition</literal>, qui fait que la technique est appliquée
-    seulement aux requêtes qui semblent fonctionner avec des tables
-    partitionnées. La valeur <literal>on</literal> fait que le planificateur
-    examine les contraintes <literal>CHECK</literal> dans chaque requête, y
+    <literal>partition</literal>, qui fait que la technique n'est appliquée
+    qu'aux requêtes qui semblent fonctionner avec des tables
+    partitionnées par héritage. La valeur <literal>on</literal> entraîne que le planificateur
+    examine les contraintes <literal>CHECK</literal> dans toutes les requêtes, y
     compris les requêtes simples qui ont peu de chance d'en profiter.
    </para>
 
@@ -4902,7 +4861,7 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     <para>
      Les contraintes d'exclusion ne sont appliquées que lors de la phase de
      planification de la requête, contrairement à l'élagage de partition,
-     qui peut être appliqué lors de la phase d'exécution de la requête.
+     qui peut être appliqué lors de la phase d'exécution.
     </para>
    </listitem>
 
@@ -4910,8 +4869,8 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     <para>
      La contrainte d'exclusion ne fonctionne que si la clause
      <literal>WHERE</literal> de la requête contient des constantes (ou des
-     paramètres externes). Par exemple, une comparaison entre une fonction
-     non immutable telle que <function>CURRENT_TIMESTAMP</function> ne peut
+     paramètres externes). Par exemple, une comparaison avec une fonction
+     non immutable comme <function>CURRENT_TIMESTAMP</function> ne peut
      pas être optimisée, car le planificateur ne peut pas savoir dans quelle
      table fille la valeur de la fonction ira lors de l'exécution.
     </para>
@@ -4919,16 +4878,16 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
 
    <listitem>
     <para>
-     Les contraintes de partitionnement doivent rester simples.  Dans le cas
+     Les contraintes de partitionnement doivent rester simples. Dans le cas
      contraire, le planificateur peut rencontrer des difficultés à déterminer
-     les tables filles qu'il n'est pas nécessaire de parcourir.  Des conditions
-     simples d'égalité pour le partitionnement de liste ou des tests
+     les tables filles qu'il n'est pas nécessaire de parcourir. Des conditions
+     simples d'égalité pour le partitionnement de liste, ou des tests
      d'intervalle simples lors de partitionnement par intervalles sont
-     recommandées, comme cela est illustré dans les exemples précédents. Une
-     bonne règle consiste à s'assurer que les comparaisons entre colonnes de
-     partitionnement et constantes utilisées par les contraintes de
-     partitionnement se fassent uniquement à l'aide d'opérateurs utilisables
-     par les index B-tree car seules les colonnes indexables avec un index
+     recommandées, comme illustré dans les exemples précédents. Une
+     règle générale est que les contraintes de partitionnement ne
+     doivent contenir que des comparaisons entre les colonnes partitionnées 
+     et des constantes, à l'aide d'opérateurs utilisables
+     par les index B-tree, car seules les colonnes indexables avec un index
      B-tree sont autorisées dans la clé de partitionnement.
     </para>
    </listitem>
@@ -4937,10 +4896,10 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     <para>
      Toutes les contraintes sur toutes les filles de la table parente sont
      examinées lors de l'exclusion de contraintes. De ce fait, un grand nombre
-     des filles augmente considérablement le temps de
-     planification de la requête. Ainsi, le partitionnement basé sur l'héritage
-     fonctionnera bien jusqu'à une centaine de tables enfant&nbsp;; n'essayez
-     pas d'utiliser plusieurs milliers d'enfants.
+     de filles augmente considérablement le temps de
+     planification de la requête. Ainsi, l'ancien partitionnement par héritage
+     fonctionnera bien jusqu'à, peut-être, une centaine de tables enfant&nbsp;; n'essayez
+     pas d'en utiliser plusieurs milliers.
     </para>
    </listitem>
 
@@ -4963,7 +4922,7 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     lesquelles vous partitionnerez. Souvent le meilleur choix sera la
     colonne ou l'ensemble de colonnes qui apparaissent le plus souvent
     dans les clauses <literal>WHERE</literal> des requêtes exécutées sur
-    la table.
+    la table partitionnée.
     Les clauses <literal>WHERE</literal> portant sur la clé de partitionnement
     et compatibles avec elle peuvent être utilisées pour élaguer les
     partitions inutiles. Cependant, le choix peut vous être imposé par
@@ -4978,17 +4937,17 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
    </para>
 
    <para>
-    Choisir le nombre cible de partitions par lequel la table sera divisée
+    Choisir le nombre cible de partitions par lequel diviser la table
     est aussi une décision critique à prendre.
     Ne pas avoir assez de partitions peut signifier que les index resteront
-    trop gros et que la localité des données restera faible, ce qui entraînera
+    trop gros, et que la localité des données restera faible, ce qui entraînera
     de mauvais <foreignphrase>hit ratios</foreignphrase>.
     Cependant, diviser la table en trop de partitions a aussi ses inconvénients.
     Trop de partitions peuvent entraîner des temps de planification plus longs
     et une plus grande consommation de mémoire pendant la planification comme
     pendant l'exécution.
     Lors du choix du partitionnement de votre table, il est aussi important de
-    considérer ce qui va changer dans le futur.
+    considérer ce qui pourrait changer dans le futur.
     Par exemple, si vous choisissez d'avoir une partition par client alors que vous n'avez
     actuellement qu'un petit nombre de gros clients, considérez les implications
     si, dans quelques années, vous vous retrouvez avec un grand nombre de
@@ -5003,7 +4962,7 @@ EXPLAIN SELECT count(*) FROM mesure WHERE date_trace &gt;= DATE '2008-01-01';
     Sous-partitionner peut être utile pour diviser encore des partitions qui
     devraient devenir plus grandes que d'autres partitions, bien qu'un
     sous-partitionnement excessif puisse facilement mener à un grand nombre
-    de partitions et puisse causer les mêmes problèmes que mentionnés au
+    de partitions, et puisse causer les mêmes problèmes que évoqués au
     paragraphe précédent.
    </para>
 


### PR DESCRIPTION
Relecture de toute la partie.

Au début il s'agissait de supprimer un passage qui bégayait (copié-collé malheureux ?). Finalement j'ai relu toute la fin du fichier, tenté d'alléger des formulations, remis d'équerre quelques phrases qui s'étaient écartées de la VO, et remplacé "déclencheur" par "trigger".