### PR TITLE
Cherset 14β2

### DIFF
--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -569,7 +569,7 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
      La collation <literal>default</literal> utilise les valeurs de
      <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol>
      définies à la création de la base de données. Les collations <literal>C</literal> et
-     <literal>POSIX</literal> spécifient toutes deux le comportement <quote>traditionnel C</quote>,
+     <literal>POSIX</literal> spécifient toutes deux le comportement <quote>C traditionnel</quote>,
      dans lequel seuls les caractères ASCII de <quote><literal>A</literal></quote> à
      <quote><literal>Z</literal></quote> sont considérés comme des lettres, et les tris sont
      ordonnés strictement par valeur de l'octet du code caractère.
@@ -586,11 +586,12 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
     <title>Collations prédéfinies</title>
 
     <para>
-     Si le système d'exploitation permet à un programme de supporter plusieurs
-     locales (fonction <function>newlocale</function> et fonctions conjointes) ou si le support d'ICU est configuré, alors
+     Si le système d'exploitation permet de supporter plusieurs
+     locales dans un même programme (fonction <function>newlocale</function> et fonctions conjointes),
+     ou si le support d'ICU est configuré, alors
      <command>initdb</command> peuplera le catalogue système <literal>pg_collation</literal>
-     en se basant sur toutes les locales qu'il trouve sur le système d'exploitation au
-     moment de l'initialisation du cluster de bases de données.
+     avec toutes les locales trouvées sur le système d'exploitation
+     lors de l'initialisation de l'instance.
     </para>
 
     <para>
@@ -600,32 +601,32 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
     </para>
 
     <sect4>
-     <title>Collations LibC</title>
+     <title>Collations libc</title>
 
      <para>
       Par exemple, le système
-      d'exploitation peut offrir une locale appelée <literal>de_DE.utf8</literal>.
+      d'exploitation peut fournir une locale appelée <literal>de_DE.utf8</literal>.
       <command>initdb</command> créera alors une collation nommée
-      <literal>de_DE.utf8</literal> pour le jeu de caractère <literal>UTF8</literal>
-      pour lequel <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> sont
+      <literal>de_DE.utf8</literal> pour le jeu de caractère <literal>UTF8</literal>,
+      pour laquelle <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> seront
       positionnés à <literal>de_DE.utf8</literal>.
-      Il créera aussi une collation dont le nom sera amputé du tag <literal>.utf8</literal>.
-      Ainsi, vous pouvez utiliser cette collation sous le nom <literal>de_DE</literal>,
-      dont l'écriture est beaucoup plus facile et qui le rend moins dépendant du jeu
-      de caractères. Néanmoins, notez que le nommage de chaque collation collectée par
-      <command>initdb</command> est dépendant de la plateforme utilisée.
+      Il créera aussi une collation avec un nom amputé de l'étiquette <literal>.utf8</literal>.
+      Ainsi, vous pourrez utiliser cette collation sous le nom <literal>de_DE</literal>,
+      plus facile à écrire, et moins dépendant du jeu
+      de caractères. Néanmoins, notez que l'ensemble initial des noms de collation
+      <command>initdb</command> est dépendant de la plateforme.
      </para>
 
      <para>
       Le jeu de collation par défaut fourni par <literal>libc</literal> pointe
       directement vers les locales installées sur le système, qui peuvent être
-      listées en utilisant la commande <literal>locale -a</literal>.  Dans le cas
-      où une collation <literal>libc</literal> avec différentes valeurs
-      pour <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> est nécessaire, ou si des nouvelles
-      locales sont installées sur le système après que la base de données
-      soit initialisée, alors une nouvelle collation pourrait être créée en utilisant
-      la commande <xref linkend="sql-createcollation"/>. De nouvelles locales du
-      système d'exploitation peuvent aussi être importées en masse en utilisant
+      listées avec la commande <literal>locale -a</literal>. Dans le cas
+      où l'on a besoin d'une collation <literal>libc</literal> avec des valeurs
+      <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> différentes, ou si de nouvelles
+      locales sont installées sur le système après l'initialisation de la base de données,
+      une nouvelle collation peut être créée par
+      la commande <xref linkend="sql-createcollation"/>. On peut aussi importer
+      en masse de nouvelles locales du système d'exploitation avec
       la fonction <link
       linkend="functions-admin-collation"><function>pg_import_system_collations()</function></link>.
      </para>
@@ -633,12 +634,12 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
      <para>
       Dans une même base de données, seules les collations qui utilisent le
       jeu de caractères de la base de données sont prises en compte. Les autres
-      entrées de <literal>pg_collation</literal> sont ignorées. De cette façon,
-      une collation dont le nom est tronqué, comme <literal>de_DE</literal>,
-      sera considérée de manière unique au sein d'une même base de données,
-      même si elle ne peut être considérée comme unique à un niveau plus global.
-      L'utilisation de collations dont le nom est tronqué est d'ailleurs
-      recommandée car vous n'aurez pas besoin de la modifier si vous décidez
+      entrées de <literal>pg_collation</literal> sont ignorées. Ainsi,
+      une collation au nom tronqué, comme <literal>de_DE</literal>,
+      peut être considérée unique au sein d'une base,
+      bien qu'elle ne le soit pas globalement.
+      L'utilisation de collations au nom tronqué est d'ailleurs
+      recommandée&nbsp;: ce sera une chose de moins à changer si vous avez besoin
       de changer le jeu de caractères de la base de données. Notez toutefois que
       les collations <literal>default</literal>, <literal>C</literal>, et
       <literal>POSIX</literal> peuvent être utilisées sans se soucier de

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -1004,28 +1004,28 @@ CREATE COLLATION ignore_accents (provider = icu, locale = 'und-u-ks-level1-kc-tr
   <indexterm zone="multibyte"><primary>jeu de caractère</primary></indexterm>
 
   <para>
-   Le support des jeux de caractères dans <productname>PostgreSQL</productname>
+      <!-- Le support des jeux de caractères dans :INUTILE  -->
+   <productname>PostgreSQL</productname>
    permet d'insérer du texte dans différents jeux de caractères (aussi appelés
-   encodages), dont
-   ceux mono-octet tels que la série ISO 8859 et ceux multi-octets tels que
+   encodages), soit mono-octet comme série ISO 8859, soit multi-octets comme
    <acronym>EUC</acronym> (Extended Unix Code), UTF-8 ou le codage interne Mule.
    Tous les jeux de caractères supportés peuvent être utilisés de façon
