### PR TITLE
Pgbench : trad vs 14ß1

### DIFF
--- a/postgresql/ref/pgbench.xml
+++ b/postgresql/ref/pgbench.xml
@@ -73,8 +73,7 @@ tps = 896.967014 (without initial connection time)
    Ils seront équivalents à moins que l'exécution ait échoué avant la fin.
    (Avec le mode <option>-T</option>, seul le nombre réel de transactions
    est affiché.)
-   La dernière ligne indique le nombre de transactions par
-   secondes.
+   La dernière ligne indique le nombre de transactions par seconde.
   </para>
 
   <para>
@@ -1175,7 +1174,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       <row>
        <entry> <literal>default_seed</literal> </entry>
        <entry>graine utilisée par défaut dans les fonctions de hachage
-        et de permutation pseudo aléatoire</entry>
+        et de permutation pseudo-aléatoire</entry>
       </row>
 
       <row>
@@ -1215,25 +1214,26 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       </para>
 
       <para>
-       Quand the <literal>\gset</literal> command est utilisée, la requête SQL précédente doit
-       renvoyer une ligne, dont les valeurs des colonnes sont enregistrées dans
-       des variables nommées d'après les noms des colonnes et préfixées avec
-       <replaceable>prefix</replaceable> si ce dernier argument est fourni.
+       Quand <literal>\gset</literal> command est utilisée, la requête SQL précédente doit
+       renvoyer une ligne. Les valeurs de ses colonnes sont enregistrées dans
+       des variables nommées d'après les noms des colonnes, et préfixées avec
+       <replaceable>prefix</replaceable>, si ce dernier est fourni.
       </para>
 
       <para>
-       When the <literal>\aset</literal> command is used, all combined SQL queries
-       (separated by <literal>\;</literal>) have their columns stored into variables
-       named after column names, and prefixed with <replaceable>prefix</replaceable>
-       if provided. If a query returns no row, no assignment is made and the variable
-       can be tested for existence to detect this. If a query returns more than one
-       row, the last value is kept.
+       Quand <literal>\aset</literal> est utilisé, toutes les requêtes
+       (séparées par <literal>\;</literal>) voient leurs colonnes stockées dans
+       des variables nommées d'après elles, et préfixées de <replaceable>prefix</replaceable>
+       s'il est fourni.
+       Si une requête ne retourne aucune ligne, aucune affectation n'est faite.
+       Il faut tester l'existence de la variable pour détecter ce cas.
+       Si une requête retourne plus d'une ligne, la dernière valeur est conservée.
       </para>
 
       <para>
-       <literal>\gset</literal> and <literal>\aset</literal> cannot be used in
-       pipeline mode, since the query results are not yet available by the time
-       the commands would need them.
+       <literal>\gset</literal> et <literal>\aset</literal> ne peuvent être
+       utilisée en mode pipeline, puisque les résultats des requêtes ne sont pas encore
+       disponible au moment où la commande en a besoin.
       </para>
 
       <para>
@@ -1241,9 +1241,10 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
        première requête dans la variable <replaceable>abalance</replaceable>,
        et remplit les variables <replaceable>p_two</replaceable> et
        <replaceable>p_three</replaceable> avec les entiers provenant de la
-       troisième requête. Les résultats de la deuxième requête sont ignorés.
-       The result of the two last combined queries are stored in variables
-       <replaceable>four</replaceable> and <replaceable>five</replaceable>.
+       troisième requête. Le résultat de la deuxième requête est ignoré.
+       Les résultats des deux dernières requêtes combinées sont stockées dans
+       les variables
+       <replaceable>four</replaceable> et <replaceable>five</replaceable>.
        <programlisting>
 UPDATE pgbench_accounts
   SET abalance = abalance + :delta
@@ -1420,11 +1421,11 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
  
      <listitem>
        <para>
-         These commands delimit the start and end of a pipeline of SQL
-         statements.  In pipeline mode, statements are sent to the server
-         without waiting for the results of previous statements.  See
-         <xref linkend="libpq-pipeline-mode"/> for more details.
-         Pipeline mode requires the use of extended query protocol.
+         Ces commandes définissent le début et la fin de requêtes SQL.
+         En mode pipeline, celles-ci sont envoyées au serveur sans attendre le
+         résultat des requêtes précédentes.
+         Voir <xref linkend="libpq-pipeline-mode"/> pour plus de détails.
+         Le mode pipeline impose l'utilisation du protocole de requête étendu.
       </para>
      </listitem>
     </varlistentry>
