### PR TITLE
wait_event_types.xml : partie 1

### DIFF
--- a/postgresql/wait_event_types.xml
+++ b/postgresql/wait_event_types.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Fichier XML généré pour tableaux 27.5 à 27.13 sur https://www.postgresql.org/docs/17/monitoring-stats.html#WAIT-EVENT-ACTIVITY-TABLE
+-->
   <table id="wait-event-activity-table">
-   <title>Wait Events of Type <literal>Activity</literal></title>
+<!--
+  Table 27.5. Wait Events of Type Activity
+-->
+    <title>Points d'attente <literal>Wait Events</literal>
+           de type <literal>Activity</literal></title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry><literal>Activity</literal> Wait Event</entry>
+      <entry>Point d'attente <literal>Activity</literal></entry>
       <entry>Description</entry>
      </row>
     </thead>
@@ -12,78 +19,99 @@
     <tbody>
      <row>
       <entry><literal>ArchiverMain</literal></entry>
-      <entry>Waiting in main loop of archiver process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>archiver</literal>.</entry>
      </row>
      <row>
       <entry><literal>AutovacuumMain</literal></entry>
-      <entry>Waiting in main loop of autovacuum launcher process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>autovacuum launcher</literal>.</entry>
      </row>
      <row>
       <entry><literal>BgwriterHibernate</literal></entry>
-      <entry>Waiting in background writer process, hibernating.</entry>
+      <entry>En attente dans le processus
+             <literal>background writer</literal>,
+             qui hiberne.</entry>
      </row>
      <row>
       <entry><literal>BgwriterMain</literal></entry>
-      <entry>Waiting in main loop of background writer process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>background writer</literal>.</entry>
      </row>
      <row>
       <entry><literal>CheckpointerMain</literal></entry>
-      <entry>Waiting in main loop of checkpointer process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>checkpointer</literal>.</entry>
      </row>
      <row>
       <entry><literal>LogicalApplyMain</literal></entry>
-      <entry>Waiting in main loop of logical replication apply process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>logical apply</literal>.</entry>
      </row>
      <row>
       <entry><literal>LogicalLauncherMain</literal></entry>
-      <entry>Waiting in main loop of logical replication launcher process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>logical apply launcher</literal>.</entry>
      </row>
      <row>
       <entry><literal>LogicalParallelApplyMain</literal></entry>
-      <entry>Waiting in main loop of logical replication parallel apply process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>logical parallel apply</literal>.</entry>
      </row>
      <row>
       <entry><literal>RecoveryWalStream</literal></entry>
-      <entry>Waiting in main loop of startup process for WAL to arrive, during streaming recovery.</entry>
+      <entry>En attente d'arrivée de WAL pendant la boucle principale
+             du processus <literal>startup</literal>,
+             pendant une restauration avec <foreignphrase>streaming</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotsyncMain</literal></entry>
-      <entry>Waiting in main loop of slot sync worker.</entry>
+      <entry>En attente dans la boucle principale du
+             <literal>slotsync worker</literal>.</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotsyncShutdown</literal></entry>
-      <entry>Waiting for slot sync worker to shut down.</entry>
+      <entry>En attente d'arrêt du
+             <literal>slotsync worker</literal>.</entry>
      </row>
      <row>
       <entry><literal>SysloggerMain</literal></entry>
-      <entry>Waiting in main loop of syslogger process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>syslogger</literal>.</entry>
      </row>
      <row>
       <entry><literal>WalReceiverMain</literal></entry>
-      <entry>Waiting in main loop of WAL receiver process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>walreceiver</literal>.</entry>
      </row>
      <row>
       <entry><literal>WalSenderMain</literal></entry>
-      <entry>Waiting in main loop of WAL sender process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>walsender</literal>.</entry>
      </row>
      <row>
       <entry><literal>WalSummarizerWal</literal></entry>
-      <entry>Waiting in WAL summarizer for more WAL to be generated.</entry>
+      <entry>En attente de la génération de nouveaux journaux dans
+             <literal>walsummarizer</literal>.</entry>
      </row>
      <row>
       <entry><literal>WalWriterMain</literal></entry>
