### PR TITLE
install-windows.xml - 14β2 

### DIFF
--- a/postgresql/install-windows.xml
+++ b/postgresql/install-windows.xml
@@ -13,53 +13,53 @@
   distribution binaire pour Windows, disponible sous la forme d'un package
   d'installation graphique à partir du site web du projet
   <productname>PostgreSQL</productname> sur <ulink
-  url="https://www.postgresql.org/download/"></ulink>. Construire à partir
-  des sources a pour seule cible les personnes qui développent
+  url="https://www.postgresql.org/download/"></ulink>. La compilation à partir
+  des sources n'est destinée qu'aux personnes qui développent
   <productname>PostgreSQL</productname> ou des extensions.
  </para>
 
  <para>
   Il existe différentes façons de construire PostgreSQL sur
-  <productname>Windows</productname>. La façon la plus simple de le faire est
-  d'utiliser les outils Microsoft. Pour cela, il faut installer une version
-  supportée de <productname>Visual Studio 2019</productname> et utiliser le compilateur inclus. Il est aussi
+  <productname>Windows</productname>. La façon la plus simple de le faire
+  avec les outils Microsoft est d'installer
+  <productname>Visual Studio 2019</productname>, et d'utiliser son compilateur. Il est aussi
   possible de construire PostgreSQL avec <productname>Microsoft Visual C++
    2013 à 2019</productname>. Dans certains cas, il faut installer le
   <productname>Windows SDK</productname> en plus du compilateur.
  </para>
 
  <para>
-  Il est aussi possible de construire PostgreSQL en utilisant les outils de
-  compilation GNU fournis par <productname>MinGW</productname> ou en utilisant
+  Il est aussi possible de construire PostgreSQL avec les outils de
+  compilation GNU fournis par <productname>MinGW</productname>, ou avec
   <productname>Cygwin</productname> pour les anciennes versions de
   <productname>Windows</productname>.
  </para>
 
  <para>
-  La construction par <productname>MinGW</productname> ou
-  <productname>Cygwin</productname> utilise le système habituel de
-  construction, voir <xref linkend="installation"/> et les notes spécifiques
+  <productname>MinGW</productname> ou
+  <productname>Cygwin</productname> utilisent le système habituel de
+  compilation (voir <xref linkend="installation"/>, et les notes spécifiques
   dans <xref linkend="installation-notes-mingw"/> et <xref linkend
-  ="installation-notes-cygwin"/>. Pour produire des binaires natifs 64 bits
+  ="installation-notes-cygwin"/>). Pour produire des binaires natifs 64 bits
   dans ces environnements, utilisez les outils de
-  <productname>MinGW-w64</productname>. Ces outils peuvent également être
-  utilisés pour faire de la cross-compilation pour les systèmes
+  <productname>MinGW-w64</productname>. Ils peuvent également être
+  utilisés pour cross-compiler vers des systèmes
   <productname>Windows</productname> 32 et 64 bits sur d'autres machines,
-  telles que <productname>Linux</productname> et
-  <productname>macOS</productname>. Il n'est pas recommandé d'utiliser
-  <productname>Cygwin</productname> pour faire fonctionner un serveur de
-  production. Il devrait uniquement être utilisé pour le fonctionnement sur
+  comme <productname>Linux</productname> et
+  <productname>macOS</productname>. <productname>Cygwin</productname>
+  n'est pas recommandé pour un serveur de
+  production, et ne devrait être utilisé qu'à destination
   d'anciennes versions de <productname>Windows</productname>, où la
   construction native ne fonctionne pas. Les exécutables officiels sont construits avec
   <productname>Visual Studio</productname>.
  </para>
 
  <para>
-  Les constructions natives de <application>psql</application> ne supportent
+  Les exécutables natifs de <application>psql</application> ne supportent
   pas l'édition de la ligne de commande. La version de psql construite avec
-  <productname>Cygwin</productname> supporte l'édition de ligne de commande,
-  donc elle devrait être utilisée là où on a besoin de psql pour des besoins
-  interactifs sous  <productname>Windows</productname>.
+  <productname>Cygwin</productname> la supporte,
+  donc elle devrait être utilisée là où on a besoin d'un psql
+  interactif sous <productname>Windows</productname>.
  </para>
 
  <sect1 id="install-windows-full">