@@ -2006,19 +2007,20 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 
       <row>
        <entry role="func_table_entry"><para role="func_signature">
-        <function>permute</function> ( <parameter>i</parameter>, <parameter>size</parameter> [, <parameter>seed</parameter> ] )
+        <function>permute</function> ( <parameter>i</parameter>, <parameter>taille</parameter> [, <parameter>graine</parameter> ] )
         <returnvalue>integer</returnvalue>
        </para>
        <para>
-        Permuted value of <parameter>i</parameter>, in the range
-        <literal>[0, size)</literal>.  This is the new position of
-        <parameter>i</parameter> (modulo <parameter>size</parameter>) in a
-        pseudorandom permutation of the integers <literal>0...size-1</literal>,
-        parameterized by <parameter>seed</parameter>, see below.
+        Valeur permutée de <parameter>i</parameter>, dans la tranche
+        <literal>[0, taille)</literal>,
+        soit la nouvelle position de <parameter>i</parameter>
+        (modulo <parameter>taille</parameter>) dans une permutation
+        pseudo-aléatoire des entiers <literal>0...taille-1</literal>,
+        paramétrée par la <parameter>graine</parameter> (voir plus bas).
        </para>
        <para>
         <literal>permute(0, 4)</literal>
-        <returnvalue>an integer between 0 and 3</returnvalue>
+        <returnvalue>un entier entre 0 and 3</returnvalue>
        </para></entry>
       </row>
 
@@ -2071,7 +2073,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 
       <row>
        <entry role="func_table_entry"><para role="func_signature">
-         <function>random_exponential</function> ( <parameter>lb</parameter>, <parameter>ub</parameter>, <parameter>parameter</parameter> )
+         <function>random_exponential</function> ( <parameter>lb</parameter>, <parameter>ub</parameter>, <parameter>paramètre</parameter> )
          <returnvalue>entier</returnvalue>
         </para>
         <para>
@@ -2086,7 +2088,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 
       <row>
        <entry role="func_table_entry"><para role="func_signature">
-         <function>random_gaussian</function> ( <parameter>lb</parameter>, <parameter>ub</parameter>, <parameter>parameter</parameter> )
+         <function>random_gaussian</function> ( <parameter>lb</parameter>, <parameter>ub</parameter>, <parameter>paramètre</parameter> )
          <returnvalue>entier</returnvalue>
         </para>
         <para>
@@ -2101,7 +2103,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 
       <row>
        <entry role="func_table_entry"><para role="func_signature">
-         <function>random_zipfian</function> ( <parameter>lb</parameter>, <parameter>ub</parameter>, <parameter>parameter</parameter> )
+         <function>random_zipfian</function> ( <parameter>lb</parameter>, <parameter>ub</parameter>, <parameter>paramètre</parameter> )
          <returnvalue>entier</returnvalue>
         </para>
         <para>
@@ -2110,7 +2112,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
         </para>
         <para>
          <literal>random_zipfian(1, 10, 1.5)</literal>
-         <returnvalue>an integer between 1 and 10</returnvalue>
+         <returnvalue>une valeur entre 1 and 10</returnvalue>
         </para></entry>
       </row>
 
@@ -2145,12 +2147,12 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
     <listitem>
      <para>
       Pour une distribution exponentielle,
-      <replaceable>parameter</replaceable> contrôle la distribution en
+      <replaceable>paramètre</replaceable> contrôle la distribution en
       tronquant une distribution exponentielle en décroissance rapide à
-      <replaceable>parameter</replaceable>, puis en projetant le résultant sur
+      <replaceable>paramètre</replaceable>, puis en projetant le résultant sur
       des entiers entre les limites. Pour être précis&nbsp;:
       <literallayout>
-       f(x) = exp(-parameter * (x - min) / (max - min + 1)) / (1 - exp(-parameter))
+       f(x) = exp(-paramètre * (x - min) / (max - min + 1)) / (1 - exp(-paramètre))
       </literallayout>
       Puis la valeur <replaceable>i</replaceable> entre les valeurs
       <replaceable>min</replaceable> et <replaceable>max</replaceable>, en les
@@ -2159,16 +2161,16 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
      </para>
 
      <para>