-      <entry>Waiting in main loop of WAL writer process.</entry>
+      <entry>En attente dans la boucle principale du processus
+             <literal>walwriter</literal>.</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
+<!--
+  Table 27.6. Wait Events of Type Activity
+-->
   <table id="wait-event-bufferpin-table">
-   <title>Wait Events of Type <literal>Bufferpin</literal></title>
+   <title>Points d'attente de type <literal>Bufferpin</literal></title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry><literal>BufferPin</literal> Wait Event</entry>
+      <entry>Point d'attente <literal>BufferPin</literal></entry>
       <entry>Description</entry>
      </row>
     </thead>
@@ -91,18 +119,22 @@
     <tbody>
      <row>
       <entry><literal>BufferPin</literal></entry>
-      <entry>Waiting to acquire an exclusive pin on a buffer.</entry>
+      <entry>En attente d'un verrou (<foreignphrase>pin</foreignphrase>)
+             exclusif sur un buffer.</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
+<!--
+  Table 27.7. Wait Events of Type Client
+-->
   <table id="wait-event-client-table">
-   <title>Wait Events of Type <literal>Client</literal></title>
+   <title>Points d'attente de type  <literal>Client</literal></title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry><literal>Client</literal> Wait Event</entry>
+      <entry>Point d'attente <literal>Client</literal></entry>
       <entry>Description</entry>
      </row>
     </thead>
@@ -110,50 +142,60 @@
     <tbody>
      <row>
       <entry><literal>ClientRead</literal></entry>
-      <entry>Waiting to read data from the client.</entry>
+      <entry>En attente de lecture de données depuis le client.</entry>
      </row>
      <row>
       <entry><literal>ClientWrite</literal></entry>
-      <entry>Waiting to write data to the client.</entry>
+      <entry>En attente d'écriture de données vers le client.</entry>
      </row>
      <row>
       <entry><literal>GssOpenServer</literal></entry>
-      <entry>Waiting to read data from the client while establishing a GSSAPI session.</entry>
+      <entry>En attente de lecture de données depuis le client
+        lors de l'établissement une session GSSAPI.</entry>
      </row>
      <row>
       <entry><literal>LibpqwalreceiverConnect</literal></entry>
-      <entry>Waiting in WAL receiver to establish connection to remote server.</entry>
+            <entry>En attente de l'établissement d'une connexion à un serveur distant
+              dans le <literal>walreceiver</literal>.</entry>
      </row>
      <row>
       <entry><literal>LibpqwalreceiverReceive</literal></entry>
-      <entry>Waiting in WAL receiver to receive data from remote server.</entry>
+            <entry>En attente de la réception de données depuis un serveur distant
+              dans le <literal>walreceiver</literal>.</entry>
      </row>
      <row>
       <entry><literal>SslOpenServer</literal></entry>
-      <entry>Waiting for SSL while attempting connection.</entry>
+      <entry>En attente du SSL lors de l'établissement d'une connexion.</entry>
      </row>
      <row>
       <entry><literal>WaitForStandbyConfirmation</literal></entry>
-      <entry>Waiting for WAL to be received and flushed by the physical standby.</entry>
+      <entry>En attente de la réception et de l'enregistrement physique des WAL par
+        le serveur secondaire (réplication physique).</entry>
      </row>
      <row>
       <entry><literal>WalSenderWaitForWal</literal></entry>
-      <entry>Waiting for WAL to be flushed in WAL sender process.</entry>
+      <entry>En attente de l'enregistrement physique de journaux par
+        le processus <literal>walsender</literal>.</entry>
      </row>
      <row>
       <entry><literal>WalSenderWriteData</literal></entry>
-      <entry>Waiting for any activity when processing replies from WAL receiver in WAL sender process.</entry>
+      <entry>En attente de n'importe quelle activité lors du traitement des
+        réponses d'un <literal>walreveiver</literal>
+        dans le processus <literal>walsender</literal>.</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
+<!--
+  Table 27.8. Wait Events of Type Extension
+-->
   <table id="wait-event-extension-table">