@@ -67,30 +67,29 @@
    <productname>Microsoft Windows SDK</productname></title>
 
   <para>
-   PostgreSQL peut être construit en utilisant la suite de compilation Visual
-   C++ de Microsoft. Ces compilateurs peuvent être soit <productname>Visual
+   PostgreSQL peut être compilés avec la suite de compilation Visual
+   C++ de Microsoft. Les compilateurs peuvent être soit <productname>Visual
     Studio</productname>, soit <productname>Visual Studio Express</productname>
    soit certaines versions du <productname>Microsoft Windows
     SDK</productname>. Si vous n'avez pas déjà un environnement
-   <productname>Visual Studio</productname> configuré, le plus simple est
-   d'utiliser les compilateurs disponibles dans <productname>Visual Studio
-    2019</productname> ou ceux fournis dans le
-   <productname>Windows SDK 10</productname>, qui sont tous disponibles en
-   téléchargement libre sur le site de Microsoft.
+   <productname>Visual Studio</productname> en place, le plus simple est
+   d'utiliser les compilateurs de <productname>Visual Studio 2019</productname>
+   ou ceux du <productname>Windows SDK 10</productname>,
+   tous les deux disponibles en téléchargement libre sur le site de Microsoft.
   </para>
 
   <para>
-   Les constructions 32 bits et 64 bits sont possibles avec la suite Microsoft
-   Compiler. Les constructions 32 bits sont possibles avec
+   Compiler en 32 bits et 64 bits est possible avec la suite Microsoft
+   Compiler. Compiler en 32 bits est possible à l'aide de
    <productname>Visual Studio 2013</productname> jusqu'à
-   <productname>Visual Studio 2019</productname>, ainsi que les versions
+   <productname>Visual Studio 2019</productname>, ainsi qu'avec les versions
    autonomes Windows SDK, de la version 8.1a à
-   la version 10. Les constructions 64 bits sont supportées avec
-   <productname>Microsoft Windows SDK</productname>, de la version 8.1a à la
-   version 10, ou <productname>Visual Studio 2013</productname> et les versions
-   ultérieures. La compilation est supportée depuis <productname>Windows
-    7</productname> et <productname>Windows Server 2008 R2 SP1</productname> lors de
-   la construction avec <productname>Visual Studio 2013</productname> et jusqu'à
+   la version 10. Les compilations 64 bits sont supportées avec
+   <productname>Microsoft Windows SDK</productname>, versions 8.1a à
+   version 10, ou <productname>Visual Studio 2013</productname> et ses versions
+   ultérieures. La compilation est supportée à partir de <productname>Windows
+    7</productname> et <productname>Windows Server 2008 R2 SP1</productname>,
+   en compilant avec <productname>Visual Studio 2013</productname> à
    <productname>Visual Studio 2019</productname>.
    <!--
        For 2013 requirements:
@@ -107,33 +106,36 @@
   <para>
    Les outils pour compiler avec <productname>Visual C++</productname> ou
    <productname>Platform SDK</productname> sont dans le répertoire