-      Intuitivement, plus <replaceable>parameter</replaceable> est grand, plus
+      Intuitivement, plus <replaceable>paramètre</replaceable> est grand, plus
       les valeurs fréquentes proches de <replaceable>min</replaceable> sont
       accédées et moins les valeurs fréquentes proches de
       <replaceable>max</replaceable> sont accédées. Plus
-      <replaceable>parameter</replaceable> est proche de 0, plus la
+      <replaceable>paramètre</replaceable> est proche de 0, plus la
       distribution d'accès sera plate (uniforme). Une approximation grossière de
       la distribution est que 1% des valeurs les plus fréquentes de
       l'intervalle, proches de <replaceable>min</replaceable>, sont tirées
-      <replaceable>parameter</replaceable>% du temps. La valeur de
-      <replaceable>parameter</replaceable> doit être strictement positive.
+      <replaceable>paramètre</replaceable>% du temps. La valeur de
+      <replaceable>paramètre</replaceable> doit être strictement positive.
      </para>
     </listitem>
 
@@ -2176,46 +2178,46 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
      <para>
       Pour une distribution gaussienne, l'intervalle correspond à une
       distribution normale standard (la courbe gaussienne classique en forme
-      de cloche) tronquée à <literal>-parameter</literal> à gauche et à
-      <literal>+parameter</literal> à droite.
+      de cloche) tronquée à <literal>-paramètre</literal> à gauche et à
+      <literal>+paramètre</literal> à droite.
       Les valeurs au milieu de l'intervalle sont plus
       susceptibles d'être sélectionnées. Pour être précis, si
       <literal>PHI(x)</literal> est la fonction de distribution cumulative de
       la distribution normale standard, avec une moyenne <literal>mu</literal>
       définie comme <literal>(max + min) / 2.0</literal>, avec
       <literallayout>
-       f(x) = PHI(2.0 * parameter * (x - mu) / (max - min + 1)) /
-       (2.0 * PHI(parameter) - 1)
+       f(x) = PHI(2.0 * paramètre * (x - mu) / (max - min + 1)) /
+       (2.0 * PHI(paramètre) - 1)
       </literallayout>
       alors la valeur <replaceable>i</replaceable> entre
       <replaceable>min</replaceable> et <replaceable>max</replaceable>
       (inclus) est sélectionnée avec une probabilité&nbsp;:
       <literal>f(i + 0.5) - f(i - 0.5)</literal>. Intuitivement, plus
-      <replaceable>parameter</replaceable> est grand, et plus les valeurs
+      <replaceable>paramètre</replaceable> est grand, et plus les valeurs
       fréquentes proches du centre de l'intervalle sont sélectionnées, et
       moins les valeurs fréquentes proches des bornes
       <replaceable>min</replaceable> et <replaceable>max</replaceable>.
       Environ 67% des valeurs sont sélectionnées à partir du centre
-      <literal>1.0 / parameter</literal>, soit
-      <literal>0.5 / parameter</literal> autour de la moyenne, et 95% dans le
-      centre <literal>2.0 / parameter</literal>, soit
-      <literal>1.0 / parameter</literal> autour de la moyenne&nbsp;; par
-      exemple, si <replaceable>parameter</replaceable> vaut 4.0, 67% des
+      <literal>1.0 / paramètre</literal>, soit
+      <literal>0.5 / paramètre</literal> autour de la moyenne, et 95% dans le
+      centre <literal>2.0 / paramètre</literal>, soit
+      <literal>1.0 / paramètre</literal> autour de la moyenne&nbsp;; par
+      exemple, si <replaceable>paramètre</replaceable> vaut 4.0, 67% des
       valeurs sont sélectionnées depuis le quart du milieu (1.0 / 4.0) de
       l'intervalle (ou à partir de <literal>3.0 / 8.0</literal> jusqu'à
       <literal>5.0 / 8.0</literal>) et 95% depuis la moitié du milieu
       (<literal>2.0 / 4.0</literal>) de l'intervalle (deuxième et troisième
-      quartiles). La valeur minimale autorisée pour <replaceable>parameter</replaceable>
+      quartiles). La valeur minimale autorisée pour <replaceable>paramètre</replaceable>
       est 2.0.
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>random_zipfian</literal> generates a bounded Zipfian
-      distribution.
-      <replaceable>parameter</replaceable>
+      <literal>random_zipfian</literal> génère une distribution bornée
+      selon la loi de Zipf.
+      <replaceable>paramètre</replaceable>
       définit à quel point la distribution est biaisée. Plus