-   <title>Wait Events of Type <literal>Extension</literal></title>
+   <title>Points d'attente de type <literal>Extension</literal></title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry><literal>Extension</literal> Wait Event</entry>
+      <entry>Point d'attente <literal>Extension</literal></entry>
       <entry>Description</entry>
      </row>
     </thead>
@@ -161,18 +203,21 @@
     <tbody>
      <row>
       <entry><literal>Extension</literal></entry>
-      <entry>Waiting in an extension.</entry>
+      <entry>En attente dans une extension.</entry>
      </row>
     </tbody>
    </tgroup>
   </table>
 
+<!--
+  Table 27.9. Wait Events of Type Io
+-->
   <table id="wait-event-io-table">
-   <title>Wait Events of Type <literal>Io</literal></title>
+   <title>Points d'attente de type <literal>Io</literal></title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry><literal>IO</literal> Wait Event</entry>
+      <entry>Point d'attente <literal>IO</literal></entry>
       <entry>Description</entry>
      </row>
     </thead>
@@ -180,311 +225,358 @@
     <tbody>
      <row>
       <entry><literal>BasebackupRead</literal></entry>
-      <entry>Waiting for base backup to read from a file.</entry>
+      <entry>En attente de la lecture d'un fichier par un <foreignphrase>base backup</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>BasebackupSync</literal></entry>
-      <entry>Waiting for data written by a base backup to reach durable storage.</entry>
+      <entry>En attente de l'écriture de données sur un stockage durable
+        par un <foreignphrase>base backup</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>BasebackupWrite</literal></entry>
-      <entry>Waiting for base backup to write to a file.</entry>
+      <entry>En attente de l'écriture d'un fichier par un <foreignphrase>base backup</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>BuffileRead</literal></entry>
-      <entry>Waiting for a read from a buffered file.</entry>
+      <entry>En attente d'une lecture depuis un fichier tampon
+        (<foreignphrase>buffered file</foreignphrase>).</entry>
      </row>
      <row>
       <entry><literal>BuffileTruncate</literal></entry>
-      <entry>Waiting for a buffered file to be truncated.</entry>
+      <entry>En attente pendant qu'un fichier tampon est tronqué.</entry>
      </row>
      <row>
       <entry><literal>BuffileWrite</literal></entry>
-      <entry>Waiting for a write to a buffered file.</entry>
+      <entry>En attente d'une écriture dans un fichier tampon.</entry>
      </row>
      <row>
       <entry><literal>ControlFileRead</literal></entry>
-      <entry>Waiting for a read from the <filename>pg_control</filename> file.</entry>
+      <entry>En attente d'une lecture dans le fichier <filename>pg_control</filename>.</entry>
      </row>
      <row>
       <entry><literal>ControlFileSync</literal></entry>
-      <entry>Waiting for the <filename>pg_control</filename> file to reach durable storage.</entry>
+      <entry>En attente de l'écriture du fichier <filename>pg_control</filename>
+        en stockage durable.</entry>
      </row>
      <row>
       <entry><literal>ControlFileSyncUpdate</literal></entry>
-      <entry>Waiting for an update to the <filename>pg_control</filename> file to reach durable storage.</entry>
+      <entry>En attente de l'écriture pour mettre à jour le fichier <filename>pg_control</filename>
+        vers un stockage durable.</entry>
      </row>
      <row>
       <entry><literal>ControlFileWrite</literal></entry>
-      <entry>Waiting for a write to the <filename>pg_control</filename> file.</entry>
+      <entry>En attente d'une écriture vers le fichier <filename>pg_control</filename>.</entry>
      </row>
      <row>
       <entry><literal>ControlFileWriteUpdate</literal></entry>
-      <entry>Waiting for a write to update the <filename>pg_control</filename> file.</entry>
+      <entry>En attente d'une écriture de mise à jour du fichier <filename>pg_control</filename>.</entry>
      </row>
      <row>
       <entry><literal>CopyFileRead</literal></entry>
-      <entry>Waiting for a read during a file copy operation.</entry>
+      <entry>En attente d'une lecture pendant une copie de fichier.</entry>
      </row>
      <row>
       <entry><literal>CopyFileWrite</literal></entry>
