### PR TITLE
Remplacement de "déclencheur" par "trigger"

### DIFF
--- a/postgresql/brin.xml
+++ b/postgresql/brin.xml
@@ -80,7 +80,7 @@
     <function>brin_summarize_new_values(regclass)</function>&nbsp;;
     automatiquement lorsque <command>VACUUM</command> va inspecter la
     table&nbsp;; ou par un résumé automatique effectué par autovacuum, au fur
-    et à mesure que des insertions sont effectuées.  (Ce dernier déclencheur
+    et à mesure que des insertions sont effectuées. (Ce dernier trigger
     est désactivé par défaut, et peut être activé avec le paramètre
     <literal>autosummarize</literal>.)  Inversement, le résumé d'un intervalle
     peut être supprimé en utilisant la fonction

--- a/postgresql/catalogs.xml
+++ b/postgresql/catalogs.xml
@@ -333,7 +333,7 @@
 
      <row>
       <entry><link linkend="catalog-pg-trigger"><structname>pg_trigger</structname></link></entry>
-      <entry>déclencheurs</entry>
+      <entry>triggers</entry>
      </row>
 
      <row>
@@ -8453,7 +8453,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
 
   <para>
    Le catalogue <structname>pg_trigger</structname> stocke les informations
-   concernant les déclencheurs des tables et des vues. Voir la commande
+   concernant les triggers des tables et des vues. Voir la commande
    <xref linkend="sql-createtrigger"/>
    pour plus d'informations.
   </para>
@@ -8488,7 +8488,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         (référence <link linkend="catalog-pg-class"><structname>pg_class</structname></link>.<structfield>oid</structfield>)
        </para>
        <para>
-        Table sur laquelle porte le déclencheur
+        Table sur laquelle porte le trigger
        </para></entry>
      </row>
 
@@ -8509,7 +8509,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         <structfield>tgname</structfield> <type>name</type>
        </para>
        <para>
-        Nom du déclencheur (doit être unique parmi les déclencheurs
+        Nom du trigger (doit être unique parmi les triggers
         d'une table)
        </para></entry>
      </row>
@@ -8599,7 +8599,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         <structfield>tgdeferrable</structfield> <type>bool</type>
        </para>
        <para>
-        Vrai si le déclencheur contrainte est retardable
+        Vrai si le trigger contrainte est retardable
        </para></entry>
      </row>
 
@@ -8608,7 +8608,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         <structfield>tginitdeferred</structfield> <type>bool</type>
        </para>
        <para>
-        Vrai si le déclencheur de contrainte est initialement retardé
+        Vrai si le trigger de contrainte est initialement retardé
        </para></entry>
      </row>
 
@@ -8618,7 +8618,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
        </para>
        <para>
         Nombre de chaînes d'arguments passées à la fonction du
-        déclencheur
+        trigger
        </para></entry>
      </row>
 
@@ -8638,7 +8638,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         <structfield>tgargs</structfield> <type>bytea</type>
        </para>
        <para>
-        Chaînes d'arguments à passer au déclencheur, chacune terminée par un
+        Chaînes d'arguments à passer au trigger, chacune terminée par un
         NULL
        </para></entry>
      </row>
@@ -14116,7 +14116,7 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
         (référence <link linkend="catalog-pg-class"><structname>pg_class</structname></link>.<structfield>relhastriggers</structfield>)
        </para>
        <para>
-        Vrai si la table dispose (ou disposait) de déclencheurs
+        Vrai si la table dispose (ou disposait) de triggers
        </para></entry>
      </row>
      <row>

--- a/postgresql/contrib-spi.xml
+++ b/postgresql/contrib-spi.xml
@@ -12,11 +12,11 @@
   fonctionnels d'utilisation de l'<link linkend="spi">interface de
    programmation du serveur (<foreignphrase>Server Programming
     Interface</foreignphrase>)</link> (<acronym>SPI</acronym>) et des
-  déclencheurs. Bien que ces fonctions aient un
+  triggers. Bien que ces fonctions aient un
   intérêt certain, elles sont encore plus utiles en tant qu'exemples
   à modifier pour atteindre ses propres buts. Les fonctions sont suffisamment
   généralistes pour être utilisées avec une table quelconque, mais la création d'un
-  déclencheur impose que les noms des tables et des champs soient précisés
+  trigger impose que les noms des tables et des champs soient précisés
   (comme cela est décrit ci-dessous).
  </para>
 
@@ -39,26 +39,26 @@
 
   <para>
    <function>check_primary_key()</function> vérifie la table de référence.
-   Pour l'utiliser, on crée un déclencheur <literal>BEFORE INSERT OR UPDATE</literal>
+   Pour l'utiliser, on crée un trigger <literal>BEFORE INSERT OR UPDATE</literal>
    qui utilise cette fonction sur une table référençant une autre table.
-   En arguments du déclencheur, on trouve&nbsp;: le nom de la colonne
+   En arguments du trigger, on trouve&nbsp;: le nom de la colonne
    de la table référençant qui forme la clé étrangère, le nom de la table
    référencée et le nom de la colonne de la table référencée qui forme la
    clé primaire/unique. Il peut y avoir plusieurs colonnes. Pour gérer
-   plusieurs clés étrangères, on crée un déclencheur pour chaque référence.
+   plusieurs clés étrangères, on crée un trigger pour chaque référence.
   </para>
 
   <para>
    <function>check_foreign_key()</function> vérifie la table référencée.
-   Pour l'utiliser, on crée un déclencheur <literal>BEFORE DELETE OR UPDATE</literal>
+   Pour l'utiliser, on crée un trigger <literal>BEFORE DELETE OR UPDATE</literal>
    qui utilise cette fonction sur une table référencée par d'autres tables.
-   En arguments du déclencheur, on trouve&nbsp;: le nombre de tables référençant pour
+   En arguments du trigger, on trouve&nbsp;: le nombre de tables référençant pour
    lesquelles la fonction réalise la vérification, l'action à exécuter si une clé
    de référence est trouvée (<literal>cascade</literal> &mdash; pour supprimer
    une ligne qui référence, <literal>restrict</literal> &mdash; pour annuler la
    transaction si des clés de référence existent, <literal>setnull</literal>
    &mdash; pour initialiser les champs des clés référençant à NULL), les noms
-   des colonnes de la table surveillées par le déclencheur, colonnes qui
+   des colonnes de la table surveillées par le trigger, colonnes qui
    forment la clé primaire/unique, puis le nom de la table référençant et les noms des
    colonnes (répétés pour autant de tables référençant que cela est précisé par
    le premier argument). Les colonnes de clé
@@ -76,7 +76,7 @@
    d'un champ</title>
 
   <para>
-   <function>autoinc()</function> est un déclencheur qui stocke la prochaine valeur
+   <function>autoinc()</function> est un trigger qui stocke la prochaine valeur
    d'une séquence dans un champ de type integer. Cela recouvre quelque peu
    la fonctionnalité interne de la colonne <quote>serial</quote>, mais
    ce n'est pas strictement identique&nbsp;: <function>autoinc()</function>
@@ -86,9 +86,9 @@
   </para>
 
   <para>
-   Pour l'utiliser, on crée un déclencheur <literal>BEFORE INSERT</literal> (ou
+   Pour l'utiliser, on crée un trigger <literal>BEFORE INSERT</literal> (ou
    en option <literal>BEFORE INSERT OR UPDATE</literal>) qui utilise cette
-   fonction. Le déclencheur accepte deux arguments&nbsp;: le nom de la
+   fonction. Le trigger accepte deux arguments&nbsp;: le nom de la
    colonne de type integer à modifier et le nom de la séquence qui fournit
    les valeurs. (En fait, plusieurs paires de noms peuvent être indiquées pour
    actualiser plusieurs colonnes.)
@@ -105,15 +105,15 @@
    ont modifié une table</title>
 
   <para>
-   <function>insert_username()</function> est un déclencheur qui stocke le
+   <function>insert_username()</function> est un trigger qui stocke le
    nom de l'utilisateur courant dans un champ texte. C'est utile pour
    savoir quel est le dernier utilisateur à avoir modifié une ligne particulière d'une
    table.
   </para>
 
   <para>
-   Pour l'utiliser, on crée un déclencheur <literal>BEFORE INSERT</literal> et/ou
-   <literal>UPDATE</literal> qui utilise cette fonction. Le déclencheur prend
+   Pour l'utiliser, on crée un trigger <literal>BEFORE INSERT</literal> et/ou
+   <literal>UPDATE</literal> qui utilise cette fonction. Le trigger prend
    pour seul argument le nom de la colonne texte à modifier.
   </para>
 
@@ -128,15 +128,15 @@
    de la dernière modification</title>
 
   <para>
-   <function>moddatetime()</function> est un déclencheur qui stocke la date et
+   <function>moddatetime()</function> est un trigger qui stocke la date et
    l'heure de la dernière modification dans un champ de type
    <type>timestamp</type>. C'est utile pour savoir quand a eu lieu la
    dernière modification sur une ligne particulière d'une table.
   </para>
 
   <para>
-   Pour l'utiliser, on crée un déclencheur <literal>BEFORE UPDATE</literal> qui
-   utilise cette fonction. Le déclencheur prend pour seul argument le
+   Pour l'utiliser, on crée un trigger <literal>BEFORE UPDATE</literal> qui
+   utilise cette fonction. Le trigger prend pour seul argument le
    nom de la colonne de type à modifier.
    La colonne doit être de type <type>timestamp</type> ou <type>timestamp with
     time zone</type>.

--- a/postgresql/datatype.xml
+++ b/postgresql/datatype.xml
@@ -5375,7 +5375,7 @@ WHERE ...</programlisting>
 
        <row>
         <entry><type>trigger</type></entry>
-        <entry>Une fonction déclencheur est déclarée comme retournant un type
+        <entry>Une fonction trigger est déclarée comme retournant un type
          <type>trigger</type>.</entry>
        </row>
 

--- a/postgresql/event-trigger.xml
+++ b/postgresql/event-trigger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <chapter id="event-triggers">
- <title>Déclencheurs (triggers) sur événement</title>
+ <title>Triggers sur événement</title>
 
  <indexterm zone="event-triggers">
   <primary>trigger sur événement</primary>

--- a/postgresql/high-availability.xml
+++ b/postgresql/high-availability.xml
@@ -1589,7 +1589,7 @@ synchronous_standby_names = 'FIRST 2 (s1, s2, s3)'
   <para>
    Pour déclencher le failover d'un serveur secondaire en log shipping,
    exécutez la commande <command>pg_ctl promote</command>, lancez la fonction
-   <function>pg_promote()</function> ou créez un fichier trigger (déclencheur)
+   <function>pg_promote()</function> ou créez un fichier trigger
    avec le nom de fichier et le chemin spécifiés par le paramètre
    <varname>promote_trigger_file</varname>. Si vous comptez utiliser la commande
    <command>pg_ctl promote</command> ou la fonction

--- a/postgresql/information_schema.xml
+++ b/postgresql/information_schema.xml
@@ -7550,7 +7550,7 @@ ORDER BY c.ordinal_position;
         <structfield>trigger_catalog</structfield> <type>sql_identifier</type>
        </para>
        <para>
-        Nom de la base de données qui contient le déclencheur (toujours la
+        Nom de la base de données qui contient le trigger (toujours la
         base de données courante)
        </para></entry>
      </row>
@@ -7560,7 +7560,7 @@ ORDER BY c.ordinal_position;
         <structfield>trigger_schema</structfield> <type>sql_identifier</type>
        </para>
        <para>
-        Nom du schéma qui contient le déclencheur
+        Nom du schéma qui contient le trigger
        </para></entry>
      </row>
 
@@ -7569,7 +7569,7 @@ ORDER BY c.ordinal_position;
         <structfield>trigger_name</structfield> <type>sql_identifier</type>
        </para>
        <para>
-        Nom du déclencheur
+        Nom du trigger
        </para></entry>
      </row>
 
@@ -7578,7 +7578,7 @@ ORDER BY c.ordinal_position;
         <structfield>event_object_catalog</structfield> <type>sql_identifier</type>
        </para>
        <para>
-        Nom de la base de données qui contient la table sur laquelle est défini le déclencheur
+        Nom de la base de données qui contient la table sur laquelle est défini le trigger
         (toujours la base de données courante)
        </para></entry>
      </row>
@@ -7589,7 +7589,7 @@ ORDER BY c.ordinal_position;
        </para>
        <para>
         Nom du schéma qui contient la table sur laquelle est défini le
-        déclencheur
+        trigger
        </para></entry>
      </row>
 
@@ -7598,7 +7598,7 @@ ORDER BY c.ordinal_position;
         <structfield>event_object_table</structfield> <type>sql_identifier</type>
        </para>
        <para>
-        Nom de la table sur laquelle est défini le déclencheur
+        Nom de la table sur laquelle est défini le trigger
        </para></entry>
      </row>
 
@@ -7607,7 +7607,7 @@ ORDER BY c.ordinal_position;
         <structfield>event_object_column</structfield> <type>sql_identifier</type>
        </para>
        <para>
-        Nom de la colonne sur laquelle est défini le déclencheur
+        Nom de la colonne sur laquelle est défini le trigger
        </para></entry>
      </row>
     </tbody>
@@ -7733,7 +7733,7 @@ ORDER BY c.ordinal_position;
         <structfield>action_statement</structfield> <type>character_data</type>
        </para>
        <para>
-        Instruction exécutée par le déclencheur (actuellement toujours
+        Instruction exécutée par le trigger (actuellement toujours
         <literal>EXECUTE FUNCTION
          <replaceable>fonction</replaceable>(...)</literal>)
        </para></entry>
@@ -7744,7 +7744,7 @@ ORDER BY c.ordinal_position;
         <structfield>action_orientation</structfield> <type>character_data</type>
        </para>
        <para>
-        Indique si le déclencheur est exécuté une fois par ligne
+        Indique si le trigger est exécuté une fois par ligne
         traitée ou une fois par instruction (<literal>ROW</literal> ou
         <literal>STATEMENT</literal>)
        </para></entry>
@@ -7812,27 +7812,27 @@ ORDER BY c.ordinal_position;
   </table>
 
   <para>
-   Les déclencheurs dans <productname>PostgreSQL</productname> ont deux
+   Les triggers dans <productname>PostgreSQL</productname> ont deux
    incompatibilités avec le standard SQL qui affectent leur représentation dans le
    schéma d'information.
   </para>
 
   <para>
-   Premièrement, les noms des déclencheurs sont locaux à chaque
+   Premièrement, les noms des triggers sont locaux à chaque
    table sous <productname>PostgreSQL</productname>, et ne sont pas des objets
-   du schéma indépendants. De ce fait, il peut exister des déclencheurs de même
+   du schéma indépendants. De ce fait, il peut exister des triggers de même
    noms au sein d'un schéma, pour peu qu'ils s'occupent de tables différentes.
    (<literal>trigger_catalog</literal> et <literal>trigger_schema</literal> sont
    les champs qui décrivent effectivement la table sur laquelle est défini le
-   déclencheur.)
+   trigger.)
   </para>
 
   <para>
-   Deuxièmement, les déclencheurs peuvent être définis pour
+   Deuxièmement, les triggers peuvent être définis pour
    s'exécuter sur plusieurs événements sous
    <productname>PostgreSQL</productname> (c'est-à-dire <literal>ON INSERT OR
     UPDATE</literal>) alors que le standard SQL n'en autorise qu'un. Si un
-   déclencheur est défini pour s'exécuter sur plusieurs événements, il est
+   trigger est défini pour s'exécuter sur plusieurs événements, il est
    représenté sur plusieurs lignes dans le schéma d'information, une pour chaque
    type d'événement.
   </para>
@@ -7842,9 +7842,9 @@ ORDER BY c.ordinal_position;
    <literal>(trigger_catalog, trigger_schema, event_object_table,
     trigger_name, event_manipulation)</literal> et non <literal>(trigger_catalog,
     trigger_schema, trigger_name)</literal> comme le spécifie le standard SQL.
-   Néanmoins, si les déclencheurs sont définis de manière conforme au
-   standard SQL (des noms de déclencheurs uniques dans le schéma et un seul
-   type d'événement par déclencheur), il n'y a pas lieu de se préoccuper de ces
+   Néanmoins, si les triggers sont définis de manière conforme au
+   standard SQL (des noms de triggers uniques dans le schéma et un seul
+   type d'événement par trigger), il n'y a pas lieu de se préoccuper de ces
    deux incompatibilités.
   </para>
 

--- a/postgresql/perform.xml
+++ b/postgresql/perform.xml
@@ -1758,10 +1758,10 @@ WHERE quelquechosedautre;</programlisting>
    <para>
     De plus, quand vous chargez des données dans une table contenant des
     contraintes de clés étrangères, chaque nouvelle ligne requiert une entrée
-    dans la liste des événements de déclencheur en attente(puisque c'est le
-    lancement d'un déclencheur qui vérifie la contrainte de clé étrangère de
+    dans la liste des événements de trigger en attente(puisque c'est le
+    lancement d'un trigger qui vérifie la contrainte de clé étrangère de
     la ligne). Le chargement de plusieurs millions de lignes peut amener la
-    taille de la file d'attente des déclencheurs à dépasser la mémoire
+    taille de la file d'attente des triggers à dépasser la mémoire
     disponible, causant ainsi une mise en mémoire swap intolérable, voire
     l'échec de la commande. Dans ce cas, il peut être
     <emphasis>nécessaire</emphasis>, pas seulement souhaitable, de supprimer

--- a/postgresql/plhandler.xml
+++ b/postgresql/plhandler.xml
@@ -89,7 +89,7 @@
  </para>
 
  <para>
-  Lorsqu'une fonction en langage procédural est appelée via un déclencheur,
+  Lorsqu'une fonction en langage procédural est appelée via un trigger,
   aucun argument ne lui est passé de façon traditionnelle mais le champ
   <structfield>context</structfield> de
   <structname>FunctionCallInfoBaseData</structname> pointe sur une structure
@@ -97,7 +97,7 @@
   <symbol>NULL</symbol> comme c'est le cas dans les appels de fonctions standard.
   Un gestionnaire de langage doit fournir les mécanismes pour que les
   fonctions de langages procéduraux obtiennent les informations du
-  déclencheur.
+  trigger.
  </para>
 
  <para>

--- a/postgresql/plperl.xml
+++ b/postgresql/plperl.xml
@@ -1167,14 +1167,14 @@ $$ LANGUAGE plperl;
  </sect1>
 
  <sect1 id="plperl-triggers">
-  <title>Déclencheurs PL/Perl</title>
+  <title>Triggers PL/Perl</title>
 
   <para>
-   PL/Perl peut être utilisé pour écrire des fonctions pour déclencheurs.
-   Dans une fonction déclencheur, la référence hachée
+   PL/Perl peut être utilisé pour écrire des fonctions pour triggers.
+   Dans une fonction trigger, la référence hachée
    <varname>$_TD</varname> contient des informations sur l'événement du
-   déclencheur en cours. <varname>$_TD</varname> est une variable globale
-   qui obtient une valeur locale séparée à chaque appel du déclencheur.
+   trigger en cours. <varname>$_TD</varname> est une variable globale
+   qui obtient une valeur locale séparée à chaque appel du trigger.
    Les champs de la référence de hachage
    <varname>$_TD</varname> sont&nbsp;:
 
@@ -1201,7 +1201,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{name}</literal></term>
      <listitem>
       <para>
-       Nom du déclencheur appelé
+       Nom du trigger appelé
       </para>
      </listitem>
     </varlistentry>
@@ -1210,7 +1210,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{event}</literal></term>
      <listitem>
       <para>
-       Événement du déclencheur&nbsp;: <literal>INSERT</literal>,
+       Événement du trigger&nbsp;: <literal>INSERT</literal>,
        <literal>UPDATE</literal>, <literal>DELETE</literal>,
        <literal>TRUNCATE</literal>, <literal>INSTEAD OF</literal> ou
        <literal>UNKNOWN</literal>
@@ -1222,7 +1222,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{when}</literal></term>
      <listitem>
       <para>
-       Quand le déclencheur a été appelé&nbsp;:
+       Quand le trigger a été appelé&nbsp;:
        <literal>BEFORE</literal> (avant), <literal>AFTER</literal>
        (après) ou <literal>UNKNOWN</literal> (inconnu)
       </para>
@@ -1233,7 +1233,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{level}</literal></term>
      <listitem>
       <para>
-       Le niveau du déclencheur&nbsp;: <literal>ROW</literal> (ligne),
+       Le niveau du trigger&nbsp;: <literal>ROW</literal> (ligne),
        <literal>STATEMENT</literal> (instruction) ou
        <literal>UNKNOWN</literal> (inconnu)
       </para>
@@ -1244,7 +1244,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{relid}</literal></term>
      <listitem>
       <para>
-       L'OID de la table sur lequel le déclencheur a été exécuté
+       L'OID de la table sur lequel le trigger a été exécuté
       </para>
      </listitem>
     </varlistentry>
@@ -1253,7 +1253,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{table_name}</literal></term>
      <listitem>
       <para>
-       Nom de la table sur lequel le déclencheur a été exécuté
+       Nom de la table sur lequel le trigger a été exécuté
       </para>
      </listitem>
     </varlistentry>
@@ -1262,7 +1262,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{relname}</literal></term>
      <listitem>
       <para>
-       Nom de la table sur lequel le déclencheur a été exécuté. Elle est obsolète
+       Nom de la table sur lequel le trigger a été exécuté. Elle est obsolète
        et pourrait être supprimée dans une prochaine version. Utilisez
        $_TD-&gt;{table_name} à la place.
       </para>
@@ -1273,7 +1273,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{table_schema}</literal></term>
      <listitem>
       <para>
-       Nom du schéma sur lequel le déclencheur a été exécuté.
+       Nom du schéma sur lequel le trigger a été exécuté.
       </para>
      </listitem>
     </varlistentry>
@@ -1282,7 +1282,7 @@ $$ LANGUAGE plperl;
      <term><literal>$_TD-&gt;{argc}</literal></term>
      <listitem>
       <para>
-       Nombre d'arguments de la fonction déclencheur
+       Nombre d'arguments de la fonction trigger
       </para>
      </listitem>
     </varlistentry>
@@ -1291,7 +1291,7 @@ $$ LANGUAGE plperl;
      <term><literal>@{$_TD-&gt;{args}}</literal></term>
      <listitem>
       <para>
-       Arguments de la fonction déclencheur. N'existe pas si
+       Arguments de la fonction trigger. N'existe pas si
        <literal>$_TD-&gt;{argc}</literal> vaut 0.
       </para>
      </listitem>
@@ -1301,7 +1301,7 @@ $$ LANGUAGE plperl;
   </para>
 
   <para>
-   Les déclencheurs niveau ligne peuvent renvoyer un des éléments suivants&nbsp;:
+   Les triggers niveau ligne peuvent renvoyer un des éléments suivants&nbsp;:
 
    <variablelist>
     <varlistentry>
@@ -1327,7 +1327,7 @@ $$ LANGUAGE plperl;
      <listitem>
       <para>
        Indique que la ligne <literal>NEW</literal> a été modifiée par la
-       fonction déclencheur
+       fonction trigger
       </para>
      </listitem>
     </varlistentry>
@@ -1335,7 +1335,7 @@ $$ LANGUAGE plperl;
   </para>
 
   <para>
-   Voici un exemple d'une fonction déclencheur illustrant certains points
+   Voici un exemple d'une fonction trigger illustrant certains points
    ci-dessus&nbsp;:
    <programlisting>CREATE TABLE test (
     i int,

--- a/postgresql/plpgsql.xml
+++ b/postgresql/plpgsql.xml
@@ -4017,7 +4017,7 @@ ASSERT <replaceable class="parameter">condition</replaceable> <optional> , <repl
  <title>Fonctions trigger</title>
 
  <indexterm zone="plpgsql-trigger">
-  <primary>déclencheur (trigger)</primary>
+  <primary>trigger (trigger)</primary>
   <secondary>en PL/pgSQL</secondary>
  </indexterm>
 
@@ -4593,7 +4593,7 @@ SELECT * FROM sales_summary_bytime;
   <para>
    Les triggers <literal>AFTER</literal> peuvent aussi utiliser les
    <firstterm>tables de transition</firstterm> pour inspecter l'ensemble
-   complet de lignes modifiées par l'instruction déclencheur. La commande
+   complet de lignes modifiées par l'instruction trigger. La commande
    <command>CREATE TRIGGER</command> donne des noms à la ou aux tables de
    transition. La fonction peut ensuite se référer à ces noms comme s'il
    s'agissait de tables temporaires en lecture seule. <xref
@@ -4610,7 +4610,7 @@ SELECT * FROM sales_summary_bytime;
     déclenche une fois par instruction, après avoir récupérer les
     informations intéressantes dans une table de transition. Cela peut être
     significativement plus rapide que l'approche du trigger par ligne lorsque
-    l'instruction déclencheur a modifié beaucoup de lignes. Notez qu'il est
+    l'instruction trigger a modifié beaucoup de lignes. Notez qu'il est
     nécessaire de faire une déclaration séparée du trigger pour chaque type
     d'événement car les clauses <literal>REFERENCING</literal> doivent être
     différentes dans chaque cas. Mais ceci ne nous empêche pas d'utiliser une

--- a/postgresql/plpython.xml
+++ b/postgresql/plpython.xml
@@ -660,10 +660,10 @@ $$ LANGUAGE plpython3u;
  </sect1>
 
  <sect1 id="plpython-trigger">
-  <title>Fonctions de déclencheurs</title>
+  <title>Fonctions de triggers</title>
 
   <indexterm zone="plpython-trigger">
-   <primary>déclencheur</primary>
+   <primary>trigger</primary>
    <secondary>en PL/Python</secondary>
   </indexterm>
 

--- a/postgresql/pltcl.xml
+++ b/postgresql/pltcl.xml
@@ -587,18 +587,18 @@ $$ LANGUAGE pltcl;
   <title>Fonctions triggers en PL/Tcl</title>
 
   <indexterm>
-   <primary>déclencheur</primary>
+   <primary>trigger</primary>
    <secondary>en PL/Tcl</secondary>
   </indexterm>
 
   <para>
    Les fonctions trigger peuvent être écrites en PL/Tcl.
-   <productname>PostgreSQL</productname> requiert qu'une fonction, devant
-   être appelée en tant que déclencheur, doit être déclarée comme une fonction
+   <productname>PostgreSQL</productname> requiert qu'une fonction
+   appelée en tant que trigger doit être déclarée comme une fonction
    sans arguments et retourner une valeur de type <literal>trigger</literal>.
   </para>
   <para>
-   L'information du gestionnaire de déclencheur est passée au corps de la
+   L'information du gestionnaire du trigger est passée au corps de la
    fonction avec les variables suivantes&nbsp;:
 
    <variablelist>
@@ -607,7 +607,7 @@ $$ LANGUAGE pltcl;
      <term><varname>$TG_name</varname></term>
      <listitem>
       <para>
-       Nom du déclencheur provenant de l'instruction <command>CREATE
+       Nom du trigger provenant de l'instruction <command>CREATE
         TRIGGER</command>.
       </para>
      </listitem>
@@ -618,7 +618,7 @@ $$ LANGUAGE pltcl;
      <listitem>
       <para>
        L'identifiant objet de la table qui est à la cause du lancement
-       du déclencheur.
+       du trigger.
       </para>
      </listitem>
     </varlistentry>
@@ -628,7 +628,7 @@ $$ LANGUAGE pltcl;
      <listitem>
       <para>
        Le nom de la table qui est à la cause du lancement
-       du déclencheur.
+       du trigger.
       </para>
      </listitem>
     </varlistentry>
@@ -638,7 +638,7 @@ $$ LANGUAGE pltcl;
      <listitem>
       <para>
        Le schéma de la table qui est à la cause du lancement
-       du déclencheur.
+       du trigger.
       </para>
      </listitem>
     </varlistentry>
@@ -663,7 +663,7 @@ $$ LANGUAGE pltcl;
       <para>
        La chaîne <literal>BEFORE</literal>, <literal>AFTER</literal> ou
        <literal>INSTEAD OF</literal> suivant le type
-       de l'événement du déclencheur.
+       de l'événement du trigger.
       </para>
      </listitem>
     </varlistentry>
@@ -673,7 +673,7 @@ $$ LANGUAGE pltcl;
      <listitem>
       <para>
        La chaîne <literal>ROW</literal> ou <literal>STATEMENT</literal> suivant le type
-       de l'événement du déclencheur.
+       de l'événement du trigger.
       </para>
      </listitem>
     </varlistentry>
@@ -684,7 +684,7 @@ $$ LANGUAGE pltcl;
       <para>
        La chaîne <literal>INSERT</literal>, <literal>UPDATE</literal>,
        <literal>DELETE</literal> ou <literal>TRUNCATE</literal> suivant le
-       type de l'événement du déclencheur.
+       type de l'événement du trigger.
       </para>
      </listitem>
     </varlistentry>
@@ -737,11 +737,11 @@ $$ LANGUAGE pltcl;
    de paires nom de colonne/valeur renvoyée par la commande Tcl
    <literal>array get</literal>. Si la valeur de retour est
    <literal>OK</literal>, l'opération (<command>INSERT</command>/<command>UP
-    DATE</command>/<command>DELETE</command>) qui a lancé le déclencheur
+    DATE</command>/<command>DELETE</command>) qui a lancé le trigger
    continuera normalement. <literal>SKIP</literal> indique au gestionnaire
-   de déclencheurs de supprimer silencieusement l'opération pour cette
+   de triggers de supprimer silencieusement l'opération pour cette
    ligne. Si une liste est renvoyée, elle indique à PL/Tcl de renvoyer la
-   ligne modifiée au gestionnaire de déclencheurs&nbsp;; le contenu de la
+   ligne modifiée au gestionnaire de triggers&nbsp;; le contenu de la
    ligne modifiée est spécifié par les noms de colonne et par les valeurs
    dans la liste. Toute colonne non mentionné dans la liste est configuré à
    NULL. Renvoyer une ligne modifiée n'a un intérêt que pour les triggers
@@ -797,7 +797,7 @@ CREATE TRIGGER trig_mytab_modcount BEFORE INSERT OR UPDATE ON mytab
    </programlisting>
 
    Notez que la fonction trigger elle-même ne connaît pas le nom de la
-   colonne&nbsp;; c'est fourni avec les arguments du déclencheur. Ceci permet
+   colonne&nbsp;; c'est fourni avec les arguments du trigger. Ceci permet
    à la fonction trigger d'être ré-utilisée avec différentes tables.
   </para>
  </sect1>

--- a/postgresql/ref/alter_table.xml
+++ b/postgresql/ref/alter_table.xml
@@ -605,7 +605,7 @@ KEY</literal>/<literal>REFERENCES</literal>&nbsp;:</phrase>
       <para>
        Configure l'exécution des triggers définis sur la table. Un trigger
        désactivé est toujours connu par le système mais n'est plus exécuté
-       lorsque l'événement déclencheur survient. Pour un trigger retardé, le
+       lorsque l'événement trigger survient. Pour un trigger retardé, le
        statut d'activité est vérifié au moment où survient l'événement, et non
        quand la fonction du trigger est réellement exécutée. Il est possible de
        désactiver ou d'activer un trigger spécifique (précisé par son nom), tous
@@ -1285,10 +1285,10 @@ KEY</literal>/<literal>REFERENCES</literal>&nbsp;:</phrase>
    </varlistentry>
 
    <varlistentry>
-    <term><replaceable class="parameter">nom_declencheur</replaceable></term>
+    <term><replaceable class="parameter">nom_trigger</replaceable></term>
     <listitem>
      <para>
-      Le nom d'un déclencheur isolé à désactiver ou activer.
+      Le nom d'un trigger isolé à désactiver ou activer.
      </para>
     </listitem>
    </varlistentry>

--- a/postgresql/ref/alter_trigger.xml
+++ b/postgresql/ref/alter_trigger.xml
@@ -63,7 +63,7 @@ ALTER TRIGGER <replaceable class="parameter">nom</replaceable> ON <replaceable c
     <term><replaceable class="parameter">nom_table</replaceable></term>
     <listitem>
      <para>
-      La table sur laquelle le déclencheur agit.
+      La table sur laquelle le trigger agit.
      </para>
     </listitem>
    </varlistentry>
@@ -72,7 +72,7 @@ ALTER TRIGGER <replaceable class="parameter">nom</replaceable> ON <replaceable c
     <term><replaceable class="parameter">nouveau_nom</replaceable></term>
     <listitem>
      <para>
-      Le nouveau nom du déclencheur.
+      Le nouveau nom du trigger.
      </para>
     </listitem>
    </varlistentry>

--- a/postgresql/ref/comment.xml
+++ b/postgresql/ref/comment.xml
@@ -351,7 +351,7 @@ COMMENT ON TEXT SEARCH DICTIONARY swedish IS 'Stemmer Snowball pour le Suédois'
 COMMENT ON TEXT SEARCH PARSER my_parser IS 'Divise le texte en mot';
 COMMENT ON TEXT SEARCH TEMPLATE snowball IS 'Stemmer Snowball';
 COMMENT ON TRANSFORM FOR hstore LANGUAGE plpython3u IS 'Transformation entre hstore et un dictionnaire Python';
-COMMENT ON TRIGGER mon_declencheur ON my_table IS 'Utilisé pour RI';
+COMMENT ON TRIGGER mon_trigger ON my_table IS 'Utilisé pour RI';
 COMMENT ON TYPE complex IS 'Type de données pour les nombres complexes';
 COMMENT ON VIEW ma_vue IS 'Vue des coûts départementaux';
    </programlisting>

--- a/postgresql/ref/copy.xml
+++ b/postgresql/ref/copy.xml
@@ -445,7 +445,7 @@ COPY <replaceable class="parameter">nombre</replaceable>
 
   <para>
    <command>COPY FROM</command> peut être utilisée avec une table standard et
-   avec des vues ayant des déclencheurs <literal>INSTEAD OF INSERT</literal>.
+   avec des vues ayant des triggers <literal>INSTEAD OF INSERT</literal>.
   </para>
 
   <para>
@@ -511,7 +511,7 @@ COPY <replaceable class="parameter">nombre</replaceable>
   </para>
 
   <para>
-   <command>COPY FROM</command> appelle tous les déclencheurs et
+   <command>COPY FROM</command> appelle tous les triggers et
    contraintes de vérification sur la table de destination, mais pas les
    règles.
   </para>

--- a/postgresql/ref/create_function.xml
+++ b/postgresql/ref/create_function.xml
@@ -85,7 +85,7 @@
   <para>
    En cas de suppression et de recréation d'une fonction, la nouvelle fonction n'est pas
    la même entité que l'ancienne&nbsp;; il faut supprimer les règles, vues,
-   déclencheurs, etc. qui référencent l'ancienne fonction.
+   triggers, etc. qui référencent l'ancienne fonction.
    <command>CREATE OR REPLACE FUNCTION</command> permet de modifier la définition
    d'une fonction sans casser les objets qui s'y réfèrent.
    De plus, <command>ALTER FUNCTION</command> peut être utilisé pour modifier la

--- a/postgresql/ref/create_rule.xml
+++ b/postgresql/ref/create_rule.xml
@@ -50,7 +50,7 @@
    &laquo;&nbsp;macro&nbsp;&raquo;. La transformation
    intervient avant l'exécution de la commande.
    Pour obtenir une opération qui s'exécute indépendamment
-   pour chaque ligne physique, il faut utiliser des déclencheurs.
+   pour chaque ligne physique, il faut utiliser des triggers.
    On trouvera plus d'informations sur le système des règles dans
    <xref linkend="rules"/>.
   </para>

--- a/postgresql/ref/create_trigger.xml
+++ b/postgresql/ref/create_trigger.xml
@@ -17,7 +17,7 @@
 
  <refnamediv>
   <refname>CREATE TRIGGER</refname>
-  <refpurpose>Définir un nouveau déclencheur</refpurpose>
+  <refpurpose>Définir un nouveau trigger</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -43,9 +43,9 @@
   <title>Description</title>
 
   <para>
-   <command>CREATE TRIGGER</command> crée un nouveau déclencheur.
+   <command>CREATE TRIGGER</command> crée un nouveau trigger.
    <command>CREATE OR REPLACE TRIGGER</command> va soit créer un nouveau
-   trigger, soit remplacer un trigger existant. Le déclencheur est associé à
+   trigger, soit remplacer un trigger existant. Le trigger est associé à
    la table, à la vue ou à la table distante spécifiée et exécute la fonction
    <replaceable class="parameter">nom_fonction</replaceable> lorsque
    certaines opérations sont réalisées sur cette table.
@@ -59,49 +59,49 @@
   </para>
 
   <para>
-   L'appel du déclencheur peut avoir lieu avant que l'opération
+   L'appel du trigger peut avoir lieu avant que l'opération
    ne soit tentée sur une ligne (avant la vérification des contraintes et
    la tentative d'<command>INSERT</command>, <command>UPDATE</command> ou
    <command>DELETE</command>) ou une fois que l'opération est
    terminée (après la vérification des contraintes et la fin de la commande
    <command>INSERT</command>, <command>UPDATE</command> ou
    <command>DELETE</command>)&nbsp;; ou bien en remplacement de l'opération
-   (dans le cas d'opérations INSERT, UPDATE ou DELETE sur une vue). Si le déclencheur est lancé avant
-   l'événement ou en remplacement de l'événement, le déclencheur peut ignorer l'opération sur la ligne
+   (dans le cas d'opérations INSERT, UPDATE ou DELETE sur une vue). Si le trigger est lancé avant
+   l'événement ou en remplacement de l'événement, le trigger peut ignorer l'opération sur la ligne
    courante ou modifier la ligne en cours d'insertion (uniquement pour les
    opérations <command>INSERT</command> et <command>UPDATE</command>). Si le
-   déclencheur est activé après l'événement, toute modification, dont celles effectuées par les
-   autres déclencheurs, est <quote>visible</quote>
-   par le déclencheur.
+   trigger est activé après l'événement, toute modification, dont celles effectuées par les
+   autres triggers, est <quote>visible</quote>
+   par le trigger.
   </para>
 
   <para>
-   Un déclencheur marqué <literal>FOR EACH ROW</literal> est appelé pour
+   Un trigger marqué <literal>FOR EACH ROW</literal> est appelé pour
    chaque ligne que l'opération modifie. Par exemple, un
    <command>DELETE</command> affectant dix lignes entraîne dix appels
-   distincts de tout déclencheur <literal>ON DELETE</literal> sur la relation
-   cible, une fois par ligne supprimée. Au contraire, un déclencheur marqué
+   distincts de tout trigger <literal>ON DELETE</literal> sur la relation
+   cible, une fois par ligne supprimée. Au contraire, un trigger marqué
    <literal>FOR EACH STATEMENT</literal> ne s'exécute qu'une fois pour une
    opération donnée, quelque soit le nombre de lignes modifiées (en
    particulier, une opération qui ne modifie aucune ligne résulte toujours en
-   l'exécution des déclencheurs <literal>FOR EACH STATEMENT</literal>
+   l'exécution des triggers <literal>FOR EACH STATEMENT</literal>
    applicables).
   </para>
 
   <para>
-   Les déclencheurs définis en remplacement (<literal>INSTEAD OF</literal>) doivent obligatoirement être marqués
+   Les triggers définis en remplacement (<literal>INSTEAD OF</literal>) doivent obligatoirement être marqués
    <literal>FOR EACH ROW</literal>, et ne peuvent être définis que sur des vues.
-   Les déclencheurs <literal>BEFORE</literal> et <literal>AFTER</literal> portant sur des vues
+   Les triggers <literal>BEFORE</literal> et <literal>AFTER</literal> portant sur des vues
    devront quant à eux être marqués <literal>FOR EACH STATEMENT</literal>.
   </para>
 
   <para>
-   Les déclencheurs peuvent également être définis pour l'événement <command>TRUNCATE</command>,
+   Les triggers peuvent également être définis pour l'événement <command>TRUNCATE</command>,
    mais ne pourront, dans ce cas, qu'être marqués <literal>FOR EACH STATEMENT</literal>.
   </para>
 
   <para>
-   Le tableau suivant récapitule quels types de déclencheurs peuvent être
+   Le tableau suivant récapitule quels types de triggers peuvent être
    utilisés sur les tables, les vues et les tables distantes&nbsp;:
   </para>
 
@@ -171,27 +171,27 @@
   </para>
 
   <para>
-   Si plusieurs déclencheurs du même genre sont définis pour le même événement,
+   Si plusieurs triggers du même genre sont définis pour le même événement,
    ils sont déclenchés suivant l'ordre alphabétique de leur nom.
   </para>
 
   <para>
    Lorsque l'option <literal>CONSTRAINT</literal> est spécifiée, cette
-   commande crée un <firstterm>déclencheur contrainte</firstterm>.
+   commande crée un <firstterm>trigger contrainte</firstterm>.
    <indexterm><primary>trigger</primary><secondary>constraint trigger</secondary></indexterm>
    Ce nouvel
-   objet est identique aux déclencheurs normaux excepté le fait que le moment
+   objet est identique aux triggers normaux excepté le fait que le moment
    de déclenchement peut alors être ajusté via l'utilisation de <link
    linkend="sql-set-constraints"><command>SET CONSTRAINTS</command></link>.
-   Les déclencheurs contraintes ne peuvent
+   Les triggers contraintes ne peuvent
    être que de type <literal>AFTER ROW</literal> sur des tables standards (pas
    des tables distantes).  Ils peuvent être déclenchés soit à la fin de
    l'instruction causant l'événement, soit à la fin de la transaction ayant
    contenu l'instruction de déclenchement&nbsp;; dans ce dernier cas, ils sont
    alors définis comme <firstterm>différés</firstterm>. L'exécution d'un
-   déclencheur différé peut également être forcée en utilisant l'option
+   trigger différé peut également être forcée en utilisant l'option
    <command>SET CONSTRAINTS</command>. Le comportement attendu des
-   déclencheurs contraintes est de générer une exception en cas de violation
+   triggers contraintes est de générer une exception en cas de violation
    de la contrainte qu'ils implémentent.
   </para>
 
@@ -220,14 +220,14 @@
 
   <para>
    <command>SELECT</command> ne modifie aucune ligne&nbsp;; la création de
-   déclencheurs sur <command>SELECT</command> n'est donc pas possible. Les
+   triggers sur <command>SELECT</command> n'est donc pas possible. Les
    règles et vues peuvent fournir des solutions fonctionnelles aux problèmes
    qui nécessitent des triggers sur <command>SELECT</command>.
   </para>
 
   <para>
    <xref linkend="triggers"/> présente de plus amples informations sur les
-   déclencheurs.
+   triggers.
   </para>
  </refsect1>
 
@@ -239,10 +239,10 @@
     <term><replaceable class="parameter">nom</replaceable></term>
     <listitem>
      <para>
-      Le nom du nouveau déclencheur. Il doit être distinct du nom de
-      tout autre déclencheur sur la table.
-      Le nom ne peut pas être qualifié d'un nom de schéma, le déclencheur héritant
-      du schéma de sa table. Pour un déclencheur contrainte, c'est également le nom à
+      Le nom du nouveau trigger. Il doit être distinct du nom de
+      tout autre trigger sur la table.
+      Le nom ne peut pas être qualifié d'un nom de schéma, le trigger héritant
+      du schéma de sa table. Pour un trigger contrainte, c'est également le nom à
       utiliser lorsqu'il s'agira de modifier son comportement via la commande
       <command>SET CONSTRAINTS</command>.
      </para>
@@ -256,7 +256,7 @@
     <listitem>
      <para>
       Détermine si la fonction est appelée avant, après ou en remplacement de l'événement.
-      Un déclencheur contrainte ne peut être spécifié qu'<literal>AFTER</literal>.
+      Un trigger contrainte ne peut être spécifié qu'<literal>AFTER</literal>.
      </para>
     </listitem>
    </varlistentry>
@@ -267,7 +267,7 @@
      <para>
       Peut-être <literal>INSERT</literal>, <literal>UPDATE</literal> ou
       <literal>DELETE</literal> ou <literal>TRUNCATE</literal>&nbsp;; précise
-      l'événement qui active le déclencheur. Plusieurs événements peuvent être
+      l'événement qui active le trigger. Plusieurs événements peuvent être
       précisés en les séparant par <literal>OR</literal>, sauf quand les
       tables de transitions sont demandées.
      </para>
@@ -298,7 +298,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
     <listitem>
      <para>
       Le nom (éventuellement qualifié du nom du schéma) de la table, de la
-      vue ou de la table distante à laquelle est rattaché le déclencheur.
+      vue ou de la table distante à laquelle est rattaché le trigger.
      </para>
     </listitem>
    </varlistentry>
@@ -310,7 +310,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
       Le nom d'une autre table (possiblement qualifiée par un nom de schéma)
       référencée par la contrainte. Cette option est à utiliser pour les contraintes
       de clés étrangères et n'est pas recommandée pour d'autres types d'utilisation.
-      Elle ne peut être spécifiée que pour les déclencheurs contraintes.
+      Elle ne peut être spécifiée que pour les triggers contraintes.
      </para>
     </listitem>
    </varlistentry>
@@ -324,7 +324,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
      <para>
       La spécification du moment de déclenchement par défaut.
       Voir la partie <xref linkend="sql-createtable"/> pour plus de détails sur cette option.
-      Elle ne peut être spécifiée que pour les déclencheurs contraintes.
+      Elle ne peut être spécifiée que pour les triggers contraintes.
      </para>
     </listitem>
    </varlistentry>
@@ -335,7 +335,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
      <para>
       Ce mot-clé précède immédiatement la déclaration d'une ou deux noms de
       table fournissant l'accès aux relations de transition de l'instruction
-      déclencheur.
+      trigger.
      </para>
     </listitem>
    </varlistentry>
@@ -355,7 +355,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
     <term><replaceable class="parameter">nom_relation_transition</replaceable></term>
     <listitem>
      <para>
-      Le nom (non qualifié) à utiliser au sein du déclencheur pour cette
+      Le nom (non qualifié) à utiliser au sein du trigger pour cette
       relation de transition.
      </para>
     </listitem>
@@ -370,7 +370,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
       Précise si la fonction trigger doit être lancée
       pour chaque ligne affectée par l'événement ou
       simplement pour chaque instruction SQL. <literal>FOR EACH STATEMENT</literal>
-      est la valeur par défaut. Les déclencheurs de contrainte ne peuvent être
+      est la valeur par défaut. Les triggers de contrainte ne peuvent être
       spécifiés que pour <literal>FOR EACH ROW</literal>.
      </para>
     </listitem>
@@ -398,7 +398,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
      </para>
 
      <para>
-      Les déclencheurs <literal>INSTEAD OF</literal> ne supportent pas de condition
+      Les triggers <literal>INSTEAD OF</literal> ne supportent pas de condition
       <literal>WHEN</literal>.
      </para>
 
@@ -408,10 +408,10 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
      </para>
 
      <para>
-      À noter que pour les déclencheurs contraintes, l'évaluation de la clause
+      À noter que pour les triggers contraintes, l'évaluation de la clause
       <literal>WHEN</literal> n'est pas différée mais intervient immédiatement
       après que l'opération de mise à jour de la ligne soit effectuée. Si la
-      condition n'est pas évaluée à vrai, alors le déclencheur n'est pas placé
+      condition n'est pas évaluée à vrai, alors le trigger n'est pas placé
       dans la file d'attente des exécutions différées.
      </para>
     </listitem>
@@ -440,7 +440,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
     <listitem>
      <para>
       Une liste optionnelle d'arguments séparés par des virgules à fournir à la
-      fonction lors de l'activation du déclencheur. Les arguments sont des
+      fonction lors de l'activation du trigger. Les arguments sont des
       chaînes littérales constantes. Il est possible d'écrire ici de
       simples noms et des constantes numériques mais ils sont tous convertis
       en chaîne. L'accès aux arguments du trigger depuis la fonction peut
@@ -464,7 +464,7 @@ UPDATE OF <replaceable>nom_colonne_1</replaceable> [, <replaceable>nom_colonne_2
 
   <para>
    Utiliser <link linkend="sql-droptrigger"><command>DROP TRIGGER</command></link>
-   pour supprimer un déclencheur.
+   pour supprimer un trigger.
   </para>
 
   <para>
@@ -711,13 +711,13 @@ CREATE TRIGGER paired_items_update
    <itemizedlist>
     <listitem>
      <para>
-      Bien que les tables de transition pour les déclencheurs
+      Bien que les tables de transition pour les triggers
       <literal>AFTER</literal> triggers sont spécifiés en utilisant la clause
       <literal>REFERENCING</literal> de la manière standard, les variables de
-      lignes utilisées dans les déclencheurs <literal>FOR EACH ROW</literal>
+      lignes utilisées dans les triggers <literal>FOR EACH ROW</literal>
       peuvent ne pas être spécifiées dans la clause
       <literal>REFERENCING</literal>.  Ils sont disponibles d'une façon qui
-      dépend du langage dans lequel la fonction déclencheur est écrite, mais
+      dépend du langage dans lequel la fonction trigger est écrite, mais
       est fixe sur un langage. Certains langages se comportent effectivement
       comme s'il y avait une clause <literal>REFERENCING</literal> contenant
       <literal>OLD ROW AS OLD NEW ROW AS NEW</literal>.
@@ -749,12 +749,12 @@ CREATE TRIGGER paired_items_update
 
   <para>
    Le standard SQL définit l'ordre de création comme ordre de lancement
-   des déclencheurs multiples. <productname>PostgreSQL</productname> utilise
+   des triggers multiples. <productname>PostgreSQL</productname> utilise
    l'ordre alphabétique de leur nom, jugé plus pratique.
   </para>
 
   <para>
-   Le standard SQL précise que les déclencheurs <literal>BEFORE DELETE</literal> sur des
+   Le standard SQL précise que les triggers <literal>BEFORE DELETE</literal> sur des
    suppressions en cascade se déclenchent <emphasis>après</emphasis> la fin du
    <literal>DELETE</literal> en cascade.
    <productname>PostgreSQL</productname> définit que <literal>BEFORE DELETE</literal>
@@ -767,7 +767,7 @@ CREATE TRIGGER paired_items_update
   </para>
 
   <para>
-   La capacité à préciser plusieurs actions pour un seul déclencheur avec
+   La capacité à préciser plusieurs actions pour un seul trigger avec
    <literal>OR</literal> est une extension <productname>PostgreSQL</productname>.
   </para>
 
@@ -775,7 +775,7 @@ CREATE TRIGGER paired_items_update
    La possibilité d'exécuter un trigger suite à une commande
    <command>TRUNCATE</command> est une extension
    <productname>PostgreSQL</productname> du standard SQL, tout comme la
-   possibilité de définir des déclencheurs de niveau instruction sur des vues.
+   possibilité de définir des triggers de niveau instruction sur des vues.
   </para>
 
   <para>

--- a/postgresql/ref/drop_function.xml
+++ b/postgresql/ref/drop_function.xml
@@ -103,7 +103,7 @@
     <term><literal>CASCADE</literal></term>
     <listitem>
      <para>
-      Les objets qui dépendent de la fonction (opérateurs ou déclencheurs)
+      Les objets qui dépendent de la fonction (opérateurs ou triggers)
       sont automatiquement supprimés, ainsi que tous les objets dépendants de
       ces objets (voir <xref linkend="ddl-depend"/>).
      </para>

--- a/postgresql/ref/drop_table.xml
+++ b/postgresql/ref/drop_table.xml
@@ -33,7 +33,7 @@
   </para>
 
   <para>
-   <command>DROP TABLE</command> supprime tout index, règle, déclencheur
+   <command>DROP TABLE</command> supprime tout index, règle, trigger
    ou contrainte qui existe sur la table cible. Néanmoins, pour supprimer une
    table référencée par une vue ou par une contrainte de clé étrangère d'une
    autre table, <literal>CASCADE</literal> doit être ajouté. (<literal>CASCADE</literal>

--- a/postgresql/ref/drop_trigger.xml
+++ b/postgresql/ref/drop_trigger.xml
@@ -12,7 +12,7 @@
 
  <refnamediv>
   <refname>DROP TRIGGER</refname>
-  <refpurpose>Supprimer un déclencheur</refpurpose>
+  <refpurpose>Supprimer un trigger</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -24,8 +24,8 @@
   <title>Description</title>
 
   <para>
-   <command>DROP TRIGGER</command> supprime la définition d'un déclencheur.
-   Seul le propriétaire de la table sur laquelle le déclencheur est défini
+   <command>DROP TRIGGER</command> supprime la définition d'un trigger.
+   Seul le propriétaire de la table sur laquelle le trigger est défini
    peut exécuter cette commande.
   </para>
  </refsect1>
@@ -48,7 +48,7 @@
     <term><replaceable class="parameter">nom</replaceable></term>
     <listitem>
      <para>
-      Le nom du déclencheur à supprimer.
+      Le nom du trigger à supprimer.
      </para>
     </listitem>
    </varlistentry>
@@ -58,7 +58,7 @@
     <listitem>
      <para>
       Le nom de la table (éventuellement qualifié du nom du schéma)
-      sur laquelle le déclencheur est défini.
+      sur laquelle le trigger est défini.
      </para>
     </listitem>
    </varlistentry>
@@ -67,7 +67,7 @@
     <term><literal>CASCADE</literal></term>
     <listitem>
      <para>
-      Les objets qui dépendent du déclencheur sont automatiquement supprimés,
+      Les objets qui dépendent du trigger sont automatiquement supprimés,
       ainsi que tous les objets dépendants de ces objets (voir <xref
       linkend="ddl-depend"/>).
      </para>
@@ -78,7 +78,7 @@
     <term><literal>RESTRICT</literal></term>
     <listitem>
      <para>
-      Le déclencheur n'est pas supprimé si un objet en dépend. Comportement par défaut.
+      Le trigger n'est pas supprimé si un objet en dépend. Comportement par défaut.
      </para>
     </listitem>
    </varlistentry>
@@ -89,7 +89,7 @@
   <title>Exemples</title>
 
   <para>
-   Destruction du déclencheur <literal>si_dist_existe</literal> de la table
+   Destruction du trigger <literal>si_dist_existe</literal> de la table
    <literal>films</literal>&nbsp;:
 
    <programlisting>DROP TRIGGER si_dist_existe ON films;
@@ -103,7 +103,7 @@
   <para>
    L'instruction <command>DROP TRIGGER</command> de
    <productname>PostgreSQL</productname> est incompatible avec le
-   standard SQL. Dans le standard, les noms de déclencheurs ne se définissent pas par rapport aux tables.
+   standard SQL. Dans le standard, les noms de triggers ne se définissent pas par rapport aux tables.
    La commande est donc simplement <literal>DROP TRIGGER <replaceable>nom</replaceable></literal>.
   </para>
  </refsect1>

--- a/postgresql/ref/pg_dump.xml
+++ b/postgresql/ref/pg_dump.xml
@@ -1414,7 +1414,7 @@
    Quand une sauvegarde des seules données est sélectionnée et que l'option
    <option>--disable-triggers</option> est utilisée,
    <application>pg_dump</application> engendre des commandes de désactivation
-   des déclencheurs sur les tables utilisateur avant l'insertion des données,
+   des triggers sur les tables utilisateur avant l'insertion des données,
    puis après coup, des commandes de réactivation après l'insertion. Si la
    restauration est interrompue, il se peut que les catalogues systèmes
    conservent cette position.

--- a/postgresql/ref/pg_dumpall.xml
+++ b/postgresql/ref/pg_dumpall.xml
@@ -177,7 +177,7 @@
      <listitem>
       <para>
        Précise le nom du super-utilisateur à utiliser pour la désactivation des
-       déclencheurs. Cela n'a d'intérêt que lorsque
+       triggers. Cela n'a d'intérêt que lorsque
        <option>--disable-triggers</option> est utilisé. (Il est en général
        préférable de ne pas utiliser cette option et de lancer le script
        résultant en tant que super-utilisateur.)

--- a/postgresql/ref/pg_restore.xml
+++ b/postgresql/ref/pg_restore.xml
@@ -437,7 +437,7 @@
      <listitem>
       <para>
        Spécifie le nom d'utilisateur du super-utilisateur à utiliser pour
-       désactiver les déclencheurs. Ceci est seulement nécessaire si
+       désactiver les triggers. Ceci est seulement nécessaire si
        <option>--disable-triggers</option> est utilisé.
       </para>
      </listitem>
@@ -940,7 +940,7 @@
       Lors de la restauration des données dans une table pré-existante et que
       l'option <option>--disable-triggers</option> est utilisée,
       <application>pg_restore</application> émet des commandes pour désactiver
-      les déclencheurs sur les tables utilisateur avant d'insérer les données,
+      les triggers sur les tables utilisateur avant d'insérer les données,
       puis émet les commandes pour les réactiver après l'insertion des
       données. Si la restauration est stoppée en plein milieu, les catalogues
       système pourraient être abandonnés dans le mauvais état.

--- a/postgresql/ref/psql-ref.xml
+++ b/postgresql/ref/psql-ref.xml
@@ -1239,7 +1239,7 @@ basetest=&gt;
         colonnes, leurs types, le tablespace (s'il ne s'agit pas du tablespace
         par défaut) et tout attribut spécial tel que <literal>NOT
          NULL</literal> ou les valeurs par défaut. Les index, contraintes, règles
-        et déclencheurs associés sont aussi affichés. Pour les tables distantes,
+        et triggers associés sont aussi affichés. Pour les tables distantes,
         le serveur distant associé est aussi affiché. (Ce qui
         <quote>correspond au motif</quote> est défini dans
         <xref linkend="app-psql-patterns"/>

--- a/postgresql/rules.xml
+++ b/postgresql/rules.xml
@@ -16,15 +16,15 @@
  <para>
   Certains autres systèmes de bases de données définissent des règles actives
   pour la base de données, conservées habituellement en tant que procédures
-  stockées et déclencheurs. Avec <productname>PostgreSQL</productname>, elles
+  stockées et triggers. Avec <productname>PostgreSQL</productname>, elles
   peuvent aussi être implémentées en utilisant des fonctions et des
-  déclencheurs.
+  triggers.
  </para>
 
  <para>
   Le système de règles (plus précisément, le système de règles de
   réécriture de requêtes) est totalement différent des procédures stockées et
-  des déclencheurs. Il modifie les requêtes pour prendre en considération les
+  des triggers. Il modifie les requêtes pour prendre en considération les
   règles puis passe la requête modifiée au planificateur de requêtes pour
   planification et exécution. Il est très puissant et peut être utilisé pour
   beaucoup de choses comme des procédures en langage de requêtes, des vues et
@@ -2220,20 +2220,20 @@ CREATE VIEW phone_number WITH (security_barrier) AS
  </sect1>
 
  <sect1 id="rules-triggers">
-  <title>Règles contre déclencheurs</title>
+  <title>Règles contre triggers</title>
 
   <indexterm zone="rules-triggers">
    <primary>règle</primary>
-   <secondary sortas="trigger">comparée aux déclencheurs</secondary>
+   <secondary sortas="trigger">comparée aux triggers</secondary>
   </indexterm>
 
   <indexterm zone="rules-triggers">
-   <primary>déclencheur</primary>
+   <primary>trigger</primary>
    <secondary sortas="regeln">comparé aux règles</secondary>
   </indexterm>
 
   <para>
-   Beaucoup de choses pouvant se faire avec des déclencheurs peuvent aussi
+   Beaucoup de choses pouvant se faire avec des triggers peuvent aussi
    être implémentées en utilisant le système de règles de
    <productname>PostgreSQL</productname>. un des points qui ne pourra pas être
    implémenté par les règles en certains types de contraintes, notamment les
@@ -2242,7 +2242,7 @@ CREATE VIEW phone_number WITH (security_barrier) AS
    pas dans l'autre table. Mais alors les données sont jetées et ce n'est pas
    une bonne idée. Si des vérifications de valeurs valides sont requises et
    dans le cas où il y a une erreur invalide, un message d'erreur devrait être
-   généré et cela devra se faire avec un déclencheur.
+   généré et cela devra se faire avec un trigger.
   </para>
 
   <para>
@@ -2256,18 +2256,18 @@ CREATE VIEW phone_number WITH (security_barrier) AS
 
   <para>
    Pour les éléments qui peuvent être implémentés par les deux, ce qui sera le
-   mieux dépend de l'utilisation de la base de données. Un déclencheur
+   mieux dépend de l'utilisation de la base de données. Un trigger
    est exécuté une fois pour chaque ligne affectée. Une règle modifie la
    requête ou en génère une autre. Donc, si un grand nombre de lignes sont
    affectées pour une instruction, une règle lançant une commande supplémentaire
-   sera certainement plus rapide qu'un déclencheur appelé pour chaque ligne et qui
+   sera certainement plus rapide qu'un trigger appelé pour chaque ligne et qui
    devra exécuter ces opérations autant de fois. Néanmoins, l'approche du
-   déclencheur est conceptuellement plus simple que l'approche de la règle et est
+   trigger est conceptuellement plus simple que l'approche de la règle et est
    plus facile à utiliser pour les novices.
   </para>
 
   <para>
-   Ici, nous montrons un exemple où le choix d'une règle ou d'un déclencheur
+   Ici, nous montrons un exemple où le choix d'une règle ou d'un trigger
    joue sur une situation. Voici les deux tables&nbsp;:
 
    <programlisting>CREATE TABLE ordinateur (
@@ -2282,15 +2282,15 @@ CREATE TABLE logiciel (
    </programlisting>
 
    Les deux tables ont plusieurs milliers de lignes et les index sur
-   <structfield>nom_hote</structfield> sont uniques. la règle ou le déclencheur devrait
+   <structfield>nom_hote</structfield> sont uniques. La règle ou le trigger devrait
    implémenter une contrainte qui supprime les lignes de <literal>logiciel</literal>
-   référençant un ordinateur supprimé. Le déclencheur utiliserait cette
+   référençant un ordinateur supprimé. Le trigger utiliserait cette
    commande&nbsp;:
 
    <programlisting>DELETE FROM logiciel WHERE nom_hote = $1;
    </programlisting>
 
-   Comme le déclencheur est appelé pour chaque ligne individuelle supprimée à
+   Comme le trigger est appelé pour chaque ligne individuelle supprimée à
    partir de <literal>ordinateur</literal>, il peut préparer et sauvegarder le plan pour
    cette commande et passer la valeur <structfield>nom_hote</structfield> dans le paramètre.
    La règle devra être réécrite ainsi&nbsp;:
@@ -2308,7 +2308,7 @@ CREATE TABLE logiciel (
    </programlisting>
 
    la table <literal>ordinateur</literal> est parcourue par l'index (rapide), et la
-   commande lancée par le déclencheur pourrait aussi utiliser un parcours
+   commande lancée par le trigger pourrait aussi utiliser un parcours
    d'index (aussi rapide). La commande supplémentaire provenant de la règle
    serait&nbsp;:
 
@@ -2325,7 +2325,7 @@ CREATE TABLE logiciel (
    </literallayout>
 
    Donc, il n'y aurait pas trop de différence de performance entre le
-   déclencheur et l'implémentation de la règle.
+   trigger et l'implémentation de la règle.
   </para>
 
   <para>
@@ -2370,14 +2370,14 @@ CREATE TABLE logiciel (
    utilisée pour un parcours d'index sur <literal>logiciel</literal> quand il existe
    plusieurs expressions de qualifications combinées avec <literal>and</literal>, ce
    qui correspond à ce qu'il fait dans la version expression rationnelle de la
-   commande. Le déclencheur sera appelé une fois pour chacun des 2000 anciens
+   commande. Le trigger sera appelé une fois pour chacun des 2000 anciens
    ordinateurs qui doivent être supprimées, et ceci résultera en un parcours
    d'index sur <literal>ordinateur</literal> et 2000 parcours d'index sur
    <literal>logiciel</literal>. l'implémentation de la règle le fera en deux commandes
    qui utilisent les index. Et cela dépend de la taille globale de la table
    <literal>logiciel</literal>, si la règle sera toujours aussi rapide dans la
    situation du parcours séquentiel. 2000 exécutions de commandes à partir du
-   déclencheur sur le gestionnaire SPI prend un peu de temps, même si tous les
+   trigger sur le gestionnaire SPI prend un peu de temps, même si tous les
    blocs d'index seront rapidement dans le cache.
   </para>
 
@@ -2388,7 +2388,7 @@ CREATE TABLE logiciel (
    </programlisting>
 
    De nouveau, ceci pourrait résulter en de nombreuses lignes à supprimer dans
-   <literal>ordinateur</literal>. donc, le déclencheur lancera de nouveau de nombreuses
+   <literal>ordinateur</literal>. donc, le trigger lancera de nouveau de nombreuses
    commandes via l'exécuteur. La commande générée par la règle sera&nbsp;:
 
    <programlisting>DELETE FROM logiciel WHERE ordinateur.constructeur = 'bim'
@@ -2411,7 +2411,7 @@ CREATE TABLE logiciel (
 
   <para>
    Voici le résumé, les règles seront seulement significativement plus lentes
-   que les déclencheurs si leur actions résultent en des jointures larges et
+   que les triggers si leur actions résultent en des jointures larges et
    mal qualifiées, une situation où le planificateur échoue.
   </para>
  </sect1>

--- a/postgresql/spi.xml
+++ b/postgresql/spi.xml
@@ -4530,7 +4530,7 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
   <para>
    <function>SPI_copytuple</function> crée une copie d'une ligne dans le
    contexte de mémoire courant. Ceci est normalement utilisé pour renvoyer une
-   ligne modifiée à partir d'un déclencheur. Dans une fonction déclarée pour
+   ligne modifiée à partir d'un trigger. Dans une fonction déclarée pour
    renvoyer un type composite, utilisez <function>SPI_returntuple</function> à
    la place.
   </para>
@@ -4607,8 +4607,8 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
   <para>
       Notez que ceci devrait être utilisé pour les fonctions qui déclarent
       renvoyer des types composites. Ce n'est pas utilisé pour les
-      déclencheurs&nbsp;; utilisez <function>SPI_copytuple</function> pour renvoyer une ligne modifiée
-      dans un déclencheur.
+      triggers&nbsp;; utilisez <function>SPI_copytuple</function> pour renvoyer une ligne modifiée
+      dans un trigger.
     </para>
  </refsect1>
 
@@ -5189,7 +5189,7 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
      <listitem>
       <para>
        Les commandes exécutées via SPI à l'intérieur d'une fonction appelée
-       par une commande SQL (soit une fonction ordinaire soit un déclencheur)
+       par une commande SQL (soit une fonction ordinaire, soit un trigger)
        suivent une des règles ci-dessus suivant le commutateur
        lecture/écriture passé à SPI. Les commandes exécutées en mode lecture
        seule suivent la première règle&nbsp;: elles ne peuvent pas voir

--- a/postgresql/trigger.xml
+++ b/postgresql/trigger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <chapter id="triggers">
- <title>Déclencheurs (triggers)</title>
+ <title>Triggers (triggers)</title>
 
  <indexterm zone="triggers">
   <primary>trigger</primary>
@@ -8,30 +8,29 @@
 
  <para>
   Ce chapitre fournit des informations générales sur l'écriture des fonctions
-  pour déclencheur. Les fonctions pour déclencheurs peuvent être écrites dans
+  pour trigger. Ces fonctions peuvent être écrites dans
   la plupart des langages de procédure disponibles incluant
   <application>PL/pgSQL</application> (<xref linkend="plpgsql"/>),
   <application>PL/Tcl</application> (<xref linkend="pltcl"/>),
   <application>PL/Perl</application> (<xref linkend="plperl"/>) et
   <application>PL/Python</application> (<xref linkend="plpython"/>). Après avoir
   lu ce chapitre, vous devriez consulter le chapitre sur votre langage de
-  procédure favori pour découvrir les spécificités de l'écriture de déclencheurs dans ce langage.
+  procédure favori pour découvrir les spécificités de l'écriture de triggers dans ce langage.
  </para>
 
  <para>
-  Il est aussi possible d'écrire une fonction déclencheur en C, bien que la plupart
+  Il est aussi possible d'écrire une fonction trigger en C, bien que la plupart
   des gens trouvent plus facile d'utiliser un des langages de procédure. Il est
-  actuellement impossible d'écrire une fonction déclencheur dans le langage de
-  fonction simple SQL.
+  actuellement impossible d'écrire une fonction trigger en simple SQL.
  </para>
 
  <sect1 id="trigger-definition">
-  <title>Aperçu du comportement des déclencheurs</title>
+  <title>Aperçu du comportement des triggers</title>
 
   <para>
-   Un déclencheur spécifie que la base de données doit
+   Un trigger spécifie que la base de données doit
    exécuter automatiquement une fonction donnée chaque fois qu'un certain type d'opération est
-   exécuté. Les fonctions déclencheur peuvent être attachées à une table (partitionnée ou non),
+   exécuté. Les fonctions trigger peuvent être attachées à une table (partitionnée ou non),
    une vue ou une table distante.
   </para>
 
@@ -69,33 +68,33 @@
   </para>
 
   <para>
-   La fonction déclencheur doit être définie avant que le déclencheur lui-même
-   puisse être créé. La fonction déclencheur doit être déclarée comme une
+   La fonction trigger doit être définie avant que le trigger lui-même
+   puisse être créé. La fonction trigger doit être déclarée comme une
    fonction ne prenant aucun argument et retournant un type <literal>trigger</literal>
-   (la fonction déclencheur reçoit ses entrées via une structure
+   (la fonction trigger reçoit ses entrées via une structure
    <structname>TriggerData</structname> passée spécifiquement, et non pas sous la forme
    d'arguments ordinaires de fonctions).
   </para>
 
   <para>
-   Une fois qu'une fonction déclencheur est créée, le déclencheur (trigger)
+   Une fois qu'une fonction trigger est créée, le trigger
    est créé avec <xref linkend="sql-createtrigger"/>.
-   La même fonction déclencheur est utilisable par plusieurs déclencheurs.
+   La même fonction trigger est utilisable par plusieurs triggers.
   </para>
 
   <para>
-   <productname>PostgreSQL</productname> offre des déclencheurs
+   <productname>PostgreSQL</productname> offre des triggers
    <firstterm>par ligne</firstterm> et <firstterm>par instruction</firstterm>. Avec un
-   déclencheur mode ligne, la fonction du
-   déclencheur est appelée une fois pour chaque ligne affectée par
-   l'instruction qui a lancé le déclencheur. Au contraire, un déclencheur mode
+   trigger en mode ligne, la fonction du
+   trigger est appelée une fois pour chaque ligne affectée par
+   l'instruction qui a lancé le trigger. Au contraire, un trigger en mode
    instruction n'est appelé qu'une seule fois lorsqu'une instruction appropriée
    est exécutée, quelque soit le nombre de lignes affectées par cette
    instruction. En particulier, une instruction n'affectant aucune ligne
-   résultera toujours en l'exécution de tout déclencheur mode instruction
+   résultera toujours en l'exécution de tout trigger en mode instruction
    applicable. Ces deux types sont quelque fois appelés respectivement des
-   <firstterm>déclencheurs niveau ligne</firstterm> et des
-   <firstterm>déclencheurs niveau instruction</firstterm>.
+   <firstterm>triggers niveau ligne</firstterm> et des
+   <firstterm>triggers niveau instruction</firstterm>.
    Les triggers sur <command>TRUNCATE</command> peuvent seulement être définis
    au niveau instruction, et non pas au niveau ligne.
   </para>
@@ -142,34 +141,34 @@
   <para>
    Si une commande <command>INSERT</command> contient une clause
    <literal>ON CONFLICT DO UPDATE</literal>, il est possible que les
-   effets des déclencheurs niveau ligne
+   effets des triggers niveau ligne
    <literal>BEFORE</literal> <command>INSERT</command> et
    <literal>BEFORE</literal> <command>UPDATE</command> puissent être
    tous les deux appliqués de telle sorte que leurs effets soient
    visibles dans la version finale de la ligne mise à jour, si une
    colonne <varname>EXCLUDED</varname> est référencée. Il n'est
    néanmoins pas nécessaire qu'il soit fait référence à une colonne
-   <varname>EXCLUDED</varname> pour que les deux types de déclencheurs
+   <varname>EXCLUDED</varname> pour que les deux types de triggers
    BEFORE s'exécutent tout de même. La possibilité d'avoir des
    résultats surprenants devrait être prise en compte quand il existe
-   des déclencheurs niveau ligne <literal>BEFORE</literal>
+   des triggers niveau ligne <literal>BEFORE</literal>
    <command>INSERT</command> et <literal>BEFORE</literal>
    <command>UPDATE</command> qui tous les deux modifient la ligne sur le
    point d'être insérée ou mise à jour (ceci peut être problématique
    si les modifications sont plus ou moins équivalentes et si elles ne
-   sont pas idempotente). Notez que les déclencheurs
+   sont pas idempotente). Notez que les triggers
    <command>UPDATE</command> niveau instruction sont exécutés lorsque
    la clause <literal>ON CONFLICT DO UPDATE</literal> est spécifiée,
    quand bien même aucune ligne ne serait affectée par la commande
    <command>UPDATE</command> (et même si la commande
    <command>UPDATE</command> n'est pas exécutée). Une commande
    <command>INSERT</command> avec une clause <literal>ON CONFLICT DO
-    UPDATE</literal> exécutera d'abord les déclencheurs niveau
+    UPDATE</literal> exécutera d'abord les triggers niveau
    instruction <literal>BEFORE</literal> <command>INSERT</command>,
-   puis les déclencheurs niveau instruction <literal>BEFORE</literal>
-   <command>UPDATE</command>, suivis par les déclencheurs niveau
+   puis les triggers niveau instruction <literal>BEFORE</literal>
+   <command>UPDATE</command>, suivis par les triggers niveau
    instruction <literal>AFTER</literal> <command>UPDATE</command>,
-   puis finalement les déclencheurs niveau instruction
+   puis finalement les triggers niveau instruction
    <literal>AFTER</literal> <command>INSERT</command>.
   </para>
 
@@ -221,11 +220,11 @@
   </para>
 
   <para>
-   Les fonctions déclencheurs appelées par des déclencheurs niveau instruction
-   devraient toujours renvoyer <symbol>NULL</symbol>. Les fonctions déclencheurs
-   appelées par des déclencheurs niveau ligne peuvent renvoyer une ligne de la
+   Les fonctions triggers appelées par des triggers niveau instruction
+   devraient toujours renvoyer <symbol>NULL</symbol>. Les fonctions triggers
+   appelées par des triggers niveau ligne peuvent renvoyer une ligne de la
    table (une valeur de type <structname>HeapTuple</structname>) vers
-   l'exécuteur appelant, s'ils le veulent. Un déclencheur niveau ligne exécuté
+   l'exécuteur appelant, s'ils le veulent. Un trigger niveau ligne exécuté
    avant une opération a les choix suivants&nbsp;:
 
    <itemizedlist>
@@ -233,28 +232,28 @@
      <para>
       Il peut retourner un pointeur <symbol>NULL</symbol> pour sauter l'opération
       pour la ligne courante. Ceci donne comme instruction à l'exécuteur de ne pas exécuter
-      l'opération niveau ligne qui a lancé le déclencheur (l'insertion, la
+      l'opération niveau ligne qui a lancé le trigger (l'insertion, la
       modification ou la suppression d'une ligne particulière de la table).
      </para>
     </listitem>
 
     <listitem>
      <para>
-      Pour les déclencheurs <command>INSERT</command> et
+      Pour les triggers <command>INSERT</command> et
       <command>UPDATE</command> de niveau ligne uniquement, la valeur de retour devient la
       ligne qui sera insérée ou remplacera la ligne en cours de mise à jour.
-      Ceci permet à la fonction déclencheur de modifier la ligne en cours
+      Ceci permet à la fonction trigger de modifier la ligne en cours
       d'insertion ou de mise à jour.
      </para>
     </listitem>
    </itemizedlist>
 
 
-   Un déclencheur <literal>BEFORE</literal> niveau ligne qui ne serait pas conçu pour avoir l'un de
+   Un trigger <literal>BEFORE</literal> niveau ligne qui ne serait pas conçu pour avoir l'un de
    ces comportements doit prendre garde à retourner la même ligne que celle
-   qui lui a été passée comme nouvelle ligne (c'est-à-dire : pour des déclencheurs
+   qui lui a été passée comme nouvelle ligne (c'est-à-dire&nbsp;: pour des triggers
    <command>INSERT</command> et <command>UPDATE</command> : la nouvelle
-   (<varname>NEW</varname>) ligne, et pour les déclencheurs
+   (<varname>NEW</varname>) ligne, et pour les triggers
    <command>DELETE</command>)&nbsp;: l'ancienne
    (<varname>OLD</varname>) ligne .
   </para>
@@ -278,7 +277,7 @@
   </para>
 
   <para>
-   La valeur de retour est ignorée pour les déclencheurs niveau ligne lancés
+   La valeur de retour est ignorée pour les triggers niveau ligne lancés
    après une opération. Ils peuvent donc renvoyer la valeur
    <symbol>NULL</symbol>.
   </para>
@@ -302,15 +301,15 @@
   </para>
 
   <para>
-   Si plus d'un déclencheur est défini pour le même événement sur la même
-   relation, les déclencheurs seront lancés dans l'ordre alphabétique de leur
-   nom. Dans le cas de déclencheurs <literal>BEFORE</literal> et
+   Si plus d'un trigger est défini pour le même événement sur la même
+   relation, les triggers seront lancés dans l'ordre alphabétique de leur
+   nom. Dans le cas de triggers <literal>BEFORE</literal> et
    <literal>INSTEAD OF</literal>, la ligne
-   renvoyée par chaque déclencheur, qui a éventuellement été modifiée, devient l'argument du
-   prochain déclencheur. Si un des déclencheurs <literal>BEFORE</literal> ou
+   renvoyée par chaque trigger, qui a éventuellement été modifiée, devient l'argument du
+   prochain trigger. Si un des triggers <literal>BEFORE</literal> ou
    <literal>INSTEAD OF</literal> renvoie un pointeur
    <symbol>NULL</symbol>, l'opération est abandonnée pour cette ligne et les
-   déclencheurs suivants ne sont pas lancés (pour cette ligne).
+   triggers suivants ne sont pas lancés (pour cette ligne).
   </para>
 
   <para>
@@ -339,16 +338,16 @@
   </para>
 
   <para>
-   Les déclencheurs <literal>BEFORE</literal> en mode ligne sont typiquement utilisés pour
+   Les triggers <literal>BEFORE</literal> en mode ligne sont typiquement utilisés pour
    vérifier ou modifier les données qui seront insérées ou mises à jour. Par
-   exemple, un déclencheur <literal>BEFORE</literal> pourrait être utilisé pour insérer l'heure
+   exemple, un trigger <literal>BEFORE</literal> pourrait être utilisé pour insérer l'heure
    actuelle dans une colonne de type <type>timestamp</type> ou pour vérifier que deux
-   éléments d'une ligne sont cohérents. Les déclencheurs <literal>AFTER</literal> en mode ligne
+   éléments d'une ligne sont cohérents. Les triggers <literal>AFTER</literal> en mode ligne
    sont pour la plupart utilisés pour propager des mises à jour vers d'autres
    tables ou pour réaliser des tests de cohérence avec d'autres tables. La
-   raison de cette division du travail est qu'un déclencheur <literal>AFTER</literal> peut être
-   certain qu'il voit la valeur finale de la ligne alors qu'un déclencheur
-   <literal>BEFORE</literal> ne l'est pas&nbsp;; il pourrait exister d'autres déclencheurs <literal>BEFORE</literal>
+   raison de cette division du travail est qu'un trigger <literal>AFTER</literal> peut être
+   certain qu'il voit la valeur finale de la ligne alors qu'un trigger
+   <literal>BEFORE</literal> ne l'est pas&nbsp;; il pourrait exister d'autres triggers <literal>BEFORE</literal>
    qui seront exécutés après lui. Si vous n'avez aucune raison spéciale pour le
    moment du déclenchement, le cas <literal>BEFORE</literal> est plus efficace car l'information
    sur l'opération n'a pas besoin d'être sauvegardée jusqu'à la fin du
@@ -356,14 +355,14 @@
   </para>
 
   <para>
-   Si une fonction déclencheur exécute des commandes SQL,
-   alors ces commandes peuvent lancer à leur tour des déclencheurs. On appelle ceci un
-   déclencheur en cascade. Il n'y a pas de limitation directe du nombre de
+   Si une fonction trigger exécute des commandes SQL,
+   alors ces commandes peuvent lancer à leur tour des triggers. On appelle ceci un
+   trigger en cascade. Il n'y a pas de limitation directe du nombre de
    niveaux de cascade. Il est possible que les cascades causent un appel
-   récursif du même déclencheur&nbsp;; par exemple, un déclencheur
+   récursif du même trigger&nbsp;; par exemple, un trigger
    <command>INSERT</command> pourrait exécuter une commande qui insère une
    ligne supplémentaire dans la même table, entraînant un nouveau lancement du
-   déclencheur <command>INSERT</command>. Il est de la responsabilité du
+   trigger <command>INSERT</command>. Il est de la responsabilité du
    programmeur d'éviter les récursions infinies dans de tels scénarios.
   </para>
 
@@ -373,32 +372,32 @@
   </indexterm>
 
   <para>
-   Quand un déclencheur est défini, des arguments peuvent être spécifiés pour
+   Quand un trigger est défini, des arguments peuvent être spécifiés pour
    lui. L'objectif de l'inclusion d'arguments dans la définition du
-   déclencheur est de permettre à différents déclencheurs ayant des exigences
+   trigger est de permettre à différents triggers ayant des exigences
    similaires d'appeler la même fonction. Par exemple, il pourrait y avoir une
-   fonction déclencheur généralisée qui prend comme arguments deux noms de
+   fonction trigger généralisée qui prend comme arguments deux noms de
    colonnes et place l'utilisateur courant dans l'une et un horodatage dans
-   l'autre. Correctement écrit, cette fonction déclencheur serait indépendante
+   l'autre. Correctement écrit, cette fonction trigger serait indépendante
    de la table particulière sur laquelle il se déclenche. Ainsi, la même
    fonction pourrait être utilisée pour des événements
    <command>INSERT</command> sur n'importe quelle table ayant des colonnes
    adéquates, pour automatiquement suivre les créations d'enregistrements dans
    une table de transactions par exemple. Elle pourrait aussi être utilisée
    pour suivre les dernières mises à jours si elle est définie comme un
-   déclencheur <command>UPDATE</command>.
+   trigger <command>UPDATE</command>.
   </para>
 
   <para>
-   Chaque langage de programmation supportant les déclencheurs a sa propre
+   Chaque langage de programmation supportant les triggers a sa propre
    méthode pour rendre les données en entrée disponible à la fonction du
-   déclencheur. Cette donnée en entrée inclut le type d'événement du
-   déclencheur (c'est-à-dire <command>INSERT</command> ou
+   trigger. Cette donnée en entrée inclut le type d'événement du
+   trigger (c'est-à-dire <command>INSERT</command> ou
    <command>UPDATE</command>) ainsi que tous les arguments listés dans
-   <command>CREATE TRIGGER</command>. Pour un déclencheur niveau ligne, la donnée en
-   entrée inclut aussi la ligne <varname>NEW</varname> pour les déclencheurs
+   <command>CREATE TRIGGER</command>. Pour un trigger niveau ligne, la donnée en
+   entrée inclut aussi la ligne <varname>NEW</varname> pour les triggers
    <command>INSERT</command> et <command>UPDATE</command> et/ou la ligne
-   <varname>OLD</varname> pour les déclencheurs <command>UPDATE</command> et
+   <varname>OLD</varname> pour les triggers <command>UPDATE</command> et
    <command>DELETE</command>.
   </para>
 
@@ -424,34 +423,34 @@
 
   <para>
    Si vous exécutez des commandes SQL dans votre fonction SQL et que ces
-   commandes accèdent à la table pour laquelle vous créez ce déclencheur,
+   commandes accèdent à la table pour laquelle vous créez ce trigger,
    alors vous avez besoin de connaître les règles de visibilité des données
    car elles déterminent si les commandes SQL voient les modifications de données pour
-   lesquelles est exécuté le déclencheur. En bref&nbsp;:
+   lesquelles est exécuté le trigger. En bref&nbsp;:
 
    <itemizedlist>
     <listitem>
      <para>
-      Les déclencheurs niveau instruction suivent des règles de visibilité
+      Les triggers niveau instruction suivent des règles de visibilité
       simples&nbsp;: aucune des modifications réalisées par une instruction
-      n'est visible aux déclencheurs niveau instruction appelés avant
+      n'est visible aux triggers niveau instruction appelés avant
       l'instruction alors que toutes les modifications sont visibles aux
-      déclencheurs <literal>AFTER</literal> niveau instruction.
+      triggers <literal>AFTER</literal> niveau instruction.
      </para>
     </listitem>
 
     <listitem>
      <para>
       Les modifications de données (insertion, mise à jour ou suppression)
-      lançant le déclencheur ne sont naturellement <emphasis>pas</emphasis>
-      visibles aux commandes SQL exécutées dans un déclencheur <literal>BEFORE</literal> en mode
+      lançant le trigger ne sont naturellement <emphasis>pas</emphasis>
+      visibles aux commandes SQL exécutées dans un trigger <literal>BEFORE</literal> en mode
       ligne parce qu'elles ne sont pas encore survenues.
      </para>
     </listitem>
 
     <listitem>
      <para>
-      Néanmoins, les commandes SQL exécutées par un déclencheur <literal>BEFORE</literal> en mode
+      Néanmoins, les commandes SQL exécutées par un trigger <literal>BEFORE</literal> en mode
       ligne <emphasis>verront</emphasis> les effets des modifications de données
       pour les lignes précédemment traitées dans la même commande externe. Ceci
       requiert une grande attention car l'ordre des événements de modification
@@ -471,9 +470,9 @@
 
     <listitem>
      <para>
-      Quand un déclencheur <literal>AFTER</literal> en mode ligne est exécuté, toutes les
+      Quand un trigger <literal>AFTER</literal> en mode ligne est exécuté, toutes les
       modifications de données réalisées par la commande externe sont déjà
-      terminées et sont visibles par la fonction appelée par le déclencheur.
+      terminées et sont visibles par la fonction appelée par le trigger.
      </para>
     </listitem>
    </itemizedlist>
@@ -495,7 +494,7 @@
  </sect1>
 
  <sect1 id="trigger-interface">
-  <title>Écrire des fonctions déclencheurs en C</title>
+  <title>Écrire des fonctions triggers en C</title>
 
   <indexterm zone="trigger-interface">
    <primary>trigger</primary>
@@ -509,24 +508,24 @@
 
   <para>
    Cette section décrit les détails de bas niveau de l'interface d'une fonction
-   déclencheur. Ces informations ne sont nécessaires que lors de l'écriture
-   d'une fonction déclencheur en C. Si vous utilisez un langage de plus haut
+   trigger. Ces informations ne sont nécessaires que lors de l'écriture
+   d'une fonction trigger en C. Si vous utilisez un langage de plus haut
    niveau, ces détails sont gérés pour vous. Dans la plupart des cas, vous
    devez considérer l'utilisation d'un langage de procédure avant d'écrire
-   vos déclencheurs en C. La documentation de chaque langage de procédures
-   explique comment écrire un déclencheur dans ce langage.
+   vos triggers en C. La documentation de chaque langage de procédures
+   explique comment écrire un trigger dans ce langage.
   </para>
 
   <para>
-   Les fonctions déclencheurs doivent utiliser la <quote>version 1</quote> de
+   Les fonctions triggers doivent utiliser la <quote>version 1</quote> de
    l'interface du gestionnaire de fonctions.
   </para>
 
   <para>
-   Quand une fonction est appelée par le gestionnaire de déclencheur, elle ne
+   Quand une fonction est appelée par le gestionnaire de trigger, elle ne
    reçoit aucun argument classique, mais un pointeur de <quote>contexte</quote>
    pointant sur une structure <structname>TriggerData</structname>. Les fonctions C
-   peuvent vérifier si elles sont appelées par le gestionnaire de déclencheurs
+   peuvent vérifier si elles sont appelées par le gestionnaire de triggers
    ou pas en exécutant la macro&nbsp;:
    <programlisting>CALLED_AS_TRIGGER(fcinfo)
    </programlisting>
@@ -586,7 +585,7 @@
          <term><literal>TRIGGER_FIRED_BEFORE(tg_event)</literal></term>
          <listitem>
           <para>
-           Renvoie vrai si le déclencheur est lancé avant l'opération.
+           Renvoie vrai si le trigger est lancé avant l'opération.
           </para>
          </listitem>
         </varlistentry>
@@ -595,7 +594,7 @@
          <term><literal>TRIGGER_FIRED_AFTER(tg_event)</literal></term>
          <listitem>
           <para>
-           Renvoie vrai si le déclencheur est lancé après l'opération.
+           Renvoie vrai si le trigger est lancé après l'opération.
           </para>
          </listitem>
         </varlistentry>
@@ -613,7 +612,7 @@
          <term><literal>TRIGGER_FIRED_FOR_ROW(tg_event)</literal></term>
          <listitem>
           <para>
-           Renvoie vrai si le déclencheur est lancé pour un événement en
+           Renvoie vrai si le trigger est lancé pour un événement en
            mode ligne.
           </para>
          </listitem>
@@ -623,7 +622,7 @@
          <term><literal>TRIGGER_FIRED_FOR_STATEMENT(tg_event)</literal></term>
          <listitem>
           <para>
-           Renvoie vrai si le déclencheur est lancé pour un événement en
+           Renvoie vrai si le trigger est lancé pour un événement en
            mode instruction.
           </para>
          </listitem>
@@ -633,7 +632,7 @@
          <term><literal>TRIGGER_FIRED_BY_INSERT(tg_event)</literal></term>
          <listitem>
           <para>
-           Retourne vrai si le déclencheur est lancé par une commande
+           Retourne vrai si le trigger est lancé par une commande
            <command>INSERT</command>.
           </para>
          </listitem>
@@ -643,7 +642,7 @@
          <term><literal>TRIGGER_FIRED_BY_UPDATE(tg_event)</literal></term>
          <listitem>
           <para>
-           Retourne vrai si le déclencheur est lancé par une commande
+           Retourne vrai si le trigger est lancé par une commande
            <command>UPDATE</command>.
           </para>
          </listitem>
@@ -653,7 +652,7 @@
          <term><literal>TRIGGER_FIRED_BY_DELETE(tg_event)</literal></term>
          <listitem>
           <para>
-           Retourne vrai si le déclencheur est lancé par une commande
+           Retourne vrai si le trigger est lancé par une commande
            <command>DELETE</command>.
           </para>
          </listitem>
@@ -704,7 +703,7 @@
      <listitem>
       <para>
        Un pointeur vers une structure décrivant la relation pour laquelle le
-       déclencheur est lancé. Voir <filename>utils/reltrigger.h</filename> pour les détails
+       trigger est lancé. Voir <filename>utils/reltrigger.h</filename> pour les détails
        de cette structure. Les choses les plus intéressantes sont
        <literal>tg_relation-&gt;rd_att</literal> (descripteur de nuplets de la
        relation) et <literal>tg_relation-&gt;rd_rel-&gt;relname</literal> (nom de la
@@ -720,13 +719,13 @@
      <term><structfield>tg_trigtuple</structfield></term>
      <listitem>
       <para>
-       Un pointeur vers la ligne pour laquelle le déclencheur a été lancé. Il
+       Un pointeur vers la ligne pour laquelle le trigger a été lancé. Il
        s'agit de la ligne étant insérée, mise à jour ou effacée. Si ce
-       déclencheur a été lancé pour une commande <command>INSERT</command> ou
+       trigger a été lancé pour une commande <command>INSERT</command> ou
        <command>DELETE</command>, c'est cette valeur que la fonction doit retourner si
        vous ne voulez pas remplacer la ligne par une ligne différente (dans le
        cas d'un <command>INSERT</command>) ou sauter l'opération. Dans le cas de
-       déclencheurs sur tables distantes, les valeurs des colonnes systèmes ne sont
+       triggers sur tables distantes, les valeurs des colonnes systèmes ne sont
        pas spécifiées ici.
       </para>
      </listitem>
@@ -736,13 +735,13 @@
      <term><structfield>tg_newtuple</structfield></term>
      <listitem>
       <para>
-       Un pointeur vers la nouvelle version de la ligne, si le déclencheur a
+       Un pointeur vers la nouvelle version de la ligne, si le trigger a
        été lancé pour un <command>UPDATE</command> et <symbol>NULL</symbol> si c'est
        pour un <command>INSERT</command> ou un <command>DELETE</command>.
        C'est ce que la fonction doit retourner si l'événement est un
        <command>UPDATE</command> et que vous ne voulez pas remplacer cette
        ligne par une ligne différente ou bien sauter l'opération. Dans le cas de
-       déclencheurs sur tables distantes, les valeurs des colonnes systèmes ne sont
+       triggers sur tables distantes, les valeurs des colonnes systèmes ne sont
        pas spécifiées ici.
       </para>
      </listitem>
@@ -778,7 +777,7 @@
 } Trigger;
        </programlisting>
 
-       où <structfield>tgname</structfield> est le nom du déclencheur,
+       où <structfield>tgname</structfield> est le nom du trigger,
        <structfield>tgnargs</structfield> est le nombre d'arguments dans
        <structfield>tgargs</structfield> et <structfield>tgargs</structfield> est un tableau de
        pointeurs vers les arguments spécifiés dans l'expression contenant la
@@ -845,7 +844,7 @@
   </para>
 
   <para>
-   Une fonction déclencheur doit retourner soit un pointeur
+   Une fonction trigger doit retourner soit un pointeur
    <structname>HeapTuple</structname> soit un pointeur <symbol>NULL</symbol> (<emphasis>pas</emphasis>
    une valeur SQL NULL, donc ne positionnez pas <parameter>isNull</parameter> à
    true). Faites attention de renvoyer soit un
@@ -860,15 +859,15 @@
   <title>Un exemple complet de trigger</title>
 
   <para>
-   Voici un exemple très simple de fonction déclencheur écrite en C (les
-   exemples de déclencheurs écrits avec différents langages de procédures
+   Voici un exemple très simple de fonction trigger écrite en C (les
+   exemples de triggers écrits avec différents langages de procédures
    se trouvent dans la documentation de ceux-ci).
   </para>
 
   <para>
    La fonction <function>trigf</function> indique le nombre de lignes de la table
    <structname>ttest</structname> et saute l'opération si la commande tente d'insérer une
-   valeur NULL dans la colonne <structfield>x</structfield> (ainsi le déclencheur agit
+   valeur NULL dans la colonne <structfield>x</structfield> (ainsi le trigger agit
    comme une contrainte non NULL mais n'annule pas la transaction).
   </para>
 
@@ -885,7 +884,7 @@
    <programlisting><![CDATA[#include "postgres.h"
 #include "fmgr.h"
 #include "executor/spi.h"       /* nécessaire pour fonctionner avec SPI */
-#include "commands/trigger.h"   /* ... les déclencheurs */
+#include "commands/trigger.h"   /* ... les triggers */
 #include "utils/rel.h"          /* ... et relations */
 
 PG_MODULE_MAGIC;
@@ -903,7 +902,7 @@ trigf(PG_FUNCTION_ARGS)
     bool        isNULL;
     int         ret, i;
 
-    /* on s'assure que la fonction est appelée en tant que déclencheur */
+    /* on s'assure que la fonction est appelée en tant que trigger */
     if (!CALLED_AS_TRIGGER(fcinfo))
         elog(ERROR, "trigf: not called by trigger manager");
 
@@ -960,7 +959,7 @@ trigf(PG_FUNCTION_ARGS)
    <para>
     Après avoir compilé le code source (voir <xref
     linkend="dfunc"/>), déclarez la fonction et les
-    déclencheurs&nbsp;:
+    triggers&nbsp;:
 <programlisting>CREATE FUNCTION trigf() RETURNS trigger
     AS '<replaceable>nomfichier</replaceable>'
     LANGUAGE C;
@@ -974,12 +973,12 @@ CREATE TRIGGER tafter AFTER INSERT OR UPDATE OR DELETE ON ttest
   </para>
 
   <para>
-   À présent, testez le fonctionnement du déclencheur&nbsp;:
+   À présent, testez le fonctionnement du trigger&nbsp;:
    <screen>=&gt; INSERT INTO ttest VALUES (NULL);
 INFO:  trigf (fired before): there are 0 rows in ttest
 INSERT 0 0
 
--- Insertion supprimée et déclencheur APRES non exécuté
+-- Insertion supprimée et trigger AFTER non exécuté
 
 =&gt; SELECT * FROM ttest;
  x

--- a/postgresql/xfunc.xml
+++ b/postgresql/xfunc.xml
@@ -2631,7 +2631,7 @@ CREATE FUNCTION concat_text(text, text) RETURNS text
      <para>
       Enfin, les conventions d'appels de la version-1 rendent possible le renvoi
       de résultats d'ensemble (<xref linkend="xfunc-c-return-set"/>),
-      l'implémentation de fonctions déclencheurs (<xref
+      l'implémentation de fonctions triggers (<xref
       linkend="triggers"/>) et d'opérateurs d'appel de langage procédural (<xref
       linkend="plhandler"/>). Pour plus de détails, voir
       <filename>src/backend/utils/fmgr/README</filename> dans les fichiers


### PR DESCRIPTION
Remplacement systématique, quasiment sans relecture au passage.
Tant pis pour la francophonie, mais cette bataille-là est perdue.