-      <replaceable>parameter</replaceable> est grand, plus fréquemment les
+      <replaceable>paramètre</replaceable> est grand, plus fréquemment les
       valeurs du début de l'intervalle seront tirées.
       La distribution est telle que, en supposant que l'intervalle commence à
       1, le ratio de probabilité d'un jet <replaceable>k</replaceable> contre
@@ -2231,7 +2233,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
       L'implémentation de <application>pgbench</application> est basée sur
       «&nbsp;Non-Uniform Random Variate Generation&nbsp;», Luc Devroye, p. 550-551,
       Springer 1986. À cause des limitations de cet algorithme, la valeur
-      <replaceable>parameter</replaceable> est restreinte à l'intervalle
+      <replaceable>paramètre</replaceable> est restreinte à l'intervalle
       [1.001, 1000].
      </para>
     </listitem>
@@ -2239,15 +2241,16 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 
    <note>
     <para>
-      When designing a benchmark which selects rows non-uniformly, be aware
-      that the rows chosen may be correlated with other data such as IDs from
-      a sequence or the physical row ordering, which may skew performance
-      measurements.
+      Lors de la conception d'un benchmark qui sélectionne des lignes de
+      manière non-uniforme, soyez conscient que les lignes choisies peuvent
+      être corrélées avec d'autres données, comme les ID d'une séquence ou
+      l'ordre physique des lignes, ce qui peut biaiser les mesures de
+      performance.
     </para>
     <para>
-      To avoid this, you may wish to use the <function>permute</function>
-      function, or some other additional step with similar effect, to shuffle
-      the selected rows and remove such correlations.
+      Pour éviter cela, pensez à la fonction <function>permute</function>,
+      ou tout autre opération avec le même effet, pour mélanger les lignes
+      sélectionnées et détruire ces corrélations.
     </para>
    </note>
 
@@ -2291,7 +2294,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 \set k2 1 + permute(:r, :size, :default_seed + 321)
     </programlisting>
 
-    A similar behavior can also be approximated with <function>hash</function>:
+    Un comportement similaire peut être approché avec <function>hash</function>&nbsp;:
 
 <programlisting>
 \set size 1000000
@@ -2299,14 +2302,14 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
 \set k 1 + abs(hash(:r)) % :size
 </programlisting>
 
-    However, since <function>hash</function> generates collisions, some values
-    will not be reachable and others will be more frequent than expected from
-    the original distribution.
+    Cependant, comme <function>hash</function> génère des collisions,
+    certaines valeurs ne sont pas atteignables, et d'autres seront plus fréquentes
+    qu'attendues par rapport à la distribution originale.
    </para>
 
    <para>
-    En tant qu'exemple, la définition complète de la construction
-    de la transaction style TPC-B est&nbsp;:
+    À titre d'exemple, la définition complète de la transaction style TPC-B
+    intégrée est&nbsp;:
 
     <programlisting>
    \set aid random(1, 100000 * :scale)

--- a/postgresql/ref/pgbench.xml
+++ b/postgresql/ref/pgbench.xml
@@ -2264,21 +2264,24 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
    </para>
 
    <para>
-     <literal>permute</literal> accepts an input value, a size, and an optional
-     seed parameter.  It generates a pseudorandom permutation of integers in
-     the range <literal>[0, size)</literal>, and returns the index of the input
-     value in the permuted values.  The permutation chosen is parameterized by
-     the seed, which defaults to <literal>:default_seed</literal>, if not
-     specified.  Unlike the hash functions, <literal>permute</literal> ensures
-     that there are no collisions or holes in the output values.  Input values
-     outside the interval are interpreted modulo the size.  The function raises
-     an error if the size is not positive.  <function>permute</function> can be
-     used to scatter the distribution of non-uniform random functions such as
-     <literal>random_zipfian</literal> or <literal>random_exponential</literal>
-     so that values drawn more often are not trivially correlated.  For
-     instance, the following <application>pgbench</application> script
-     simulates a possible real world workload typical for social media and
-     blogging platforms where a few accounts generate excessive load:
+     <literal>permute</literal> accepte en entrée une valeur, une taille,
+     et une graine optionnelle. Elle génère une permutation
+     pseudo-aléatoire des entiers dans la tranche <literal>[0, taille)</literal>,
+     et retourne l'index de la valeur d'entrée dans les valeurs permutées.
+     La permutation choisie est paramétrée par la graine, soit par défaut
+     <literal>:default_seed</literal> si elle n'est pas fournie.
+     Au contraire des fonctions de hachage, <literal>permute</literal>
+     garantit qu'il n'y aura ni collision ni trou dans les valeurs retournées.
+     Les valeurs d'entrée hors de l'intervalle sont interprétées modulo
+     la taille. La fonction lève une erreur si la taille n'est pas positive.
+     <function>permute</function> peut être utilisée pour disperser
+     la distribution de fonctions aléatoires non uniformes comme
+     <literal>random_zipfian</literal> ou <literal>random_exponential</literal>,
+     afin que les valeurs les plus couramment tirées ne soient pas corrélées
+     de manière triviale. Par exemple, le script <application>pgbench</application>
+     suivant simule une charge réaliste typique des médias sociaux et
+     des plateformes de blogs, où quelques comptes génèrent une charge
+     excessive :
     <programlisting>
 \set size 1000000
 \set r random_zipfian(1, :size, 1.07)