-      <entry>Waiting for a write during a file copy operation.</entry>
+      <entry>En attente d'une écriture pendant une copie de fichier.</entry>
      </row>
      <row>
       <entry><literal>DataFileExtend</literal></entry>
-      <entry>Waiting for a relation data file to be extended.</entry>
+      <entry>En attente de l'extension du fichier d'une relation.</entry>
      </row>
      <row>
       <entry><literal>DataFileFlush</literal></entry>
-      <entry>Waiting for a relation data file to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement du fichier d'une relation
+        sur un stockage durable.</entry>
      </row>
      <row>
       <entry><literal>DataFileImmediateSync</literal></entry>
-      <entry>Waiting for an immediate synchronization of a relation data file to durable storage.</entry>
+      <entry>En attente d'une synchronisation immédiate du fichier de données
+        d'une relation vers un stockage durable.</entry>
      </row>
      <row>
       <entry><literal>DataFilePrefetch</literal></entry>
-      <entry>Waiting for an asynchronous prefetch from a relation data file.</entry>
+      <entry>En attente d'un préchargement asynchrone d'un fichier de données d'une relation.</entry>
      </row>
      <row>
       <entry><literal>DataFileRead</literal></entry>
-      <entry>Waiting for a read from a relation data file.</entry>
+      <entry>En attente d'une lecture dans un fichier de données d'une relation.</entry>
      </row>
      <row>
       <entry><literal>DataFileSync</literal></entry>
-      <entry>Waiting for changes to a relation data file to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement des changements d'un fichier de données d'une relation
+        vers un stockage durable.</entry>
      </row>
      <row>
       <entry><literal>DataFileTruncate</literal></entry>
-      <entry>Waiting for a relation data file to be truncated.</entry>
+      <entry>En attente pendant qu'un fichier de données d'une relation
+        est tronqué.</entry>
      </row>
      <row>
       <entry><literal>DataFileWrite</literal></entry>
-      <entry>Waiting for a write to a relation data file.</entry>
+      <entry>En attente d'une écriture dans un fichier de données d'une relation.</entry>
      </row>
      <row>
       <entry><literal>DsmAllocate</literal></entry>
-      <entry>Waiting for a dynamic shared memory segment to be allocated.</entry>
+      <entry>En attente de l'allocation d'un segment de mémoire partagée dynamique.</entry>
      </row>
      <row>
       <entry><literal>DsmFillZeroWrite</literal></entry>
-      <entry>Waiting to fill a dynamic shared memory backing file with zeroes.</entry>
+      <entry>En attente du remplissage par des zéros d'un fichier de la mémoire partagée.</entry>
      </row>
      <row>
       <entry><literal>LockFileAddtodatadirRead</literal></entry>
-      <entry>Waiting for a read while adding a line to the data directory lock file.</entry>
+      <entry>En attente d'une lecture lors de l'addition d'une ligne au fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LockFileAddtodatadirSync</literal></entry>
-      <entry>Waiting for data to reach durable storage while adding a line to the data directory lock file.</entry>
+      <entry>En attente de l'enregistrement de données sur un stockage durable
+        lors de l'addition d'une ligne au fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LockFileAddtodatadirWrite</literal></entry>
-      <entry>Waiting for a write while adding a line to the data directory lock file.</entry>
+      <entry>En attente d'une écriture lors de l'ajout d'une ligne au fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LockFileCreateRead</literal></entry>
-      <entry>Waiting to read while creating the data directory lock file.</entry>
+      <entry>En attente de lecture lors de la création du fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LockFileCreateSync</literal></entry>
-      <entry>Waiting for data to reach durable storage while creating the data directory lock file.</entry>
+      <entry>En attente de l'écriture de données sur un stockage durable
+        lors de la création du fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LockFileCreateWrite</literal></entry>
-      <entry>Waiting for a write while creating the data directory lock file.</entry>
+      <entry>En attente d'une écriture
+        lors de la création du fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LockFileRecheckdatadirRead</literal></entry>
-      <entry>Waiting for a read during recheck of the data directory lock file.</entry>
+      <entry>En attente d'une lecture lors de la vérification du fichier de verrouillage
+        du répertoire de données.</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteCheckpointSync</literal></entry>
-      <entry>Waiting for logical rewrite mappings to reach durable storage during a checkpoint.</entry>
+      <entry>En attente de l'écriture sur un stockage durable
+        des données mappées d'une réécriture logique
+        pendant un checkpoint.</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteMappingSync</literal></entry>
-      <entry>Waiting for mapping data to reach durable storage during a logical rewrite.</entry>
+      <entry>En attente de l'écriture sur un stockage durable
+        des données mappées lors d'une réécriture logique.</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteMappingWrite</literal></entry>
-      <entry>Waiting for a write of mapping data during a logical rewrite.</entry>
+      <entry>En attente de l'écriture
+        des données mappées pendant une réécriture logique.</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteSync</literal></entry>
-      <entry>Waiting for logical rewrite mappings to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement sur un stockage durable
+        des données mappées d'une réécriture logique.</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteTruncate</literal></entry>
-      <entry>Waiting for truncate of mapping data during a logical rewrite.</entry>
+      <entry>En attente pendant que les données mappées sont tronquées
+        pendant une réécriture logique.</entry>
      </row>
      <row>
       <entry><literal>LogicalRewriteWrite</literal></entry>
