### PR TITLE
create_subscription.xml : synchronous_commit

### DIFF
--- a/postgresql/ref/create_subscription.xml
+++ b/postgresql/ref/create_subscription.xml
@@ -294,24 +294,24 @@ CREATE SUBSCRIPTION <replaceable class="parameter">nom_souscription</replaceable
 
          <para>
           Il est sans danger d'utiliser <literal>off</literal> pour la
-          réplication logique&nbsp;: Si le souscripteur perd des transactions à
-          cause d'une synchronisation manquante, les données seront renvoyée par
+          réplication logique&nbsp;: si le souscripteur perd des transactions à
+          cause d'une synchronisation manquée, les données seront renvoyées par
           le serveur publiant les données.
          </para>
 
          <para>
-          Un paramétrage différent pourrait être appropriée lorsque la
-          réplication logique est utilisée.  Les workers de réplication logique
-          rapportent la position d'écriture et de synchronisation au serveur
-          publiant les données, et lorsque la réplication synchrone est
-          utilisée, le serveur publiant les données attendra la synchronisation.
-          Cela veut dire que positionner <literal>synchronous_commit</literal>
-          pour le souscripteur à <literal>off</literal> quand la souscription
-          est utilisée pour de la réplication synchrone pourrait augmenter la
+          Un paramétrage différent peut être appropriée si l'on utilise une
+          réplication logique synchrone. Les workers de réplication logique
+          rapportent les positions d'écriture et de synchronisation au serveur
+          publiant les données, et, en réplication synchrone,
+          ce dernier attendra que la synchronisation ait lieu.
+          Cela veut dire que laisser <literal>synchronous_commit</literal>
+          à <literal>off</literal> sur une souscription
+          en réplication synchrone peut augmenter la
           latence des <command>COMMIT</command> sur le serveur publiant les
           données. Dans ce scénario, il peut être avantageux de positionner
-          <literal>synchronous_commit</literal> à <literal>local</literal> ou au
-          dessus.
+	  <literal>synchronous_commit</literal> à <literal>local</literal> ou
+	  au-dessus.
          </para>
         </listitem>
        </varlistentry>


### PR DESCRIPTION
Il manquait un mot "synchrone" en VF. Revue de tout le paragraphe au passage. (Pas sûr qu'il soit plus clair pour autant.)