### PR TITLE
pageinspect: suppression d'un paragraphe en doublon

### DIFF
--- a/postgresql/pageinspect.xml
+++ b/postgresql/pageinspect.xml
@@ -171,40 +171,6 @@ test=# SELECT fsm_page_contents(get_raw_page('pg_class', 'fsm', 0));
   <variablelist>
    <varlistentry>
     <term>
-     <function>fsm_page_contents(page bytea) returns text</function>
-     <indexterm>
-      <primary>fsm_page_contents</primary>
-     </indexterm>
-    </term>
-
-    <listitem>
-     <para>
-      <function>fsm_page_contents</function> montre la structure interne du
-      nœud d'une page FSM. Par exemple&nbsp;:
-      <screen>
-test=# SELECT fsm_page_contents(get_raw_page('pg_class', 'fsm', 0));
-      </screen>
-      La sortie est une chaîne de texte multiligne, avec une ligne par nœud
-      dans l'arbre binaire au sein de la page.  Seuls ces nœuds qui ne valent
-      pas zéro sont affichés.  Le pointeur appelé « next », qui pointe vers le
-      prochain slot à être retourné depuis la page, est également affiché.
-     </para>
-
-     <para>
-      Voir <filename>src/backend/storage/freespace/README</filename> pour plus
-      d'information sur la structure d'une page FSM.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </sect2>
-
- <sect2>
-  <title>Fonctions Heap</title>
-
-  <variablelist>
-   <varlistentry>
-    <term>
      <function>heap_page_items(page bytea) returns setof record</function>
      <indexterm>
       <primary>heap_page_items</primary>


### PR DESCRIPTION
Voir les sommaires de : https://docs.postgresql.fr/14/pageinspect.html et https://www.postgresql.org/docs/14/pageinspect.html

Depuis la traduction v12 le titre  "Fonctions Heap" était doublé, avec un bout qui vient d'au-dessus.