-      <entry>Waiting for a write of logical rewrite mappings.</entry>
+      <entry>En attente d'une écriture de données mappées
+        d'une réécriture logique.</entry>
      </row>
      <row>
       <entry><literal>RelationMapRead</literal></entry>
-      <entry>Waiting for a read of the relation map file.</entry>
+      <entry>En attente d'une lecture du fichier de correspondance d'une relation.</entry>
      </row>
      <row>
       <entry><literal>RelationMapReplace</literal></entry>
-      <entry>Waiting for durable replacement of a relation map file.</entry>
+      <entry>En attente pendant le remplacement durable d'un fichier de correspondance de relation.</entry>
      </row>
      <row>
       <entry><literal>RelationMapWrite</literal></entry>
-      <entry>Waiting for a write to the relation map file.</entry>
+      <entry>En attente pendant l'écriture du fichier de correspondance d'une relation.</entry>
      </row>
      <row>
       <entry><literal>ReorderBufferRead</literal></entry>
-      <entry>Waiting for a read during reorder buffer management.</entry>
+      <entry>En attente d'une lecture pendant la réorganisation des
+        <foreignphrase>buffers</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>ReorderBufferWrite</literal></entry>
-      <entry>Waiting for a write during reorder buffer management.</entry>
+      <entry>En attente d'une écriture pendant la réorganisation des
+        <foreignphrase>buffers</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>ReorderLogicalMappingRead</literal></entry>
-      <entry>Waiting for a read of a logical mapping during reorder buffer management.</entry>
+      <entry>En attente d'une lecture du mapping logique pendant la réorganisation des
+        <foreignphrase>buffers</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotRead</literal></entry>
-      <entry>Waiting for a read from a replication slot control file.</entry>
+      <entry>En attente d'une lecture depuis le fichier de contrôle d'un slot de réplication.</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotRestoreSync</literal></entry>
-      <entry>Waiting for a replication slot control file to reach durable storage while restoring it to memory.</entry>
+      <entry>En attente de l'écriture sur un stockage durable d'un fichier de contrôle
+        d'un slot de réplication, pendant une restauration en mémoire.</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotSync</literal></entry>
-      <entry>Waiting for a replication slot control file to reach durable storage.</entry>
+      <entry>En attente de l'écriture sur un stockage durable d'un fichier de contrôle
+        d'un slot de réplication.</entry>
      </row>
      <row>
       <entry><literal>ReplicationSlotWrite</literal></entry>
-      <entry>Waiting for a write to a replication slot control file.</entry>
+      <entry>En attente d'une écriture dans un fichier de contrôle
+        d'un slot de réplication.</entry>
      </row>
      <row>
       <entry><literal>SlruFlushSync</literal></entry>