--- a/postgresql/ref/pgbench.xml
+++ b/postgresql/ref/pgbench.xml
@@ -1132,7 +1132,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
     Il est possible de procéder facilement à de la substitution de variables
     dans les fichiers scripts.
     Les noms de variables doivent consister en lettres (y compris des caractères
-    non-Latin), chiffres et soulignés (<literal>_</literal>), mais le premier
+    non latins), chiffres et soulignés (<literal>_</literal>), mais le premier
     caractère ne doit pas être un chiffre.
     Les variables peuvent être instanciées via
     l'option <option>-D</option> de la ligne de commande comme décrit ci-dessus,
@@ -1214,26 +1214,27 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
       </para>
 
       <para>
-       Quand <literal>\gset</literal> command est utilisée, la requête SQL précédente doit
-       renvoyer une ligne. Les valeurs de ses colonnes sont enregistrées dans
-       des variables nommées d'après les noms des colonnes, et préfixées avec
+       Quand la commande <literal>\gset</literal> command est utilisée,
+       la requête SQL précédente doit renvoyer une ligne.
+       Les valeurs de ses colonnes sont enregistrées dans
+       des variables nommées d'après les noms de colonnes, préfixées avec
        <replaceable>prefix</replaceable>, si ce dernier est fourni.
       </para>
 
       <para>
-       Quand <literal>\aset</literal> est utilisé, toutes les requêtes
+       Quand la commande <literal>\aset</literal> est utilisée, toutes les requêtes
        (séparées par <literal>\;</literal>) voient leurs colonnes stockées dans
-       des variables nommées d'après elles, et préfixées de <replaceable>prefix</replaceable>
+       des variables nommées d'après elles, préfixées de <replaceable>prefix</replaceable>
        s'il est fourni.
        Si une requête ne retourne aucune ligne, aucune affectation n'est faite.
-       Il faut tester l'existence de la variable pour détecter ce cas.
+       On peut tester l'existence de la variable pour détecter ce cas.
        Si une requête retourne plus d'une ligne, la dernière valeur est conservée.
       </para>
 
       <para>
        <literal>\gset</literal> et <literal>\aset</literal> ne peuvent être
-       utilisée en mode pipeline, puisque les résultats des requêtes ne sont pas encore
-       disponible au moment où la commande en a besoin.
+       utilisées en mode pipeline, puisque les résultats des requêtes ne sont pas
+       encore disponibles au moment où la commande en a besoin.
       </para>
 
       <para>
@@ -2242,7 +2243,7 @@ SELECT 4 AS four \; SELECT 5 AS five \aset
    <note>
     <para>
       Lors de la conception d'un benchmark qui sélectionne des lignes de
-      manière non-uniforme, soyez conscient que les lignes choisies peuvent
+      manière non uniforme, soyez conscient que les lignes choisies peuvent
       être corrélées avec d'autres données, comme les ID d'une séquence ou
       l'ordre physique des lignes, ce qui peut biaiser les mesures de
       performance.


### PR DESCRIPTION
+ Traduction des nouveautés

+ 1 ligne oubliée

+ remplacé "parameter" par "paramètre" pour les arguments de fonction, mais je ne suis pas certain que ce soit une bonne idée, ou simplement cohérent avec d'autres pages