-   transparente par les clients mais certains ne sont pas supportés par le
-   serveur (c'est-à-dire comme encodage du serveur).
-   Le jeu de caractères par défaut est sélectionné pendant l'initialisation
-   du cluster de base de données avec <command>initdb</command>. Ce choix peut
+   transparente par les clients, mais certains ne sont pas supportés par le
+   serveur (c'est-à-dire comme encodage côté serveur).
+   Le jeu de caractères par défaut est choisi pendant l'initialisation
+   de l'instance avec <command>initdb</command>. Ce choix peut
    être surchargé à la création de la base. Il est donc possible de disposer
    de bases utilisant chacune un jeu de caractères différent.
   </para>
 
   <para>
-   Il existe, cependant une importante restriction&nbsp;: le jeu de caractère
-   de la base de données doit être compatible avec les variables
-   d'environnement <envar>LC_CTYPE</envar> (classification des caractères) et
-   <envar>LC_COLLATE</envar> (ordre de tri des chaînes) de la base de données.
+   Cependant, une importante restriction existe&nbsp;: le jeu de caractère
+   de chaque base doit être compatible avec les variables
+   <envar>LC_CTYPE</envar> (classification des caractères) et
+   <envar>LC_COLLATE</envar> (ordre de tri des chaînes) de cette même base.
    Pour les locales <literal>C</literal> ou <literal>POSIX</literal>, tous
-   les jeux de caractères sont autorisés, mais pour les locales provenant de la libc,
-   il n'y a qu'un seul jeux de caractères qui fonctionne correctement.
+   les jeux de caractères sont autorisés, mais pour d'autres locales provenant de la libc,
+   il n'y a qu'un seul jeu de caractères qui fonctionne correctement.
    (Néanmoins, sur Windows, l'encodage UTF-8 peut être utilisé avec toute
    locale.)
    Si le support d'ICU est configuré, les locales fournies par ICU peuvent
@@ -1101,13 +1101,6 @@ by pg_wchar_table.mblen function for each encoding.
        <entry>Non</entry>
        <entry>1&ndash;3</entry>
        <entry></entry>
-      </row>
-      <row>
-       <entry><literal>EUC_JIS_2004</literal></entry>
-       <entry><emphasis>EUC_JIS_2004</emphasis>,
-        <literal>SHIFT_JIS_2004</literal>,
-        <literal>UTF8</literal>
-       </entry>
       </row>
       <row>
        <entry><literal>EUC_KR</literal></entry>
@@ -1189,15 +1182,6 @@ by pg_wchar_table.mblen function for each encoding.
        <entry>Non</entry>
        <entry>1-3</entry>
        <entry></entry>
-      </row>
-      <row>
-       <entry><literal>KOI8</literal></entry>
-       <entry><acronym>KOI</acronym>8-R(U)</entry>
-       <entry>Cyrillique</entry>
-       <entry>Oui</entry>
-       <entry>Oui</entry>
-       <entry>1</entry>
-       <entry><literal>KOI8R</literal></entry>
       </row>
       <row>
        <entry><literal>KOI8R</literal></entry>
@@ -1292,7 +1276,7 @@ by pg_wchar_table.mblen function for each encoding.
       <row>
        <entry><literal>LATIN9</literal></entry>
        <entry>ISO 8859-15</entry>
-       <entry><literal>ISO885915</literal> avec l'Euro et les accents</entry>
+       <entry><literal>LATIN1</literal> avec l'Euro et les accents</entry>
        <entry>Oui</entry>
        <entry>Oui</entry>
        <entry>1</entry>
@@ -1337,7 +1321,7 @@ by pg_wchar_table.mblen function for each encoding.
       <row>
        <entry><literal>SQL_ASCII</literal></entry>
        <entry>non spécifié (voir le texte)</entry>
-       <entry><emphasis>tout</emphasis></entry>
+       <entry><emphasis>toutes</emphasis></entry>
        <entry>Oui</entry>
        <entry>Non</entry>
        <entry>1</entry>
@@ -1355,7 +1339,7 @@ by pg_wchar_table.mblen function for each encoding.
       <row>
        <entry><literal>UTF8</literal></entry>
        <entry>Unicode, 8-bit</entry>
-       <entry><emphasis>tous</emphasis></entry>
+       <entry><emphasis>toutes</emphasis></entry>
        <entry>Oui</entry>
        <entry>Oui</entry>
        <entry>1&ndash;4</entry>
@@ -1373,7 +1357,7 @@ by pg_wchar_table.mblen function for each encoding.
       <row>
        <entry><literal>WIN874</literal></entry>
        <entry>Windows CP874</entry>
-       <entry>Thai</entry>
+       <entry>Thaï</entry>
        <entry>Oui</entry>
        <entry>Non</entry>
        <entry>1</entry>

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -345,82 +345,78 @@
    Cette fonctionnalité permet de définir par colonne, ou pour chaque requête,
    la collation utilisée pour déterminer l'ordre de tri et le classement des
    caractères.
-   Cette fonctionnalité permet de lever la restriction sur les paramètres
+   Elle permet de lever la restriction sur les paramètres
    <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> d'une base de
-   données et qui ne pouvaient pas être modifiés après sa création.
+   données, qui ne pouvaient pas être modifiés après sa création.
 </para>
 
   <sect2>
    <title>Concepts</title>
 
    <para>
-	Conceptuellement, toute expression d'un type de donnée qui est collatable a
-	une collation. (Les types de données intégrés qui supportent
-	une collation sont <type>text</type>, <type>varchar</type>,
-	et <type>char</type>. Les types de données définies par l'utilisateur
-	peuvent aussi être marqués comme supportant la collation, et
-	bien entendu un domaine qui est défini sur un type de données
-	supportant la collation est, lui aussi, collationnable.)
-	Si l'expression est une colonne, la collation de l'expression est déterminée
+	Conceptuellement, toute expression d'un type de donnée supportant les collations a
+	une collation. (Les types de données intégrés supportant
+	les collations sont <type>text</type>, <type>varchar</type>,
+	et <type>char</type>. Les types de données définis par l'utilisateur
+	peuvent aussi être marqués comme supportant les collations.
+	Bien entendu, un domaine défini sur un type de données
+	supportant les collations les supporte aussi.)
+	Si l'expression est une référence de colonne, la collation de l'expression est déterminée
 	par la collation de la colonne. Si l'expression est une constante, la collation
-	utilisée sera la collation par défaut du type de données de la constante. La
+	sera celle par défaut du type de la constante. La
 	collation d'une expression plus complexe est déterminée à partir des
 	différentes collations de ses entrées, comme cela est décrit ci-dessous.
    </para>
 
    <para>
 	Une expression peut prendre la collation par défaut, <quote>default</quote>,
-	c'est à dire la collation définie au niveau de la base de données. Il est
+	c'est-à-dire la collation définie au niveau de la base de données. Il est
 	possible que la collation d'une expression soit indéterminée. Dans un tel cas,
-	les opérations de tri et les autres opérations qui ont besoin de connaître
+	les tris et les autres opérations ayant besoin de connaître
 	la collation vont échouer.
    </para>
 
    <para>
 	Lorsque la base de données doit réaliser un tri ou classement de caractères,
-	alors elle utilisera la collation de l'expression en entrée. Ce cas se
-	présentera, par exemple, si vous employez la clause <literal>ORDER BY</literal>
-	et des appels à des fonctions ou des opérateurs tels que <literal>&lt;</literal>.
-	La collation qui s'applique à une clause <literal>ORDER BY</literal> est
-	simplement la collation de la clé de tri. La collation qui s'applique pour
-	l'appel à une fonction ou à un opérateur est dérivé des arguments, comme
+	elle utilise la collation de l'expression entrée. Ce cas se
+	présentera, par exemple, avec des clauses <literal>ORDER BY</literal>,
+	ou des appels à des fonctions ou opérateurs tels que <literal>&lt;</literal>.
+	La collation à appliquer à une clause <literal>ORDER BY</literal> est
+	simplement la collation de la clé de tri. La collation à appliquer pour
+	l'appel à une fonction ou à un opérateur est dérivée des arguments, comme
 	décrit plus bas. En plus de s'appliquer aux opérateurs de comparaison, les
-	collations sont également prises en compte par les fonctions qui réalisent
-	les conversions entre minuscules et majuscules, comme <function>lower</function>,
-	<function>upper</function> et <function>initcap</function>&nbsp;; par les opérateurs de
-	correspondance de motifs et par <function>to_char</function> et les fonctions affiliées.
+	collations sont également prises en compte par les fonctions qui
+	convertissent entre minuscules et majuscules, comme <function>lower</function>,
+	<function>upper</function> et <function>initcap</function>, par les opérateurs de
+	correspondance de motifs, et par <function>to_char</function> et les fonctions affiliées.
    </para>
 
    <para>
-	Pour un appel à une fonction ou un opérateur, la collation est déterminée
-	à partir de la collation des arguments qui sont passés à l'exécution de
-	l'opération. Si une expression voisine nécessite de connaître la collation
-	de la fonction ou de l'opérateur, et si le type de données du résultat
-	de l'appel possède une collation alors cette collation est interprétée
-	comme la collation de l'expression au moment de l'analyse.
+	Pour un appel à une fonction ou un opérateur, la collation dérivée
+	des collations des arguments est utilisée à l'exécution de
+	l'opération. Si le type du résultat
+	de la fonction ou de l'opérateur supporte les collations, alors cette collation est utilisée
+	dès l'analyse en tant que la collation de la fonction ou de l'opérateur,
+	au cas où une expression voisine nécessiterait de la connaître.
    </para>
 
    <para>
 	Le <firstterm>calcul de la collation</firstterm> d'une expression est
 	réalisé implicitement ou explicitement. Cette distinction affecte la façon
-	dont les collations sont combinées entre elles lorsque plusieurs collations
-	différentes sont utilisées dans une expression. La collation d'une expression
-	peut être déterminée explicitement par l'emploi de la clause <literal>COLLATE</literal>&nbsp;;
-	dans les autres cas, la collation est déterminée de manière implicite. Les règles
+	dont les collations sont combinées entre elles quand plusieurs collations
+	différentes apparaissent dans une expression. 
+	Une dérivation explicite utilise la clause <literal>COLLATE</literal>&nbsp;;
+	dans tous les autres cas, la dérivation de collation est implicite. Les règles
 	suivantes s'appliquent lorsque plusieurs collations doivent être utilisée en
-    même temps, par exemple dans un appel à une fonction, les règles suivantes
-    s'appliquent:
+	même temps, par exemple dans un appel à une fonction&nbsp;:
 
     <orderedlist>
      <listitem>
       <para>
-	   Si la collation d'une expression d'entrée est déclarée explicitement
-	   alors les collations déclarée explicitement pour les autres
-	   expressions d'entrées doivent être les mêmes, sinon une erreur est levée.
-	   Si une expression en entrée contient une collation explicite,
-	   toutes les collations explicitement dérivées parmi les expressions
-	   en entrée doivent être identiques. Dans le cas contraire, une
-	   erreur est renvoyée. Si une collation dérivée explicitement est
+	   Si une expression en entrée porte une dérivation de collation explicite,
+	   alors toutes les collations explicitement dérivées des autres
+	   expressions en entrées doivent être identiques, sinon une erreur est levée.
+	   Si une collation explicitement dérivée est
 	   présente, elle est le résultat de la combinaison des collations.
       </para>
      </listitem>
@@ -428,9 +424,9 @@
      <listitem>
       <para>
 	   Dans les autres cas, toutes les expressions en entrée doivent avoir
-	   la même collation, qu'elle soit implicite ou déterminée à partir
-	   de la collation par défaut. Si une collation est présente, autre
-	   que celle par défaut, elle est le résultat de la combinaison des
+	   la même collation, qu'elle soit implicitement dérivée, ou
+	   celle par défaut. Si est présente une collation autre
+	   que celle par défaut, alors elle est aussi le résultat de la combinaison des
 	   collations. Sinon, le résultat correspond à la collation par
 	   défaut.
       </para>
@@ -438,10 +434,11 @@
 
      <listitem>
       <para>
-	   S'il existe des collations implicites mais non par défaut qui
-	   entrent en conflit avec les expressions en entrée, alors la
+	   S'il existe, parmi les expressions en entrées,
+	   des collations implicites, qui ne sont pas celles par défaut,
+	   et qui entrent en conflit, alors la
 	   combinaison ne peut aboutir qu'à une collation indéterminée. Ce
-	   n'est pas une erreur sauf si la fonction appelée requiert une
+	   n'est pas une erreur, sauf si la fonction appelée requiert une
 	   application de la collation. Dans ce cas, une erreur est
 	   renvoyée lors de l'exécution.
       </para>
@@ -461,26 +458,26 @@ CREATE TABLE test1 (
     <programlisting>
 SELECT a &lt; 'foo' FROM test1;
     </programlisting>
-    la comparaison <literal>&lt;</literal> est réalisée en tenant compte
-    des règles de la locale <literal>de_DE</literal>, parce que l'expression
-    combine la collation calculée implicitement avec la collation par défaut.
+    la comparaison <literal>&lt;</literal> est réalisée selon
+    les règles de la locale <literal>de_DE</literal>, car l'expression
+    combine une collation dérivée implicitement avec la collation par défaut.
     Mais, dans la requête
     <programlisting>
 	SELECT a &lt; ('foo' COLLATE "fr_FR") FROM test1;
 	</programlisting>
 	la comparaison est effectuée en utilisant les règles de la locale <literal>fr_FR</literal>,
 	parce que l'utilisation explicite de cette locale prévaut sur la locale
-	déterminée de manière implicite.
+	implicite.
 	De plus, avec la requête
 	<programlisting>
 	SELECT a &lt; b FROM test1;
 	</programlisting>
 	l'analyseur ne dispose pas des éléments pour déterminer quelle collation
 	employer, car les collations des colonnes <structfield>a</structfield> et <structfield>b</structfield>
-	sont différentes. Comme l'opérateur <literal>&lt;</literal> a besoin de connaître
-	quelle locale utiliser, une erreur sera générée. Cette erreur peut être résolue
+	sont différentes. Comme l'opérateur <literal>&lt;</literal> a besoin de savoir
+	la locale à utiliser, on obtiendra une erreur. Elle peut être résolue
 	en attachant une déclaration de collation explicite à l'une ou l'autre des expressions
-	d'entrées, soit:
+	d'entrées, soit&nbsp;:
 <programlisting>
 	SELECT a &lt; b COLLATE "de_DE" FROM test1;
     </programlisting>
@@ -489,33 +486,31 @@ SELECT a &lt; 'foo' FROM test1;
 	SELECT a COLLATE "de_DE" &lt; b FROM test1;
     </programlisting>
 
-    Toutefois, pour un cas structurellement similaire comme
+    Toutefois, dans ce cas suivant, structurellement similaire,
     <programlisting>
 SELECT a || b FROM test1;
     </programlisting>
-    ne retournera pas d'erreur car l'opérateur <literal>||</literal> ne tient
-    pas compte des collations: son résultat sera le même quel que soit
-    la collation.
+    il n'y aura pas d'erreur, car l'opérateur <literal>||</literal> ne tient
+    pas compte des collations&nbsp;: son résultat sera le même quelle qu'elle soit.
    </para>
 
    <para>
-    La collation qui est assignée à une fonction ou à une combinaison d'un
+    La collation assignée à une fonction ou à une combinaison d'un
     opérateur avec ses expressions d'entrées s'applique également au résultat
-    de la fonction ou de l'opérateur. Bien évidemment, cela s'applique que si
-    la fonction de l'opérateur délivre un résultat dans un type de données auquel
-    la collation peut s'appliquer. Ainsi, dans la requête
+    de la fonction ou de l'opérateur, si le résultat est d'un type supportant les collations.
+    Ainsi, dans la requête
     <programlisting>
 	SELECT * FROM test1 ORDER BY a || 'foo';
 	</programlisting>
 	le tri sera réalisé en fonction des règles de la locale <literal>de_DE</literal>.
-	Mais cette requête:
+	Mais cette requête&nbsp;:
 <programlisting>
 SELECT * FROM test1 ORDER BY a || b;
     </programlisting>
-    retournera une erreur car bien que l'opérateur <literal>||</literal> ne tienne pas
-    compte des collations de ses expressions, la clause <literal>ORDER BY</literal> en tient
-    compte. Comme précédemment, ce conflit peut être résolue par l'emploi d'une
-    déclaration explicite de la collation:
+    retournera une erreur car, bien que l'opérateur <literal>||</literal> ne tienne pas
+    compte des collations de ses expressions, la clause <literal>ORDER BY</literal>, elle, en tient
+    compte. Comme précédemment, ce conflit peut être résolu par l'emploi d'une
+    déclaration explicite de la collation&nbsp;:
     <programlisting>
 SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
     </programlisting>
@@ -526,42 +521,41 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
    <title>Gestion des collations</title>
 
    <para>
-    Une collation est un objet du catalogue dont le nom au niveau SQL
-    correspond à une locale fournie par les bibliothèques installées sur le système. Une
-    définition de la collation a un <firstterm>fournisseur</firstterm> spécifiant quelle bibliothèque
+    Une collation est un objet du catalogue SQL qui associe un nom SQL
+    à une locale fournie par les bibliothèques installées sur le système. Une
+    définition de collation a un <firstterm>fournisseur</firstterm>, qui spécifie quelle bibliothèque
     fournit les données locales. L'un des fournisseurs standards est <literal>libc</literal>,
     qui utilise les locales fournies par la bibliothèque C du système. Ce sont les locales
-    les plus utilisées par des outils du système. Un autre fournisseur est
+    utilisées par la plupart des outils du système. Un autre fournisseur est
     <literal>icu</literal>, qui utilise la bibliothèque externe
-    ICU<indexterm><primary>ICU</primary></indexterm>. Les locales ICU peuvent
-    seulement être utilisées si le support d'ICU a été configuré lors de la
-    construction de PostgreSQL.
+    ICU<indexterm><primary>ICU</primary></indexterm>. Les locales ICU ne peuvent
+    être utilisées que si le support d'ICU a été configuré lors de la
+    compilation de PostgreSQL.
    </para>
 
    <para>
-    Un objet de type collation fourni par <literal>libc</literal> pointe sur
+    Un objet de type collation fourni par la <literal>libc</literal> pointe sur
     une combinaison de paramètres <symbol>LC_COLLATE</symbol> et
-    <symbol>LC_CTYPE</symbol>, comme accepté par l'appel système
+    <symbol>LC_CTYPE</symbol>, comme acceptés par l'appel système
     <literal>setlocale()</literal>.
     (Comme le nom le suggère, le principal objectif d'une collation est de
-    positionner <symbol>LC_COLLATE</symbol> qui contrôle l'ordre de tri.
+    positionner <symbol>LC_COLLATE</symbol>, qui contrôle l'ordre de tri.
     Dans la pratique, il est très rarement nécessaire de définir un
     paramètre <symbol>LC_CTYPE</symbol> différent de
-    <symbol>LC_COLLATE</symbol>. De cette façon, il est plus facile de
-    regrouper ces deux paramètres dans un même concept plutôt que de créer
+    <symbol>LC_COLLATE</symbol>. Il est donc plus facile de
+    regrouper ces deux paramètres dans un même concept, que de créer
     une infrastructure différente simplement pour pouvoir positionner
-    <symbol>LC_CTYPE</symbol> pour chaque requête.) De la même façon, une
-    collation <literal>libc</literal> est liée à un jeu de caractère (voir <xref linkend="multibyte"/>).
-    Ainsi, plusieurs jeux de caractères peuvent utiliser une collation portant
-    le même nom.
+    <symbol>LC_CTYPE</symbol> pour chaque expression.) De la même façon, une
+    collation <literal>libc</literal> est liée à un encodage de jeu de caractère (voir <xref linkend="multibyte"/>).
+    Le même nom de collation peut exister pour différents encodages.
    </para>
 
    <para>
     Un objet de type collation fourni par <literal>icu</literal> pointe sur un collateur nommé
-    fourni par la bibliothèque ICU.  ICU ne permet pas de paramétrages
-    <quote>collate</quote> et <quote>ctype</quote> séparés, ils sont donc
+    fourni par la bibliothèque ICU. ICU ne permet pas de séparer 
+    <quote>collate</quote> et <quote>ctype</quote>, ils sont donc
     toujours les mêmes. De même, les collations ICU sont indépendantes de
-    l'encodage, donc il n'y a toujours qu'une seule collation ICU pour un nom donné dans une
+    l'encodage&nbsp;; il n'y a donc toujours qu'une seule collation ICU pour un nom donné dans une
     base de données.
    </para>
 
@@ -570,10 +564,10 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
 
     <para>
      Les collations nommées <literal>default</literal>, <literal>C</literal>, et <literal>POSIX</literal>
-     sont disponibles sur toutes les plateformes. Les collations complémentaires seront
-     ou non disponibles en fonction de leur support au niveau du système d'exploitation.
-     La collation <literal>default</literal> permet d'utiliser les valeurs de
-     <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> telles que
+     sont disponibles sur toutes les plateformes. Des collations complémentaires peuvent
+     être disponibles, ou non, en fonction du support au niveau du système d'exploitation.
+     La collation <literal>default</literal> utilise les valeurs de
+     <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol>
      définies à la création de la base de données. Les collations <literal>C</literal> et
      <literal>POSIX</literal> spécifient toutes deux le comportement <quote>traditionnel C</quote>,
      dans lequel seuls les caractères ASCII de <quote><literal>A</literal></quote> à

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -664,15 +664,16 @@ SELECT a COLLATE "C" &lt; b COLLATE "POSIX" FROM test1;
      <title>Collations ICU</title>
 
      <para>
-      Avec ICU, il n'est pas nécessaire d'énumérer tous les noms de locales
+      Avec ICU, il n'est pas raisonnable d'énumérer tous les noms de locales
       possibles. ICU utilise un système de nommage particulier pour les
-      locales, mais il y a plus de façons de nommer une locale qu'il n'y a
-      actuellement de locales distinctes. <command>initdb</command>
-      utilise l'API ICU pour extraire un jeu de locales distinct afin de
+      locales, mais il y a plus de façons de nommer une locale qu'il n'y en a
+      réellement de distinctes. <command>initdb</command>
+      utilise les API d'ICU pour extraire un jeu de locales distinctes, afin de
       peupler le jeu initial de collations. Les collations fournies par ICU sont
-      créées dans l'environnement SQL avec des noms en suivant le format de balises
-      de langues BCP 47, avec une extension d'<quote>utilisation privée</quote>
-      <literal>-x-icu</literal> ajoutée pour les distinguer des locales de libc.
+      créées dans l'environnement SQL avec des noms suivant le format d'étiquettes
+      <!-- https://fr.wikipedia.org/wiki/%C3%89tiquette_d%27identification_de_langues_IETF -->
+      de langues BCP 47, plus une extension d'<quote>utilisation privée</quote>
+      <literal>-x-icu</literal>, ajoutée pour les distinguer des locales de libc.
      </para>
 
      <para>
@@ -692,8 +693,8 @@ SELECT a COLLATE "C" &lt; b COLLATE "POSIX" FROM test1;
          <para>Collation allemande pour l'Autriche, variante par défaut</para>
          <para>
           (Il y a aussi, par exemple, <literal>de-DE-x-icu</literal> ou
-          <literal>de-CH-x-icu</literal> mais, lorsque cette partie fut rédigée,
-          elles étaient équivalentes à <literal>de-x-icu</literal>.)
+          <literal>de-CH-x-icu</literal> mais, au moment de l'écriture de ces lignes,
+          elles sont équivalentes à <literal>de-x-icu</literal>.)
          </para>
         </listitem>
        </varlistentry>
@@ -702,8 +703,8 @@ SELECT a COLLATE "C" &lt; b COLLATE "POSIX" FROM test1;
         <term><literal>und-x-icu</literal> (pour <quote>undefined</quote>)</term>
         <listitem>
          <para>
-          Collation <quote>root</quote> ICU.  Utilisez ceci pour avoir un ordre de tri
-          linguistique agnostique raisonnable.
+          Collation <quote>racine</quote> ICU. Utilisez ceci pour avoir un ordre de tri
+          raisonnable et linguistiquement agnostique.
          </para>
         </listitem>
        </varlistentry>
@@ -711,7 +712,7 @@ SELECT a COLLATE "C" &lt; b COLLATE "POSIX" FROM test1;
      </para>
 
      <para>
-      Certains encodages parmi les moins fréquemment utilisés ne sont pas
+      Certains encodages (les moins fréquemment utilisés) ne sont pas
       supportés par ICU. Si c'est le cas pour l'encodage de la base de données,
       les enregistrements de collations ICU dans <literal>pg_collation</literal>
       sont ignorés. Tenter d'en utiliser un renverra une erreur du type
@@ -745,8 +746,8 @@ SELECT a COLLATE "C" &lt; b COLLATE "POSIX" FROM test1;
       <programlisting>
 CREATE COLLATION german (provider = libc, locale = 'de_DE');
       </programlisting>
-      Les valeurs exactes qui sont acceptables pour la clause
-      <literal>locale</literal> dans cette commande dépendent du système
+      Les valeurs exactes de la clause <literal>locale</literal>
+      acceptées par cette commande dépendent du système
       d'exploitation. Sur les systèmes Unix, la commande <literal>locale
        -a</literal> affichera une liste.
      </para>
@@ -754,10 +755,10 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
      <para>
       Comme les collations libc prédéfinies incluent déjà toutes les collations
       définies dans le système d'exploitation au moment de l'initialisation de
-      l'instance, il est souvent nécessaire de créer celles qui sont ajoutées
-      après coup. Des raisons possibles seraient l'utilisation d'un autre système
-      de nommage (auquel cas, voir aussi <xref linkend="collation-copy"/>) ou si
-      le système d'exploitation a été mis à jour pour fournir les définitions
+      l'instance, il n'est pas souvent nécessaire d'en créer de nouvelles.
+      Des raisons possibles sont l'utilisation d'un autre système
+      de nommage (auquel cas, voir aussi <xref linkend="collation-copy"/>), ou
+      une mise à jour du système d'exploitation pour fournir les définitions
       des nouvelles locales (auquel cas, voir aussi <link
       linkend="functions-admin-collation"><function>pg_import_system_collations()</function></link>).
      </para>
@@ -767,15 +768,14 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
      <title>Collations ICU</title>
 
      <para>
-      ICU permet la personnalisation des collations en dehors de l'ensemble pré-
-      enregistré langue/pays, préchargé par <command>initdb</command>. Les
+      ICU permet la personnalisation des collations en dehors de l'ensemble
+      pré-enregistré langue/pays, préchargé par <command>initdb</command>. Les
       utilisateurs sont encouragés à définir leur propres objets de collation
-      utilisant ces fonctionnalités pour rendre le comportement de tri
-      compatible avec leurs besoins.
+      pour adapter le comportement du tri à leurs besoins.
       Voir <ulink url="http://userguide.icu-project.org/locale"></ulink>
       et <ulink url="http://userguide.icu-project.org/collation/api"></ulink>
-      pour plus d'informations sur le nommage des locales ICU. L'ensemble de
-      noms et attributs acceptables dépend de la version ICU spécifique.
+      pour plus d'informations sur le nommage des locales ICU. L'ensemble des
+      noms et attributs acceptables dépend de la version ICU précise.
      </para>
 
      <para>
@@ -790,16 +790,16 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
           carnet d'adresses</para>
          <para>
           Le premier exemple sélectionne la locale ICU en utilisant une
-          <quote>balise de langue</quote> d'après BCP 47. Le deuxième exemple
+          <quote>étiquette de langue</quote> d'après BCP 47. Le deuxième exemple
           utilise la syntaxe de locale traditionnelle spécifique à ICU. La
-          préférence va au premier style mais il n'est pas supporté par les
+          préférence va au premier style, mais il n'est pas supporté par les
           anciennes versions d'ICU.
          </para>
          <para>
-          Notez que vous pouvez nommer comme vous le voulez les objets de
-          collation dans l'environnement SQL. Dans cet exemple, nous suivons le
+          Notez que, dans l'environnement SQL, vous pouvez nommer les objets de
+          collation comme vous le voulez. Dans cet exemple, nous suivons le
           style de nommage que les collations prédéfinies utilisent, qui suit
-          aussi BCP 47, mais qui n'est pas requis pour les collations définis
+          lui-même BCP 47, mais ce n'est pas obligatoire pour les collations définies
           par l'utilisateur.
          </para>
         </listitem>
@@ -880,7 +880,7 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
      </para>
 
      <para>
-      Notez qu'alors que ce système permet la création de collations qui
+      Notez qu'alors que, si ce système permet la création de collations qui
       <quote>ignorent la casse</quote> ou <quote>ignorent les accents</quote> ou
       quelque chose de similaire (en utilisant la clé <literal>ks</literal>),
       pour que ces collations se comportent d'une manière réellement insensible
@@ -888,18 +888,20 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
       non <firstterm>déterministes</firstterm> dans
       <command>CREATE COLLATION</command>;
       voir <xref linkend="collation-nondeterministic"/>.
-      Le cas échéant, les chaînes qui sont considérées comme égales d'après
-      la collation mais ne sont pas équivalentes au niveau de l'octet seront
+      Sinon, les chaînes qui sont considérées comme égales d'après
+      la collation, mais non équivalentes au niveau des octets seront
       triées en fonction des valeurs de leurs octets.
      </para>
 
      <note>
       <para>
-       Par design, ICU acceptera pratiquement toute chaîne comme nom de locale
-       et la fera correspondre à la locale la plus proche qu'il peut fournir en
-       utilisant la procédure fallback décrite dans sa documentation. De ce
+       De par sa conception, ICU acceptera pratiquement
+       n'importe quelle chaîne comme nom de locale,
+       et la fera correspondre à la locale la plus proche qu'il peut fournir, en
+       utilisant la procédure de «&nbsp;fallback&nbsp;» décrite dans sa documentation. De ce
+       <!-- https://unicode-org.github.io/icu/userguide/locale/#fallback -->
        fait, il n'y aura pas de retour direct si la spécification d'une
-       collation est composée en utilisant des fonctionnalités que
+       collation est composée avec des fonctionnalités que
        l'installation ICU donnée ne supporte pas. Il est donc recommandé de
        créer des cas de tests au niveau applicatif pour vérifier que les
        définitions de collations satisfont les besoins.
@@ -912,8 +914,8 @@ CREATE COLLATION german (provider = libc, locale = 'de_DE');
 
      <para>
       La commande <xref linkend="sql-createcollation"/> peut également être utilisée pour
-      créer une nouvelle collation depuis une collation existante, ce qui peut être utile afin
-      d'être capable d'utiliser une collation indépendante du système dans
+      créer une nouvelle collation depuis une collation existante, ce qui peut être utile
+      pour utiliser une collation indépendante du système dans
       les applications, de créer des noms compatibles, ou d'utiliser une collation fournie par ICU
       avec un nom plus lisible. Par exemple&nbsp;:
       <programlisting>
@@ -932,14 +934,14 @@ CREATE COLLATION french FROM "fr-x-icu";
      <firstterm>non déterministe</firstterm>. Une collation déterministe utilise
      des comparaisons déterministes, ce qui signifie qu'elle considère les chaînes
      de caractères comme égales seulement si elles sont constituées des mêmes
-     séquences d'octets. Les comparaisons non déterministes peuvent conclure
-     que des chaînes sont égales même si elles sont constituées d'octets différents.
-     Les cas d'usage typiques comprennent la comparaison insensible à la casse,
-     insensible aux accents, de même que la comparaison de chaînes
-     de différentes formes normales Unicode. C'est au fournisseur de collation
-     d'implémenter des comparaisons de ce type&nbsp;; le drapeau disant que
-     la collation est déterministe indique seulement si les chaînes égales
-     seront départagées ou non par une comparaison au niveau de l'octet.
+     séquences d'octets. Les comparaisons non déterministes peuvent considérer
+     des chaînes comme égales même si elles sont constituées d'octets différents.
+     Les cas d'usage typiques comprennent des comparaisons insensible à la casse,
+     ou insensible aux accents, de même que la comparaison de chaînes
+     dans différentes formes normales Unicode. C'est au fournisseur de collation
+     d'implémenter de telles comparaisons insensibles&nbsp;; le drapeau
+     donnant la collation comme déterministe n'indique que si les chaînes égales
+     doivent être départagées ou non par une comparaison au niveau de l'octet.
      Voir aussi <ulink url="https://www.unicode.org/reports/tr10">Unicode Technical
       Standard 10</ulink> pour plus d'information sur la terminologie.
     </para>
@@ -968,16 +970,16 @@ CREATE COLLATION ignore_accents (provider = icu, locale = 'und-u-ks-level1-kc-tr
      Toutes les collations standards et prédéfinies sont déterministes, et
      toutes les collations définies par les utilisateurs sont déterministes
      par défaut.
-     Alors que les collations non déterministes ont un comportement plus
+     Bien que les collations non déterministes aient un comportement plus
      <quote>correct</quote>, particulièrement considérant la puissance
      d'Unicode et ses nombreux cas spécifiques, elles ont aussi quelques
      inconvénients.
      D'abord, leur utilisation génère une pénalité de performance.
-     Il est à noter en particulier que le B-tree ne peut pas utiliser
-     la déduplication avec les index utilisant une collation non déterministe.
+     Il est à noter en particulier qu'un B-tree ne peut pas utiliser
+     la déduplication dans les index utilisant une collation non déterministe.
      Par ailleurs, certaines opérations ne sont pas possibles avec des
      collations non déterministes, comme la recherche par motif.
-     Par conséquent, elles devraient être utilisées uniquement dans les cas
+     Par conséquent, elles ne devraient être utilisées que dans les cas
      où elles sont spécifiquement désirables.
     </para>
 

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -3,8 +3,9 @@
  <title>Localisation</title>
 
  <para>
-  Ce chapitre décrit, du point de vue de l'administrateur, les fonctionnalités
-  de régionalisation (ou localisation) disponibles.
+  Ce chapitre décrit les fonctionnalités
+  de régionalisation (ou localisation) disponibles,
+  du point de vue de l'administrateur.
   <productname>PostgreSQL</productname> fournit deux approches
   différentes pour la gestion de la localisation&nbsp;:
 
@@ -12,19 +13,20 @@
    <listitem>
     <para>
      l'utilisation des fonctionnalités de locales du système d'exploitation pour
-     l'ordonnancement du tri, le formatage des chiffres, les messages
-     traduits et autres aspects spécifiques à la locale.
-     Ces aspects sont couverts dans <xref linkend="locale"/> et
+     adapter à la locale
+     l'ordre des tris, le formatage des chiffres, la traduction des messages
+     et d'autres aspects.
+     Ceci est couvert dans <xref linkend="locale"/> et
      <xref linkend="collation"/>.&nbsp;;
     </para>
    </listitem>
 
    <listitem>
     <para>
-     la fourniture d'un certain nombre d'encodages différents pour permettre
-     le stockage de texte dans toutes les langues et fournir la traduction de
-     l'encodage entre serveur et client.
-     Ces aspects sont couverts dans <xref linkend="multibyte"/>.
+     la fourniture d'un certain nombre d'encodages différents, afin de pouvoir
+     stocker du texte dans toutes les langues, et de la capacité à traduire
+     l'encodage entre client et serveur.
+     Ceci est couvert dans <xref linkend="multibyte"/>.
     </para>
    </listitem>
   </itemizedlist>
@@ -38,10 +40,10 @@
 
   <para>
    Le support des <firstterm>locales</firstterm> fait référence à une application
-   respectant les préférences culturelles au regard des alphabets,
-   du tri, du format des nombres, etc. <productname>PostgreSQL</productname> utilise
-   les possibilités offertes par C et <acronym>POSIX</acronym> du standard
-   ISO fournies par le système d'exploitation du serveur. Pour plus d'informations,
+   respectant les préférences culturelles portant sur les alphabets,
+   le tri, le format des nombres, etc. <productname>PostgreSQL</productname> utilise
+   les outils C et <acronym>POSIX</acronym> du standard
+   ISO fournis par le système d'exploitation du serveur. Pour plus d'informations,
    consulter la documentation du système.
   </para>
 
@@ -49,28 +51,28 @@
    <title>Aperçu</title>
 
    <para>
-    Le support des locales est configuré automatiquement lorsqu'un cluster de
-    base de données est créé avec <command>initdb</command>.
-    <command>initdb</command> initialise le cluster avec la valeur des
-    locales de son environnement d'exécution par défaut. Si le système est
+    Le support des locales est configuré automatiquement lorsqu'une instance de
+    base de données est créée avec <command>initdb</command>.
+    <command>initdb</command> initialise le cluster avec la valeur de
+    locale de son environnement d'exécution par défaut. Si le système est
     déjà paramétré pour utiliser la locale souhaitée pour le cluster, il n'y
-    a donc rien d'autre à faire. Si une locale différente est souhaitée (ou
-    que celle utilisée par le serveur n'est pas connue avec certitude), il
-    est possible d'indiquer à <command>initdb</command> la locale à
-    utiliser à l'aide de l'option <option>--locale</option>.
+    a donc rien d'autre à faire. Si l'on désire une locale différente, ou
+    si celle du serveur n'est pas connue avec certitude, il
+    est possible d'indiquer à <command>initdb</command> la locale
+    à l'aide de l'option <option>--locale</option>.
     Par exemple&nbsp;:
     <screen>initdb --locale=sv_SE</screen>
    </para>
 
    <para>
     Cet exemple pour les systèmes Unix positionne la locale au suédois
-    (<literal>sv</literal>) tel que parlé en
+    (<literal>sv</literal>), tel que parlé en
     Suède (<literal>SE</literal>). Parmi les autres possibilités, on peut
     inclure <literal>en_US</literal> (l'anglais américain) ou
-    <literal>fr_CA</literal> (français canadien). Si plus d'un ensemble de
+    <literal>fr_CA</literal> (français canadien). Si plusieurs ensembles de
     caractères peuvent être utilisés pour une locale, alors les spécifications
     peuvent prendre la forme <replaceable>langage_territoire.codeset</replaceable>.
-    Par exemple, <literal>fr_BE.UTF-8</literal> représente la langue française
+    Par exemple, <literal>fr_BE.UTF-8</literal> représente la langue française,
     telle qu'elle est parlée en Belgique (BE), avec un encodage
     <acronym>UTF-8</acronym>.
    </para>
@@ -81,7 +83,7 @@
     et de ce qui est installé. Sur la plupart des systèmes Unix, la commande
     <literal>locale -a</literal> fournit la liste des locales disponibles.
     Windows utilise des noms de locale plus verbeux, comme
-    <literal>German_Germany</literal> ou <literal>Swedish_Sweden.1252</literal>
+    <literal>German_Germany</literal> ou <literal>Swedish_Sweden.1252</literal>,
     mais le principe est le même.
    </para>
 
@@ -103,7 +105,7 @@
        <row>
         <entry><envar>LC_CTYPE</envar></entry>
         <entry>Classification de caractères (Qu'est-ce qu'une lettre&nbsp;?
-         La majuscule équivalente&nbsp;?)</entry>
+         Et la majuscule équivalente&nbsp;?)</entry>
        </row>
        <row>
         <entry><envar>LC_MESSAGES</envar></entry>
@@ -125,56 +127,56 @@
      </tgroup>
     </informaltable>
 
-    Les noms des catégories se traduisent par des options à la commande
-    <command>initdb</command> qui portent un nom identique pour surcharger
-    le choix de locale pour une catégorie donnée. Par exemple, pour utiliser
-    la locale français canadien avec des règles américaines pour le
-    formatage monétaire, on utilise
+    Les noms des catégories se traduisent en ceux des options
+    d'<command>initdb</command> pour surcharger
+    le choix de locale d'une catégorie donnée. Par exemple, pour utiliser
+    la locale français canadien, mais avec des règles américaines de
+    formatage monétaire, utilisez
     <literal>initdb --locale=fr_CA --lc-monetary=en_US</literal>.
    </para>
 
    <para>
-    Pour bénéficier d'un système qui se comporte comme s'il ne disposait pas du
-    support des locales, on utilise les locales spéciales <literal>C</literal>
-    ou un équivalent, <literal>POSIX</literal>.
+    Si vous voulez un système qui se comporte comme s'il n'avait aucun
+    support des locales, utilisez les locales spéciales <literal>C</literal>,
+    ou l'équivalent <literal>POSIX</literal>.
    </para>
 
    <para>
-    Certaines catégories de locales doivent avoir leur valeurs fixées lors de la
-    création de la base de données. Vous pouvez utiliser des paramétrages
-    différents pour chaque bases de données. En revanche, une fois que la base
-    est créée, les paramétrages de locales ne peuvent plus être modifiés.
+    Certaines catégories de locales doivent être fixées à la
+    création de la base de données. Elles peuvent différer
+    entre bases de données, mais, une fois la base
+    créée, elles ne peuvent plus être modifiées.
     <literal>LC_COLLATE</literal> et <literal>LC_CTYPE</literal> sont
-    ces catégories. Elles affectent l'ordre de tri des index et doivent donc
+    ces catégories. Elles affectent l'ordre de tri des index, et doivent donc
     rester inchangées, les index sur les colonnes de texte risquant d'être
     corrompus dans le cas contraire.
-    (Mais vous pouvez lever ces restrictions sur les collations, comme cela est
+    (Mais vous pouvez lever ces restrictions grâce aux collations, comme
     discuté dans <xref linkend="collation"/>.)
-    La valeur par défaut pour ces catégories
-    est déterminée lors de l'exécution d'<command>initdb</command>. Ces valeurs
-    sont utilisées quand de nouvelles bases de données sont créées, sauf si
-    d'autres valeurs sont indiquées avec la commande <command>CREATE
+    Les valeurs par défaut de ces catégories
+    sont déterminées à l'exécution d'<command>initdb</command>,
+    et utilisées à la création de nouvelles bases de données, sauf
+    indication contraire dans la commande <command>CREATE
     DATABASE</command>.
    </para>
 
    <para>
     Les autres catégories de locale peuvent être modifiées à n'importe quel
-    moment en configurant les variables d'environnement de même nom (voir la
+    moment en configurant les variables d'environnement de même nom (voir
     <xref linkend="runtime-config-client-format"/> pour de plus amples
-    détails). Les valeurs par défaut choisies par
-    <command>initdb</command> sont en fait écrites dans le fichier de
+    détails). Les valeurs choisies par
+    <command>initdb</command> sont en fait juste écrites dans le fichier de
     configuration <filename>postgresql.conf</filename> pour servir de
-    valeurs par défaut au démarrage du serveur. Si ces déclarations sont
-    supprimées du fichier <filename>postgresql.conf</filename>, le serveur
+    valeurs par défaut au démarrage du serveur. Si elles sont supprimées
+    du fichier <filename>postgresql.conf</filename>, le serveur
     hérite des paramètres de son environnement d'exécution.
    </para>
 
    <para>
-    Le comportement des locales du serveur est déterminé par les
+    Notez que les locales du serveur sont déterminées par les
     variables d'environnement vues par le serveur, pas par celles de
     l'environnement d'un quelconque client. Il est donc important de
     configurer les bons paramètres de locales avant le démarrage du serveur.
-    Cela a pour conséquence que, si les locales du client et du serveur
+    En conséquence, si les locales du client et du serveur
     diffèrent, les messages peuvent apparaître dans des langues différentes
     en fonction de leur provenance.
    </para>
@@ -183,17 +185,18 @@
     <para>
      Hériter la locale de l'environnement d'exécution signifie, sur la
      plupart des systèmes d'exploitation, la chose suivante&nbsp;:
-     pour une catégorie de locales donnée (l'ordonnancement par exemple)
-     les variables d'environnement <envar>LC_ALL</envar>,
-     <envar>LC_COLLATE</envar> (ou la variable qui correspond à la catégorie)
-     et <envar>LANG</envar> sont consultées dans cet ordre jusqu'à en
-     trouver une qui est fixée. Si aucune de ces variables n'est fixée,
-     c'est la locale par défaut, <literal>C</literal>, qui est utilisée.
+     pour une catégorie de locales donnée (disons la collation)
+     les variables d'environnement suivantes sont consultées dans cet ordre
+     jusqu'à en trouver une qui est définie&nbsp;:
+     <envar>LC_ALL</envar>,
+     <envar>LC_COLLATE</envar> (ou la variable correspondant à la catégorie)
+     et <envar>LANG</envar>. Si aucune de ces variables n'est définie,
+     la locale devient par défaut <literal>C</literal>.
     </para>
 
     <para>
      Certaines bibliothèques de localisation regardent aussi la variable
-     d'environnement <envar>LANGUAGE</envar> qui surcharge tout autre
+     d'environnement <envar>LANGUAGE</envar>, laquelle surcharge tout autre
      paramètre pour fixer la langue des messages. En cas de doute,
      lire la documentation du système d'exploitation,
      en particulier la partie concernant <application>gettext</application>.
@@ -202,9 +205,9 @@
 
    <para>
     Pour permettre la traduction des messages dans la langue préférée de
-    l'utilisateur, <acronym>NLS</acronym> doit avoir été activé pendant la
-    compilation (<literal>configure --enable-nls</literal>). Tout autre support
-    de la locale est construit automatiquement.
+    l'utilisateur, <acronym>NLS</acronym> doit avoir été activé à la
+    compilation (<literal>configure --enable-nls</literal>). Le reste
+    de l'outillage des locales est automatiquement inclus.
    </para>
   </sect2>
 
@@ -227,18 +230,18 @@
 
      <listitem>
       <para>
-       Les fonctions <function>upper</function>, <function>lower</function> et <function>initcap</function>
+       les fonctions <function>upper</function>, <function>lower</function> et <function>initcap</function>
        <indexterm><primary>upper</primary><secondary>et locales</secondary></indexterm>
-       <indexterm><primary>lower</primary><secondary>et locales</secondary></indexterm>
+       <indexterm><primary>lower</primary><secondary>et locales</secondary></indexterm>&nbsp;;
       </para>
      </listitem>
 
      <listitem>
       <para>
-       Les opérateurs de correspondance de motifs (<literal>LIKE</literal>, <literal>SIMILAR TO</literal>
-       et les expressions rationnelles de type POSIX); les locales affectent aussi bien
-       les opérateurs insensibles à la classe et le classement des caractères par les expressions
-       rationnelles portant sur des caractères.
+       les opérateurs de correspondance de motifs (<literal>LIKE</literal>, <literal>SIMILAR TO</literal>
+       et les expressions rationnelles de type POSIX)&nbsp;les locales affectent
+       les opérateurs insensibles à la classe, et le classement des caractères par les expressions
+       rationnelles portant sur des caractères&nbsp;;
        <indexterm><primary>LIKE</primary><secondary>et locales</secondary></indexterm>
        <indexterm><primary>expressions rationnelles</primary><secondary>et locales</secondary></indexterm>
       </para>
@@ -246,38 +249,38 @@
 
      <listitem>
       <para>
-       La famille de fonctions <function>to_char</function>.
-       <indexterm><primary>to_char</primary><secondary>et locales</secondary></indexterm>
+       la famille des fonctions <function>to_char</function>.
+       <indexterm><primary>to_char</primary><secondary>et locales</secondary></indexterm>&nbsp;;
       </para>
      </listitem>
 
      <listitem>
       <para>
-       La possibilité d'utiliser des index avec des clauses <literal>LIKE</literal>
+       l'utilisation d'index avec des clauses <literal>LIKE</literal>.
       </para>
      </listitem>
     </itemizedlist>
    </para>
 
    <para>
-    Le support des locales autres que <literal>C</literal> ou
-    <literal>POSIX</literal> dans <productname>PostgreSQL</productname> a
-    pour inconvénient son impact sur les performances. Il ralentit la gestion
-    des caractères et empêche l'utilisation des index ordinaires par
+    L'inconvénient du support dans <productname>PostgreSQL</productname>
+    des locales (autres que <literal>C</literal> ou <literal>POSIX</literal>)
+    est l'impact sur les performances. Il ralentit la gestion
+    des caractères, et empêche l'utilisation des index ordinaires lors d'un
     <literal>LIKE</literal>. Pour cette raison, il est préférable de
     n'utiliser les locales qu'en cas de réel besoin.
    </para>
 
    <para>
-    Toutefois, pour permettre à <productname>PostgreSQL</productname> d'utiliser
+    Toutefois, il existe plusieurs classes d'opérateurs personnalisées
+    pour permettre à <productname>PostgreSQL</productname> d'utiliser
     des index avec les clauses <literal>LIKE</literal> et une locale
-    différente de <literal>C</literal>, il existe plusieurs classes
-    d'opérateurs personnalisées. Elles permettent
-    la création d'un index qui réalise une stricte comparaison caractère par
-    caractère, ignorant les règles de comparaison des locales. Se référer à
+    autre que <literal>C</literal>. Ces classes permettent
+    la création d'un index réalisant une stricte comparaison caractère par
+    caractère, en ignorant les règles de comparaison des locales&nbsp;; se référer à
     la <xref linkend="indexes-opclass"/> pour plus d'informations. Une autre
     possibilité est de créer des index en utilisant la collation
-    <literal>C</literal>, comme cela est indiqué dans
+    <literal>C</literal>, comme discuté dans
     <xref linkend="collation"/>.
    </para>
   </sect2>
@@ -287,7 +290,7 @@
 
    <para>
     Si le support des locales ne fonctionne pas au regard des explications ci-dessus,
-    il faut vérifier que le support des locales du système d'exploitation est
+    vérifiez que le support au niveau du système d'exploitation est
     correctement configuré. Pour vérifier les locales installées sur
     le système, on peut utiliser la commande <literal>locale -a</literal>,
     si elle est fournie avec le système d'exploitation.
@@ -295,15 +298,15 @@
 
    <para>
     Il faut vérifier que <productname>PostgreSQL</productname> utilise
-    effectivement la locale supposée. Les paramètres <envar>LC_COLLATE</envar>
+    effectivement la locale que vous pensez. Les paramètres <envar>LC_COLLATE</envar>
     et <envar>LC_CTYPE</envar> sont déterminés lors de la création de la base
-    de données et ne peuvent pas être modifiés sauf en créant une nouvelle
+    de données, et ne peuvent pas être modifiés, sauf en créant une nouvelle
     base de données.
     D'autres paramètres de locale, y compris <envar>LC_MESSAGES</envar> et
     <envar>LC_MONETARY</envar>, sont déterminés initialement par
-    l'environnement dans lequel le serveur est lancé mais peuvent être
-    modifiés pendant l'exécution. Pour vérifier le paramétrage
-    de la locale active on utilise la commande <command>SHOW</command>.
+    l'environnement dans lequel le serveur est lancé, mais peuvent être
+    modifiés pendant l'exécution. Pour vérifier
+    la locale active, utilisez la commande <command>SHOW</command>.
    </para>
 
    <para>
@@ -313,20 +316,20 @@
    </para>
 
    <para>
-    Les applications clientes qui gèrent les erreurs en provenance du
-    serveur par l'analyse du texte du message d'erreur vont certainement
-    éprouver des difficultés lorsque les messages du serveur sont dans une langue
-    différente. Les auteurs de telles applications sont
-    invités à utiliser le schéma de code d'erreur à la place.
+    Certaines applications clientes, qui gèrent les erreurs en provenance du
+    serveur en analysant le texte des messages associés, auront
+    évidemment des problèmes lorsque ces messages du serveur seront
+    dans une autre langue. Les auteurs de telles applications sont
+    invités à utiliser plutôt le mécanisme de code d'erreur.
    </para>
 
    <para>
-    Le maintien de catalogues de traductions de messages nécessitent les
-    efforts permanents de beaucoup de volontaires qui souhaitent voir
+    Le maintien de catalogues de traduction des messages nécessite les
+    efforts permanents de beaucoup de volontaires souhaitant voir
     <productname>PostgreSQL</productname> parler correctement leur langue
-    préférée. Si certains messages dans une langue ne sont pas disponibles ou
+    préférée. Si certains messages dans une langue ne sont pas disponibles, ou
     pas complètement traduits, toute aide est la bienvenue. Pour apporter
-    son aide à ce projet, consulter le <xref linkend="nls"/> ou écrire à
+    votre aide à ce projet, consultez le <xref linkend="nls"/>, ou écrivez à
     la liste de diffusion des développeurs.
    </para>
   </sect2>
@@ -563,16 +566,16 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
    </para>
 
    <sect3>
-    <title>Standard de collations</title>
+    <title>Collations standard</title>
 
     <para>
      Les collations nommées <literal>default</literal>, <literal>C</literal>, et <literal>POSIX</literal>
      sont disponibles sur toutes les plateformes. Les collations complémentaires seront
      ou non disponibles en fonction de leur support au niveau du système d'exploitation.
      La collation <literal>default</literal> permet d'utiliser les valeurs de
-     <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> telles qu'elles ont été
+     <symbol>LC_COLLATE</symbol> et <symbol>LC_CTYPE</symbol> telles que
      définies à la création de la base de données. Les collations <literal>C</literal> et
-     <literal>POSIX</literal> spécifie toute deux le comportement <quote>traditionnel C</quote>,
+     <literal>POSIX</literal> spécifient toutes deux le comportement <quote>traditionnel C</quote>,
      dans lequel seuls les caractères ASCII de <quote><literal>A</literal></quote> à
      <quote><literal>Z</literal></quote> sont considérés comme des lettres, et les tris sont
      ordonnés strictement par valeur de l'octet du code caractère.
@@ -581,7 +584,7 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR";
     <para>
      En complément, la collation du standard SQL, nommée <literal>ucs_basic</literal>,
      est disponible avec l'encodage <literal>UTF8</literal>. Elle est équivalente
-     à <literal>C</literal> et trie les données par le point de code Unicode.
+     à <literal>C</literal>, et trie les données par le point de code Unicode.
     </para>
    </sect3>
 

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -1478,17 +1478,17 @@ by pg_wchar_table.mblen function for each encoding.
 
    <para>
     <command>initdb</command> définit le jeu de caractères par défaut (encodage)
-    pour un cluster. Par exemple,
+    pour une instance. Par exemple,
 
     <screen>initdb -E EUC_JP</screen>
 
      paramètre le jeu de caractères à
      <literal>EUC_JP</literal> (Extended Unix Code for Japanese).
-     L'option <option>--encoding</option> (option longue) peut aussi être
-     utilisée à la place de <option>-E</option>. Si aucune option
-     <option>-E</option> ou <option>--encoding</option> n'est
-     donnée, <command>initdb</command> tente de déterminer l'encodage approprié
-     en fonction de la locale indiquée ou de celle par défaut.
+     Vous préférerez peut-être l'option longue <option>--encoding</option>
+     à la place de <option>-E</option>. Si ni
+     <option>-E</option> ni <option>--encoding</option> n'est
+     donné, <command>initdb</command> tente de déterminer l'encodage approprié
+     en se basant sur la locale indiquée ou celle par défaut.
     </para>
 
     <para>
@@ -1508,8 +1508,8 @@ by pg_wchar_table.mblen function for each encoding.
 
     Notez que les commandes ci-dessus précisent de copier la base de données
     <literal>template0</literal>. Lors de la copie d'une autre base, les
-    paramètres d'encodage et de locale ne peuvent pas être modifiés de ceux de
-    la base de données source car cela pourrait corrompre les données. Pour
+    paramètres d'encodage et de locale repris de la base de données source
+    ne peuvent pas être modifiés, car cela pourrait corrompre les données. Pour
     plus d'informations, voir <xref linkend="manage-ag-templatedbs"/>.
    </para>
 
@@ -1520,17 +1520,17 @@ by pg_wchar_table.mblen function for each encoding.
     <command>psql</command>.
 
     <screen>$ <userinput>psql -l</userinput>
-                                         List of databases
-   Name | Owner | Encoding | Collation | Ctype | Access Privileges
------------+----------+-----------+-------------+-------------+-------------------------------------
- clocaledb | hlinnaka | SQL_ASCII | C | C |
- englishdb | hlinnaka | UTF8 | en_GB.UTF8 | en_GB.UTF8 |
- japanese | hlinnaka | UTF8 | ja_JP.UTF8 | ja_JP.UTF8 |
- korean | hlinnaka | EUC_KR | ko_KR.euckr | ko_KR.euckr |
- postgres | hlinnaka | UTF8 | fi_FI.UTF8 | fi_FI.UTF8 |
- template0 | hlinnaka | UTF8 | fi_FI.UTF8 | fi_FI.UTF8 | {=c/hlinnaka,hlinnaka=CTc/hlinnaka}
- template1 | hlinnaka | UTF8 | fi_FI.UTF8 | fi_FI.UTF8 | {=c/hlinnaka,hlinnaka=CTc/hlinnaka}
-(7 rows)</screen>
+                                Liste des bases de données
+   Nom     | Propriétaire | Encodage  | Collationnement | Type caract. |      Droits d'accès
+-----------+--------------+-----------+-----------------+--------------+------------------------------------
+ clocaledb | hlinnaka     | SQL_ASCII | C               | C            |
+ englishdb | hlinnaka     | UTF8      | en_GB.UTF8      | en_GB.UTF8   |
+ japanese  | hlinnaka     | UTF8      | ja_JP.UTF8      | ja_JP.UTF8   |
+ korean    | hlinnaka     | EUC_KR    | ko_KR.euckr     | ko_KR.euckr  |
+ postgres  | hlinnaka     | UTF8      | fi_FI.UTF8      | fi_FI.UTF8   |
+ template0 | hlinnaka     | UTF8      | fi_FI.UTF8      | fi_FI.UTF8   | {=c/hlinnaka,hlinnaka=CTc/hlinnaka}
+ template1 | hlinnaka     | UTF8      | fi_FI.UTF8      | fi_FI.UTF8   | {=c/hlinnaka,hlinnaka=CTc/hlinnaka}
+(7 lignes)</screen>
     </para>
 
     <important>

--- a/postgresql/charset.xml
+++ b/postgresql/charset.xml
@@ -1565,13 +1565,13 @@ by pg_wchar_table.mblen function for each encoding.
     <para>
      <productname>PostgreSQL</productname> automatise la conversion de jeux de
      caractères entre client et serveur pour un grand nombre de combinaisons
-     de jeux de caractères (<xref linkend="multibyte-conversions-supported"/>
+     de jeux de caractères (la <xref linkend="multibyte-conversions-supported"/>
      montre lesquels).
     </para>
 
     <para>
      Pour activer la conversion automatique des jeux de caractères, il
-     est nécessaire d'indiquer à <productname>PostgreSQL</productname>
+     faut indiquer à <productname>PostgreSQL</productname>
      le jeu de caractères (encodage) souhaité côté client. Il y a plusieurs
      façons de le faire&nbsp;:
 
@@ -1622,7 +1622,7 @@ by pg_wchar_table.mblen function for each encoding.
        <para>
         en utilisant <envar>PGCLIENTENCODING</envar>.
         Si la variable d'environnement <envar>PGCLIENTENCODING</envar> est définie
-        dans l'environnement client, l'encodage client est automatiquement
+        dans l'environnement client, cet encodage client est automatiquement
         sélectionné lors de l'établissement d'une connexion au serveur (cette
         variable peut être surchargée à l'aide de toute autre méthode
         décrite ci-dessus)&nbsp;;
@@ -1645,7 +1645,7 @@ by pg_wchar_table.mblen function for each encoding.
 
     <para>
      Si la conversion d'un caractère particulier n'est pas possible &mdash;
-     dans le cas d'encodages <literal>EUC_JP</literal> pour le serveur
+     par exemple dans le cas d'encodages <literal>EUC_JP</literal> pour le serveur
      et <literal>LATIN1</literal> pour le client, et que certains caractères
      japonais renvoyés n'ont pas de représentation en <literal>LATIN1</literal>
      &mdash; une erreur est remontée.
@@ -1656,9 +1656,9 @@ by pg_wchar_table.mblen function for each encoding.
      la conversion de l'encodage est désactivée quelque soit celui du serveur.
      (Toutefois, si l'encodage serveur n'est pas
      <literal>SQL_ASCII</literal>, le serveur testera toujours que les données
-     en entrée sont valides pour cet encodage&nbsp;; le résultat final est
-	 identique à si l'encodage client était le même que celui du serveur).
-     Comme pour le serveur, <literal>SQL_ASCII</literal> est déconseillé sauf à ne
+     en entrée sont valides pour son encodage&nbsp;; le résultat final est identique
+     à avoir comme encodage client celui du serveur).
+     Comme pour le serveur, <literal>SQL_ASCII</literal> est déconseillé, sauf à ne
      travailler qu'avec des données ASCII.
     </para>
    </sect2>
@@ -1888,7 +1888,7 @@ by pg_wchar_table.mblen function for each encoding.
        </row>
        <row>
         <entry><literal>SQL_ASCII</literal></entry>
-        <entry><emphasis>any (no conversion will be performed)</emphasis>
+        <entry><emphasis>tous (aucune conversion ne sera effectuée)</emphasis>
         </entry>
        </row>
        <row>
@@ -1993,8 +1993,8 @@ by pg_wchar_table.mblen function for each encoding.
          <footnote>
           <para>
            Les noms des conversions suivent un standard de nommage&nbsp;:
-           Le nom officiel de l'encodage source dont tous les caractères
-           non alphanumériques sont remplacés par le caractère de soulignement,
+           le nom officiel de l'encodage source, avec tous les caractères
+           non alphanumériques remplacés par un souligné,
            suivi de <literal>_to_</literal>, suivi du nom de l'encodage
            de destination transformé de la même manière.
            Par conséquent, ces noms diffèrent parfois des noms d'encodage
@@ -2637,8 +2637,8 @@ by pg_wchar_table.mblen function for each encoding.
     <title>Pour aller plus loin</title>
 
     <para>
-     Il existe quelques sources intéressantes pour commencer à maîtriser les différents
-     jeux de caractères.
+     Il existe quelques sources intéressantes pour commencer à découvrir les différents
+     systèmes d'encodage.
 
      <variablelist>
       <varlistentry>
@@ -2646,7 +2646,7 @@ by pg_wchar_table.mblen function for each encoding.
 
        <listitem>
         <para>
-         Contient des explications détaillées de <literal>EUC_JP</literal>,
+         Contient des explications détaillées sur <literal>EUC_JP</literal>,
          <literal>EUC_CN</literal>, <literal>EUC_KR</literal>,
          <literal>EUC_TW</literal>.
         </para>
@@ -2658,7 +2658,7 @@ by pg_wchar_table.mblen function for each encoding.
 
        <listitem>
         <para>
-         Le site web du Unicode Consortium.
+         Le site web du consortium Unicode.
         </para>
        </listitem>
       </varlistentry>
@@ -2669,7 +2669,7 @@ by pg_wchar_table.mblen function for each encoding.
        <listitem>
         <para>
          <acronym>UTF</acronym>-8 (8-bit UCS/Unicode Transformation
-         Format) est défini ici.
+         Format) est défini là.
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
Relecture complète de charset.xml

(Je sais, il n'y avait (théoriquement) rien à traduire de neuf dedans, mais il y avait une typo et ça a dérivé.)

Il y avait des lignes en trop dans les tableaux, un écran psql à traduire et reformater ;
sinon quelques typos et faux sens, et essentiellement des reformulations pour essayer d'alléger.