-      <entry>Waiting for SLRU data to reach durable storage during a checkpoint or database shutdown.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable de données d'un cache SLRU
+        pendant un checkpoint ou un arrêt de l'instance.</entry>
      </row>
      <row>
       <entry><literal>SlruRead</literal></entry>
-      <entry>Waiting for a read of an SLRU page.</entry>
+      <entry>En attente d'une lecture d'une page d'un cache SLRU.</entry>
      </row>
      <row>
       <entry><literal>SlruSync</literal></entry>
-      <entry>Waiting for SLRU data to reach durable storage following a page write.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable des données d'un cache SLRU
+        suite à une écriture de page.</entry>
      </row>
      <row>
       <entry><literal>SlruWrite</literal></entry>
-      <entry>Waiting for a write of an SLRU page.</entry>
+      <entry>En attente de l'enregistrement d'une page d'un cache SLRU.</entry>
      </row>
      <row>
       <entry><literal>SnapbuildRead</literal></entry>
-      <entry>Waiting for a read of a serialized historical catalog snapshot.</entry>
+      <entry>En attente d'une lecture d'un snapshot historique et sérialisé du catalogue.</entry>
      </row>
      <row>
       <entry><literal>SnapbuildSync</literal></entry>
-      <entry>Waiting for a serialized historical catalog snapshot to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable d'un snapshot historique et sérialisé du catalogue.</entry>
      </row>
      <row>
       <entry><literal>SnapbuildWrite</literal></entry>
-      <entry>Waiting for a write of a serialized historical catalog snapshot.</entry>
+      <entry>En attente d'une écriture d'un snapshot historique et sérialisé du catalogue.</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryFileSync</literal></entry>
-      <entry>Waiting for a timeline history file received via streaming replication to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable d'un fichier d'historique
+        de timeline reçu lors d'une réplication par <foreignphrase>streaming</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryFileWrite</literal></entry>
-      <entry>Waiting for a write of a timeline history file received via streaming replication.</entry>
+      <entry>En attente d'une écriture d'un fichier d'historique
+        de timeline reçu par réplication par <foreignphrase>streaming</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryRead</literal></entry>
-      <entry>Waiting for a read of a timeline history file.</entry>
+      <entry>En attente de lecture d'un fichier d'historique de timeline.</entry>
      </row>
      <row>
       <entry><literal>TimelineHistorySync</literal></entry>
-      <entry>Waiting for a newly created timeline history file to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable
+         d'un nouveau fichier d'historique de timeline.</entry>
      </row>
      <row>
       <entry><literal>TimelineHistoryWrite</literal></entry>
-      <entry>Waiting for a write of a newly created timeline history file.</entry>
+      <entry>En attente d'écriture d'un nouveau fichier d'historique de timeline.</entry>
      </row>
      <row>
       <entry><literal>TwophaseFileRead</literal></entry>
-      <entry>Waiting for a read of a two phase state file.</entry>
+      <entry>En attente de lecture d'un fichier d'état de two-phase commit.</entry>
      </row>
      <row>
       <entry><literal>TwophaseFileSync</literal></entry>
-      <entry>Waiting for a two phase state file to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable d'un fichier d'état de two-phase commit.</entry>
      </row>
      <row>
       <entry><literal>TwophaseFileWrite</literal></entry>
-      <entry>Waiting for a write of a two phase state file.</entry>
+      <entry>En attente d'écriture d'un fichier d'état de two-phase commit.</entry>
      </row>
      <row>
       <entry><literal>VersionFileSync</literal></entry>
-      <entry>Waiting for the version file to reach durable storage while creating a database.</entry>
+      <entry>En attente de l'enregistrement sur stockage durable du fichier de version,
+        lors de création d'une base de données.</entry>
      </row>
      <row>
       <entry><literal>VersionFileWrite</literal></entry>
-      <entry>Waiting for the version file to be written while creating a database.</entry>
+      <entry>En attente de l'écriture du fichier de version
+        lors de création d'une base de données.</entry>
      </row>
      <row>
       <entry><literal>WalsenderTimelineHistoryRead</literal></entry>