-   <filename>src\tools\msvc</filename>. Lors de la construction, assurez-vous
-   qu'il n'y a pas d'outils provenant de <productname>MinGW</productname> ou
-   <productname>Cygwin</productname> présents dans le chemin des applications
-   du système. De plus, assurez-vous que vous avez tous les outils Visual C++
-   requis disponibles dans le chemin des applications (variable
-   d'environnement <literal>PATH</literal>). À partir de <productname>Visual
-    Studio 2017</productname>, ceci peut se faire à partir de la ligne de
-   commande en utilisant <command>VsDevCmd.bat</command>, voir
+   <filename>src\tools\msvc</filename>. Lors de la compilation, assurez-vous
+   qu'il n'y a pas d'outils de <productname>MinGW</productname> ou
+   <productname>Cygwin</productname> présents dans votre <literal>PATH</literal>
+   système. Assurez-vous aussi que vous avez tous les outils Visual C++
+   requis disponibles dans le <literal>PATH</literal>.
+   Dans <productname>Visual Studio</productname>, lancez le
+   <application>Visual Studio Command Prompt</application>. Pour compiler
+   une version 64 bits, vous devez utiliser la version 64 bits, et inversement.
+   À partir de <productname>Visual Studio 2017</productname>,
+   ceci peut se faire à partir de la ligne de
+   commande en utilisant <command>VsDevCmd.bat</command> (voir
    <command>-help</command> pour les options disponibles et leur valeurs par
-   défaut. <command>vsvars32.bat</command> est disponible dans
+   défaut). <command>vsvars32.bat</command> est disponible dans
    <productname>Visual Studio 2015</productname> et les versions antérieures
-   dans le même but. À partir de <application>Visual Studio Command
+   dans le même but. À partir du <application>Visual Studio Command
     Prompt</application>, vous pouvez modifier l'architecture CPU ciblée, le
-   type de construction, et le système d'exploitation cible en utilisant la
-   commande <command>vcvarsall.bat</command>, par exemple
-   <command>vcvarsall.bat x64 10.0.10240.0</command> pour cibler Windows 10
-   avec une construction 64-bits. Voir <command>-help</command> pour les
+   type de compilation, et le système d'exploitation cible grâce à la
+   commande <command>vcvarsall.bat</command>. Par exemple,
+   <command>vcvarsall.bat x64 10.0.10240.0</command> ciblera Windows 10
+   en 64 bits. Voir <command>-help</command> pour les
    autres options de <command>vcvarsall.bat</command>. Toutes les commandes
    doivent être exécutées à partir du répertoire
    <filename>src\tools\msvc</filename>.
   </para>
 
   <para>
-   Avant de lancer la construction, vous aurez besoin d'éditer le fichier
+   Avant de compiler, il faudra peut-être éditer le fichier
    <filename>config.pl</filename> pour y modifier toutes les options de
    configuration nécessaires, ainsi que les chemins utilisés par les
-   bibliothèques de tierces parties. La configuration complète est déterminée
+   bibliothèques tierces. La configuration complète est déterminée
    tout d'abord en lisant et en analysant le fichier
    <filename>config_default.pl</filename>, puis en appliquant les
    modifications provenant du fichier <filename>config.pl</filename>. Par
@@ -143,23 +145,22 @@
    <programlisting>
    $config->{python} = 'c:\python26';
    </programlisting>
-   Vous avez seulement besoin de spécifier les paramètres qui sont différents
-   de la configuration par défaut, ce qui est à faire dans le fichier
-   <filename>config_default.pl</filename>.
+   Vous n'avez besoin de spécifier que les paramètres différents
+   de ceux définis dans <filename>config_default.pl</filename>.
   </para>
 
   <para>
    Si vous avez besoin de configurer d'autres variables d'environnement, créez
-   un fichier appelé <filename>buildenv.pl</filename> et placez-y les
+   un fichier <filename>buildenv.pl</filename>, et placez-y les
    commandes souhaitées. Par exemple, pour ajouter le chemin vers bison s'il
-   ne se trouve pas dans le chemin, créez un fichier contenant&nbsp;:
+   ne se trouve pas dans le <literal>PATH</literal>, créez un fichier contenant&nbsp;:
    <programlisting>
    $ENV{PATH}=$ENV{PATH} . ';c:\chemin\vers\bison\bin';
    </programlisting>
   </para>
 
   <para>
-   Pour passer des arguments en ligne de commande supplémentaires à la commande
+   Pour passer d'autres arguments en ligne de commande à la commande
    de compilation de Visual Studio (msbuild or vcbuild) :
    <programlisting>
 $ENV{MSBFLAGS}="/m";
@@ -170,10 +171,10 @@ $ENV{MSBFLAGS}="/m";
    <title>Prérequis</title>
 
    <para>
-    Les outils supplémentaires suivants sont requis pour construire
+    Les outils suivants sont requis pour compiler
     <productname>PostgreSQL</productname>. Utilisez le fichier
-    <filename>config.pl</filename> pour indiquer les répertoires où se
-    trouvent les bibliothèques.
+    <filename>config.pl</filename> pour indiquer les chemins
+    des bibliothèques.
 
     <variablelist>
      <varlistentry>
@@ -182,16 +183,16 @@ $ENV{MSBFLAGS}="/m";
        <para>
         Si votre environnement de compilation ne contient pas une version
         supportée du <productname>Microsoft Windows SDK</productname>, il est
-        recommandé de mettre à jour avec la dernière version supportée
-        (actuellement la version 10), téléchargeable sur le <ulink
+        recommandé de mettre à jour vers la dernière version supportée
+        (actuellement la 10), téléchargeable sur le <ulink
         url="https://www.microsoft.com/download/">site de Microsoft</ulink>.
        </para>
 
        <para>
         Vous devez toujours inclure la partie <application>Windows Headers and
          Libraries</application> du SDK. Si vous installez un
-        <productname>Windows SDK</productname> incluant les compilateurs
-        (<application>Visual C++ Compilers</application>), vous n'avez pas de
+        <productname>Windows SDK</productname> incluant les
+        <application>Visual C++ Compilers</application>, vous n'avez pas besoin de
         <productname>Visual Studio</productname>. Notez que la version 8.0a du
         Windows SDK ne contient plus d'environnement complet de compilation en
         ligne de commande.
@@ -202,12 +203,12 @@ $ENV{MSBFLAGS}="/m";
       <term><productname>ActiveState Perl</productname></term>
       <listitem>
        <para>
-        ActiveState Perl est requis pour exécuter les scripts de construction.
-        La commande Perl de MinGW et de Cygwin ne fonctionnera pas. Elle doit
-        aussi être présente dans le chemin (PATH). Les binaires de cet outil
+        ActiveState Perl est requis pour exécuter les scripts de compilation.
+        La commande Perl de MinGW et de Cygwin ne fonctionnera pas. ActiveState Perl
+        doit aussi être présent dans le <literal>PATH</literal>. Ses binaires
         sont téléchargeables à partir du <ulink
-        url="https://www.activestate.com">site officiel</ulink> (la version
-        5.8.3 ou ultérieure est requise, la distribution standard libre est
+        url="https://www.activestate.com">site officiel</ulink> (il faut
+        une version 5.8.3, la distribution standard libre est
         suffisante).
        </para>
       </listitem>
@@ -216,18 +217,18 @@ $ENV{MSBFLAGS}="/m";
    </para>
 
    <para>
-    Les produits suivants ne sont pas nécessaires pour commencer, mais sont
-    requis pour installer la distribution complète. Utilisez le fichier
-    <filename>config.pl</filename> pour indiquer les répertoires où sont
-    placées les bibliothèques.
+    Les produits suivants ne sont pas nécessaires pour démarrer, mais sont
+    nécessaires pour construire la distribution complète. Utilisez le fichier
+    <filename>config.pl</filename> pour indiquer les chemins
+    des bibliothèques.
 
     <variablelist>
      <varlistentry>
       <term><productname>ActiveState TCL</productname></term>
       <listitem>
        <para>
-        Requis pour construire <application>PL/Tcl</application> (la version
-        8.4 est requise, la distribution standard libre est suffisante).
+        Nécessaire pour construire <application>PL/Tcl</application> (NB&nbsp;:
+        il faut la version 8.4, la distribution standard libre est suffisante).
        </para>
       </listitem>
      </varlistentry>
@@ -238,9 +239,9 @@ $ENV{MSBFLAGS}="/m";
       <listitem>
        <para>
         <productname>Bison</productname> et <productname>Flex</productname>
-        sont requis pour construire à partir de Git, mais ne le sont pas pour
-        construire à partir d'une version distribuée. Seul
-        <productname>Bison</productname> 1.875 ou les versions 2.2 et
+        sont nécessaires pour compiler à partir de Git, mais pas pour
+        compiler à partir d'une version distribuée. Seul
+        <productname>Bison</productname> 1.875, ou les versions 2.2 et
         ultérieures fonctionneront. <productname>Flex</productname> doit être
         en version 2.5.31 ou supérieure.
        </para>
@@ -249,27 +250,28 @@ $ENV{MSBFLAGS}="/m";
         <productname>Bison</productname> et <productname>Flex</productname>
         sont inclus dans la suite d'outils <productname>msys</productname>,
         disponible à partir de son <ulink
-        url="http://www.mingw.org/wiki/MSYS">site officiel</ulink> et faisant
+        url="http://www.mingw.org/wiki/MSYS">site officiel</ulink>, comme
         partie de la suite de compilation <productname>MinGW</productname>.
        </para>
 
        <para>
-        Vous aurez besoin d'ajouter le répertoire contenant
-        <filename>flex.exe</filename> et <filename>bison.exe</filename> à la
-        variable d'environnement PATH dans <filename>buildenv.pl</filename>
-        sauf s'ils y sont déjà. Dans le cas de MinGW, le répertoire est le
+        Le répertoire contenant
+        <filename>flex.exe</filename> et <filename>bison.exe</filename>
+        devra être ajouté à la
+        variable d'environnement <literal>PATH</literal> dans <filename>buildenv.pl</filename>
+        s'ils n'y est pas déjà. Dans le cas de MinGW, le répertoire est le
         sous-répertoire <filename>\msys\1.0\bin</filename> de votre répertoire
         d'installation de MinGW.
        </para>
 
        <note>
         <para>
-         La distribution Bison de GnuWin32 a apparemment un bug qui cause des
-         dysfonctionnements de Bison lorsqu'il est installé dans un répertoire
-         dont le nom contient des espaces, tels que l'emplacement par défaut
+         La distribution Bison de GnuWin32 a apparemment un bug menant à un
+         dysfonctionnement de Bison s'il est installé dans un répertoire
+         dont le nom contient des espaces, tel que l'emplacement par défaut
          dans les installations en anglais&nbsp;: <filename>C:\Program
-          Files\GnuWin32</filename>. Installez donc plutôt dans
-         <filename>C:\GnuWin32</filename> ou utilisez le chemin court NTFS de
+          Files\GnuWin32</filename>. Installez-le donc plutôt dans
+         <filename>C:\GnuWin32</filename>, ou utilisez le chemin court NTFS de
          GnuWin32 dans votre variable d'environnement PATH (par exemple
          <filename>C:\PROGRA~1\GnuWin32</filename>).
         </para>
@@ -283,8 +285,8 @@ $ENV{MSBFLAGS}="/m";
        <para>
         Diff est nécessaire pour exécuter les tests de régression, et peut
         être téléchargé à partir de la <ulink
-        url="http://gnuwin32.sourceforge.net">page du projet gnuwin32 du site
-         sourceforge.net</ulink>.
+        url="http://gnuwin32.sourceforge.net">page du projet gnuwin32 sur
+         Sourceforge</ulink>.
        </para>
       </listitem>
      </varlistentry>
@@ -295,8 +297,8 @@ $ENV{MSBFLAGS}="/m";
        <para>
         Gettext est requis pour construire le support des langues (NLS), et
         peut être téléchargé à partir de la <ulink
-        url="http://gnuwin32.sourceforge.net">page du projet gnuwin32 du site
-         sourceforge.net</ulink>. Notez que les binaires, dépendances et
+        url="http://gnuwin32.sourceforge.net">page du projet gnuwin32 sur
+         Sourceforge</ulink>. Notez que les binaires, dépendances et
         fichiers d'en-tête sont tous nécessaires.
        </para>
       </listitem>
@@ -318,11 +320,11 @@ $ENV{MSBFLAGS}="/m";
        <productname>libxslt</productname></term>
       <listitem>
        <para>
-        Requis pour le support du XML. Les binaires sont disponibles sur le
-        <ulink url="https://zlatkovic.com/pub/libxml">site
+        Nécessaire pour le support du XML. Les binaires sont disponibles sur
+        <ulink url="https://zlatkovic.com/pub/libxml">
          zlatkovic.com</ulink> et les sources sur le <ulink
-        url="http://xmlsoft.org">site xmlsoft.org</ulink>. Notez que libxml2
-        nécessite iconv, qui est disponible sur le même site web.
+        url="http://xmlsoft.org">xmlsoft.org</ulink>. Notez que libxml2
+        nécessite iconv, disponible sur le même site.
        </para>
       </listitem>
      </varlistentry>
@@ -330,9 +332,8 @@ $ENV{MSBFLAGS}="/m";
      <varlistentry>
       <term><productname>LZ4</productname></term>
       <listitem><para>
-       Required for supporting <productname>LZ4</productname> compression
-       method for compressing the table data. Binaries and source can be
-       downloaded from
+       Nécessaire pour la méthode de compression <productname>LZ4</productname>
+       des données de table. Binaires et sources peuvent être téléchargés depuis
        <ulink url="https://github.com/lz4/lz4/releases"></ulink>.
       </para></listitem>
      </varlistentry>
@@ -341,11 +342,11 @@ $ENV{MSBFLAGS}="/m";
       <term><productname>OpenSSL</productname></term>
       <listitem>
        <para>
-        Requis pour le support de SSL. Les binaires peuvent être téléchargés à
-        partir du <ulink
-        url="https://slproweb.com/products/Win32OpenSSL.html">site slproweb.com</ulink>
-        alors que les sources sont disponibles sur le <ulink
-        url="https://www.openssl.org">site openssl.org</ulink>.
+        Nécessaire pour le support de SSL. Les binaires peuvent être téléchargés à
+        partir de <ulink
+        url="https://slproweb.com/products/Win32OpenSSL.html">slproweb.com</ulink>,
+        ou les sources à partir de <ulink
+        url="https://www.openssl.org">openssl.org</ulink>.
        </para>
       </listitem>
      </varlistentry>
@@ -354,9 +355,9 @@ $ENV{MSBFLAGS}="/m";
       <term><productname>ossp-uuid</productname></term>
       <listitem>
        <para>
-        Requis pour le support d'UUID-OSSP (seulement en contrib). Les sources
-        peuvent être récupérées sur le <ulink
-        url="http://www.ossp.org/pkg/lib/uuid/">site ossp.org</ulink>.
+        Nécessaire pour le support d'UUID-OSSP (seulement en contrib). Les sources
+        peuvent être récupérées sur <ulink
+        url="http://www.ossp.org/pkg/lib/uuid/">ossp.org</ulink>.
        </para>
       </listitem>
      </varlistentry>
@@ -365,9 +366,9 @@ $ENV{MSBFLAGS}="/m";
       <term><productname>Python</productname></term>
       <listitem>
        <para>
-        Requis pour la construction de <application>PL/Python</application>.
-        Les binaires sont téléchargeables sur le <ulink
-        url="https://www.python.org">site officiel du langage Python</ulink>.
+        Nécessaire pour la compilation de <application>PL/Python</application>.
+        Les binaires sont téléchargeables sur <ulink
+        url="https://www.python.org">python.org</ulink>.
        </para>
       </listitem>
      </varlistentry>
@@ -376,10 +377,10 @@ $ENV{MSBFLAGS}="/m";
       <term><productname>zlib</productname></term>
       <listitem>
        <para>
-        Requis pour le support de la compression dans
+        Nécessaire pour le support de la compression dans
         <application>pg_dump</application> et
-        <application>pg_restore</application>. Les binaires sont disponibles à
-        partir du <ulink url="https://www.zlib.net">site officiel</ulink>.
+        <application>pg_restore</application>. Les binaires sont disponibles sur
+        le <ulink url="https://www.zlib.net">site officiel</ulink>.
        </para>
       </listitem>
      </varlistentry>
@@ -391,20 +392,20 @@ $ENV{MSBFLAGS}="/m";
    <title>Considérations spéciales pour Windows 64 bits</title>
 
    <para>
-    PostgreSQL ne peut être compilé pour l'architecture x64 que sur Windows 64
-    bits. De plus, il n'y a pas de support pour les processeurs Itanium.
+    PostgreSQL ne peut être compilé pour l'architecture x64 que sur un Windows 64
+    bits. Il n'y a pas de support pour les processeurs Itanium.
    </para>
 
    <para>
-    Mixer des versions 32 bits et des versions 64 bits dans le même répertoire
-    de construction n'est pas supporté. Le système de compilation détecte
-    automatiquement si l'environnement est 32 bits ou 64 bits, et construit
-    PostgreSQL en accord. Pour cette raison, il est important de commencer
-    avec la bonne invite de commande avant de lancer la compilation.
+    Le mélange de versions 32 bits et des versions 64 bits dans le même répertoire
+    de compilation n'est pas supporté. Le système de compilation détecte
+    automatiquement si l'environnement est 32 bits ou 64 bits, et compile
+    PostgreSQL en accord. Pour cette raison, il est important de démarrer
+    la  bonne invite de commande avant de lancer la compilation.
    </para>
 
    <para>
-    Pour utiliser une bibliothèque de tierce partie côté serveur comme
+    Pour utiliser une bibliothèque tierce côté serveur, comme
     <productname>Python</productname> ou <productname>OpenSSL</productname>,
     cette bibliothèque <emphasis>doit</emphasis> aussi être en 64 bits. Il n'y
     a pas de support pour le chargement d'une bibliothèque 32 bits sur un
@@ -418,27 +419,28 @@ $ENV{MSBFLAGS}="/m";
    <title>Construction</title>
 
    <para>
-    Pour construire tout PostgreSQL dans la configuration par défaut, exécutez
+    Pour compiler tout PostgreSQL dans la configuration publiée (par défaut), exécutez
     la commande&nbsp;:
     <screen><userinput>build</userinput></screen>
     Pour construire tout PostgreSQL dans la configuration de débogage,
-    exécutez la commande&nbsp;:
+    exécutez&nbsp;:
     <screen><userinput>build DEBUG</userinput></screen>
     Pour construire un seul projet, par exemple psql, exécutez l'une des deux
     commandes ci-dessous, suivant que vous souhaitez la configuration par
-    défaut ou la configuration de débogage&nbsp;:
+    défaut ou celle de débogage&nbsp;:
     <screen>
      <userinput>build psql</userinput>
      <userinput>build DEBUG psql</userinput>
     </screen>
-    Pour modifier la configuration de construction par défaut, placez ce qui
+    Pour modifier la configuration de compilation par défaut, placez ce qui
     suit dans le fichier <filename>buildenv.pl</filename>&nbsp;:
     <programlisting>
+$ENV{CONFIG}="Debug";
     </programlisting>
    </para>
 
    <para>
-    Il est aussi possible de construire à partir de l'interface de Visual
+    Il est aussi possible de compiler à partir de l'interface graphique de Visual
     Studio. Dans ce cas, vous devez exécuter&nbsp;:
     <screen><userinput>perl mkvcbuild.pl</userinput></screen>
     à partir de l'invite, puis ouvrir le fichier
@@ -453,20 +455,19 @@ $ENV{MSBFLAGS}="/m";
    <para>
     La plupart du temps, la récupération automatique des dépendances dans
     Visual Studio prendra en charge les fichiers modifiés. Mais, s'il y a eu
-    trop de modifications, vous pouvez avoir besoin de nettoyer
+    trop de modifications, il peut y avoir besoin de nettoyer
     l'installation. Pour cela, exécutez simplement la commande
-    <filename>clean.bat</filename>, qui nettoiera automatiquement les fichiers
+    <filename>clean.bat</filename>, qui nettoiera automatiquement tous les fichiers
     générés. Vous pouvez aussi l'exécuter avec le paramètre
-    <parameter>dist</parameter>, auquel cas il se comporte comme
-    <userinput>make distclean</userinput> et supprime les fichiers flex/bison
-    en sortie.
+    <parameter>dist</parameter>, auquel cas elle se comporte comme
+    <userinput>make distclean</userinput>, et supprime aussi les fichiers flex/bison.
    </para>
 
    <para>
     Par défaut, tous les fichiers sont écrits dans un sous-répertoire de
     <filename>debug</filename> ou <filename>release</filename>. Pour installer
-    ces fichiers en utilisant les emplacements standards et pour générer aussi
-    les fichiers requis pour initialiser et utiliser la base de données,
+    ces fichiers en utilisant les emplacements standards, et pour générer aussi
+    les fichiers nécessaire à l'installation et l'utilisation de la base de données,
     exécutez la commande&nbsp;:
     <screen><userinput>install c:\destination\directory</userinput></screen>
    </para>
@@ -495,6 +496,7 @@ $ENV{MSBFLAGS}="/m";
      <userinput>vcregress installcheck</userinput>
      <userinput>vcregress plcheck</userinput>
      <userinput>vcregress contribcheck</userinput>
+     <userinput>vcregress modulescheck</userinput>
      <userinput>vcregress ecpgcheck</userinput>
      <userinput>vcregress isolationcheck</userinput>
      <userinput>vcregress bincheck</userinput>
@@ -510,22 +512,22 @@ $ENV{MSBFLAGS}="/m";
    </para>
 
    <para>
-    Exécuter les tests de régression sur les programmes clients, avec
-    <command>vcregress bincheck</command>, ou sur les tests de restauration,
-    avec <command>vcregress recoverycheck</command>,
-    nécessite l'installation d'un module Perl supplémentaire&nbsp;:
+    Les tests de régression des programmes clients
+    (<command>vcregress bincheck</command>) ou des tests de restauration
+    (<command>vcregress recoverycheck</command>)
+    nécessitent l'installation d'un module Perl supplémentaire&nbsp;:
     <variablelist>
      <varlistentry>
       <term><productname>IPC::Run</productname></term>
       <listitem>
        <para>
-        Lors de l'écriture de cette partie, <literal>IPC::Run</literal>
-        n'était pas inclus dans l'installation de ActiveState Perl, pas plus
-        que dans la bibliothèque ActiveState Perl Package Manager (PPM). Pour
+        Au moment où ces lignes sont écrites, <literal>IPC::Run</literal>
+        n'est pas inclus dans l'installation de ActiveState Perl,
+        ni dans la bibliothèque ActiveState Perl Package Manager (PPM). Pour
         l'installer, téléchargez l'archive source
         <filename>IPC-Run-&lt;version&gt;.tar.gz</filename> à partir du <ulink
-        url="https://metacpan.org/release/IPC-Run">site CPAN</ulink>, et
-        déballez-la. Modifiez le fichier <filename>buildenv.pl</filename> en
+        url="https://metacpan.org/release/IPC-Run">CPAN</ulink>, et
+        décompressez-la. Modifiez le fichier <filename>buildenv.pl</filename> en
         ajoutant une variable PERL5LIB pointant vers le sous-répertoire
         <filename>lib</filename> des fichiers extraits de l'archive. Par
         exemple&nbsp;:
@@ -536,21 +538,21 @@ $ENV{MSBFLAGS}="/m";
   </para>
 
   <para>
-   The TAP tests run with <command>vcregress</command> support the
-   environment variables <varname>PROVE_TESTS</varname>, that is expanded
-   automatically using the name patterns given, and
-   <varname>PROVE_FLAGS</varname>. These can be set on a Windows terminal,
-   before running <command>vcregress</command>:
+   Les tests TAP lancés par <command>vcregress</command>) supportent les
+   variables d'environnement <varname>PROVE_TESTS</varname>, étendues
+   automatiquement selon le modèle donné, et <varname>PROVE_FLAGS</varname>.
+   Elles peuvent être mises en place dans un terminal Windows,
+   avant de lancer <command>vcregress</command>&nbsp;:
 <programlisting>
 set PROVE_FLAGS=--timer --jobs 2
 set PROVE_TESTS=t/020*.pl t/010*.pl
 </programlisting>
-   It is also possible to set up those parameters in
-   <filename>buildenv.pl</filename>:
+   Il est possible de placer ces paramètres dans
+   <filename>buildenv.pl</filename>&nbsp;:
 <programlisting>
 $ENV{PROVE_FLAGS}='--timer --jobs 2'
 $ENV{PROVE_TESTS}='t/020*.pl t/010*.pl'
-</programlisting>
+</programlisting>   
   </para>
   </sect2>
 


### PR DESCRIPTION
Revue complète d'install-windows.xml
Traduction des quelques nouveautés en anglais
Il manquait 2-3 phrases ou lignes
Tentative de reformulations pour alléger les tournures, quitte à franciser,
comme compilation à la place de construction,
ou nécessaire à la place de requis.
Le PATH est un concept supposé connu vu le public,
je l'ai remis tel quel.
Les adresses des sites devraient peut-être remplacées par juste les URL
comme dans la VO mais j'ai renoncé.