-      <entry>Waiting for a read from a timeline history file during a walsender timeline command.</entry>
+      <entry>En attente d'une lecture dans un fichier d'historique de timeline,
+        lors d'une commande de demande de timeline du <literal>walsender</literal>.</entry>
      </row>
      <row>
       <entry><literal>WalBootstrapSync</literal></entry>
-      <entry>Waiting for WAL to reach durable storage during bootstrapping.</entry>
+      <entry>En attente de l'enregistrement d'un WAL en stockage durable lors du
+        <foreignphrase>bootstrap</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>WalBootstrapWrite</literal></entry>
-      <entry>Waiting for a write of a WAL page during bootstrapping.</entry>
+      <entry>En attente d'une écriture d'une page de WAL lors du
+        <foreignphrase>bootstrap</foreignphrase>.</entry>
      </row>
      <row>
       <entry><literal>WalCopyRead</literal></entry>
-      <entry>Waiting for a read when creating a new WAL segment by copying an existing one.</entry>
+      <entry>En attente d'une lecture lors de la création d'un nouveau segment de WAL
+        créé par copie d'un segment existant.</entry>
      </row>
      <row>
       <entry><literal>WalCopySync</literal></entry>
-      <entry>Waiting for a new WAL segment created by copying an existing one to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement en stockage durable d'un nouveau segment de WAL
+        créé par copie d'un segment existant.</entry>
      </row>
      <row>
       <entry><literal>WalCopyWrite</literal></entry>
-      <entry>Waiting for a write when creating a new WAL segment by copying an existing one.</entry>
+      <entry>En attente d'une écriture lors de la création d'un nouveau segment de WAL
+        créé par copie d'un segment existant.</entry>
      </row>
      <row>
       <entry><literal>WalInitSync</literal></entry>
-      <entry>Waiting for a newly initialized WAL file to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement en stockage durable
+        d'un fichier WAL nouvellement initialisé.</entry>
      </row>
      <row>
       <entry><literal>WalInitWrite</literal></entry>
-      <entry>Waiting for a write while initializing a new WAL file.</entry>
+      <entry>En attente d'une écriture lors de l'initialisation d'un nouveau fichier WAL.</entry>
      </row>
      <row>
       <entry><literal>WalRead</literal></entry>
-      <entry>Waiting for a read from a WAL file.</entry>
+      <entry>En attente d'une lecture depuis un fichier WAL.</entry>
      </row>
      <row>
       <entry><literal>WalSummaryRead</literal></entry>
-      <entry>Waiting for a read from a WAL summary file.</entry>
+      <entry>En attente d'une lecture depuis un fichier résumé de WAL.</entry>
      </row>
      <row>
       <entry><literal>WalSummaryWrite</literal></entry>
-      <entry>Waiting for a write to a WAL summary file.</entry>
+      <entry>En attente d'une écriture vers un fichier résumé de WAL.</entry>
      </row>
      <row>
       <entry><literal>WalSync</literal></entry>
-      <entry>Waiting for a WAL file to reach durable storage.</entry>
+      <entry>En attente de l'enregistrement en stockage durable
+        d'un fichier WAL.</entry>
      </row>
      <row>
       <entry><literal>WalSyncMethodAssign</literal></entry>
-      <entry>Waiting for data to reach durable storage while assigning a new WAL sync method.</entry>
+      <entry>En attente de l'enregistrement en stockage durable
+        lors de l'assignation d'une nouvelle méthode de synchronisation.</entry>
      </row>
      <row>
       <entry><literal>WalWrite</literal></entry>
-      <entry>Waiting for a write to a WAL file.</entry>
+      <entry>En attente d'une écriture vers un fichier WAL.</entry>
      </row>
     </tbody>
    </tgroup>


### PR DESCRIPTION
Première moitié du fichier wait_event_types.xml. Problèmes habituels de traduction (ou pas) de pin, buffer, bootstrap, two-phase commit... J'ai de plus en plus tendance à laisser en anglais.

Questionnement sur la traduction exacte de `serialized historical catalog snapshot` (« snapshot historique et sérialisé du catalogue » ?)

Je continuerai par plus petits morceaux, c'est assez abrutissant.