### PR TITLE
Quelques corrections orthographiques et grammaticales

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Ce répertoire contient la documentation de PostgreSQL au format XML.
 
 Ce répertoire était auparavant nommé manuel car seule la documentation de
 PostgreSQL était traduite à ce moment. Il a été renommé quand la documentation
-du manuel de Slony a été ajouté.
+du manuel de Slony a été ajoutée.
 
 Les fichiers de la documentation sont au format XML, ce qui permet ensuite de
 produire, grâce au fichier Makefile, en différents formats : HTML, PDF, texte.
@@ -24,7 +24,7 @@ Répertoire slony
 Ce répertoire contient la documentation de Slony au format XML. Il contient
 aussi la traduction du site web, dans le sous-répertoire website.
 
-Là-aussi, l'utilisation du XML permet la production de différents formats.
+Là aussi, l'utilisation du XML permet la production de différents formats.
 
 Répertoire divers
 *****************
@@ -54,7 +54,7 @@ Lelarge (guillaume at lelarge.info).
 En rapportant les erreurs trouvées
 **********************************
 
-Nous sommes intéressés de connaître les erreurs que vous avez trouvé. Quelque
+Nous sommes intéressés de connaître les erreurs que vous avez trouvées. Quelque
 soit l'erreur : une erreur de sens, une faute d'orthographe, de français, etc.
 N'hésitez donc pas à nous informer. Là-aussi, le plus simple est d'envoyer un
 mail à Guillaume Lelarge.

--- a/divers/annotated_postgresql_conf.xml
+++ b/divers/annotated_postgresql_conf.xml
@@ -170,7 +170,7 @@
   <entry>
   <para>
   Un port alternatif est essentiellement utilisé lorsque plusieurs serveurs
-  postgreSQL tournent sur la même machine, pendant une mise à niveau par exemple.
+  PostgreSQL tournent sur la même machine, pendant une mise à niveau par exemple.
   </para>
   <para>
   Une alternative à cette configuration est l'utilisation de l'option de compilation
@@ -278,7 +278,7 @@
   </para>
   </entry>
   <entry>
-  Aucune recommandation particulère.</entry>
+  Aucune recommandation particulière.</entry>
  </row>
  <row>
   <entry>bonjour_name</entry>
@@ -358,7 +358,7 @@
 <title>Securité et authentification</title>
 
 <table>
-<title>Securité et authentication (Fichier postgresql.conf et guide de configuration utilisateur générale (<foreignphrase>Global User Configuration (GUC)</foreignphrase>) annotés)</title>
+<title>Sécurité et authentification (Fichier postgresql.conf et guide de configuration utilisateur générale (<foreignphrase>Global User Configuration (GUC)</foreignphrase>) annotés)</title>
 <tgroup cols="7" align="left" colsep="1" rowsep="1">
 
 <thead>
@@ -524,7 +524,7 @@
  <para>
   Augmenter la valeur de la plupart des paramètres suivants
   oblige à modifier les options du noyau du système d'exploitation 
-  pour augmenter la mémoire alloué à un processus ou à un utilisateur.
+  pour augmenter la mémoire allouée à un processus ou à un utilisateur.
   La documentation en ligne fournit des <ulink
   url="http://docs.postgresqlfr.org/8.1/kernel-resources.html">informations sur
   les commandes à utiliser pour de nombreux systèmes d'exploitation</ulink>. Sauf indication
@@ -558,7 +558,7 @@
   </entry>
   <entry>-B x</entry>
   <entry>
-  Positionne le nombre de tampons de mémoire partagée utilisé par le 
+  Positionne le nombre de tampons de mémoire partagée utilisés par le
   serveur de bases de données. Le minimum est 2 X max_connections.
   La valeur par défaut est généralement 1000 mais elle peut être
   inférieure si la configuration du noyau l'impose (ce qu'initdb détermine). 
@@ -582,7 +582,7 @@
   1&nbsp;000 et 50&nbsp;000 (8Mo et 400Mo). Les facteurs qui incitent à augmenter
   la valeur sont des connexions plus nombreuses, des parties actives de la base
   plus grandes, des requêtes longues et complexes, et des grandes tables. La
-  RAM disponible limite le ombre maximum de shared_buffers&nbsp;; 1/3 de la RAM
+  RAM disponible limite le nombre maximum de shared_buffers&nbsp;; 1/3 de la RAM
   disponible est la limite maximale à utiliser.
   </para>
   </entry>
@@ -948,7 +948,7 @@
   </para>
   </entry>
   <entry>
-  Cela n'est utile que pour dans le cas de bases de données spécialisées.
+  Cela n'est utile que dans le cas de bases de données spécialisées.
   Une base de cartographie peut, par exemple, gagner légèrement en performances
   en préchargeant les bibliothèques GIS. Pour la plupart des systèmes, il est
   préférable de ne pas renseigner cette option.
@@ -1121,7 +1121,7 @@ Writer</foreignphrase>)</title>
   </para>
   <para>
   L'OSDL effectue toujours des tests de configuration du bgwriter&nbsp;; aucune
-  recommendation ne peut être faite à ce jour.
+  recommandation ne peut être faite à ce jour.
   </para>
   </entry>
  </row>
@@ -2140,7 +2140,7 @@ SELECT * FROM parent WHERE clef = 2400;
   du système.
   </entry>
   <entry>
-  Pas de recommendation particulière.
+  Pas de recommandation particulière.
   </entry>
  </row>
  <row>
@@ -3197,7 +3197,7 @@ SELECT * FROM parent WHERE clef = 2400;
    avant que le serveur ne recherche les verrous morts.
   </entry>
   <entry>
-   Pas de recommendations autres que celles dans la documentation.
+   Pas de recommandations autres que celles dans la documentation.
   </entry>
  </row>
  <row>

--- a/postgresql/acronyms.xml
+++ b/postgresql/acronyms.xml
@@ -108,10 +108,10 @@
     <listitem>
      <para>
       <ulink
-      url="https://fr.wikipedia.org/wiki/Comma-separated_values">Comma
-       Separated Values</ulink>, valeurs séparées par des virgules (format de
+      url="https://fr.wikipedia.org/wiki/Comma-separated_values">
+       Comma-Separated Values</ulink>, valeurs séparées par des virgules (format de
       fichier présentant les données en ligne en séparant les colonnes par des virgules ou
-      point-virgules)
+      points-virgules)
      </para>
     </listitem>
    </varlistentry>
@@ -130,7 +130,7 @@
     <listitem>
      <para>
       <ulink url="https://cve.mitre.org/">Common Vulnerabilities and
-       Exposures</ulink>, vulnérabilités usuelles
+       Exposures</ulink>, vulnérabilités et expositions courantes
      </para>
     </listitem>
    </varlistentry>
@@ -280,7 +280,7 @@
     <listitem>
      <para>
       <ulink
-      url="https://en.wikipedia.org/wiki/Git_(software)">Git</ulink>
+      url="https://en.wikipedia.org/wiki/Git_(software)">Git</ulink>,
      </para>
     </listitem>
    </varlistentry>
@@ -312,7 +312,7 @@
     <listitem>
      <para>
       <link linkend="config-setting">Grand Unified Configuration</link>,
-      Configuration générale unifiée
+      Configuration générale unifiée,
       le sous-système <productname>PostgreSQL</productname> qui gère la
       configuration du serveur
      </para>
@@ -407,7 +407,7 @@
     <term><acronym>JIT</acronym></term>
     <listitem>
      <para>
-      <ulink url="https://en.wikipedia.org/wiki/Just-in-time_compilation">Just-in-Time
+      <ulink url="https://en.wikipedia.org/wiki/Just-in-time_compilation">Just-in Time
        compilation</ulink>
      </para>
     </listitem>
@@ -447,8 +447,7 @@
     <term><acronym>MCF</acronym></term>
     <listitem>
      <para>
-      Most Common Frequency, fréquence la plus commune qui est associée avec certaines
-      Most Common Value
+      Most Common Frequency, fréquence associée à une des valeurs les plus fréquentes (MCV)
      </para>
     </listitem>
    </varlistentry>
@@ -457,7 +456,7 @@
     <term><acronym>MCV</acronym></term>
     <listitem>
      <para>
-      Most Common Value, valeur la plus commune, une des valeurs qui apparait le plus
+      Most Common Value, valeur la plus commune, une des valeurs qui apparaît le plus
       souvent dans une colonne spécifique d'une table.
      </para>
     </listitem>

--- a/postgresql/advanced.xml
+++ b/postgresql/advanced.xml
@@ -87,7 +87,7 @@ SELECT * FROM ma_vue;</programlisting>
     n'insère de ligne dans la table <classname>temps</classname> qui ne
     corresponde à une entrée dans la table <classname>villes</classname>. On
     appelle cela maintenir l'<firstterm>intégrité référentielle</firstterm> des
-    données. Dans les systèmes de bases de données simplistes, lorsqu'au moins
+    données. Dans les systèmes de bases de données simplistes, lorsque
     c'est possible, cela est parfois obtenu par la vérification préalable de
     l'existence d'un enregistrement correspondant dans la table
     <classname>villes</classname>, puis par l'insertion, ou l'interdiction, du
@@ -107,8 +107,8 @@ SELECT * FROM ma_vue;</programlisting>
 
 CREATE TABLE temps (
 	ville      varchar(80) references villes(nom),
-	t_haute int,
-	t_basse int,
+	t_haute    int,
+	t_basse    int,
 	prcp       real,
 	date       date
 );</programlisting>
@@ -118,7 +118,7 @@ CREATE TABLE temps (
 <programlisting>INSERT INTO temps VALUES ('Berkeley', 45, 53, 0.0, '1994-11-28');</programlisting>
 
 <screen>ERROR:  insert or update on table "temps" violates foreign key constraint "temps_ville_fkey"
-DETAIL : Key (ville)=(a) is not present in table "villes".</screen>
+DETAIL: Key (ville)=(a) is not present in table "villes".</screen>
    </para>
 
    <para>
@@ -520,7 +520,7 @@ SELECT salaire, sum(salaire) OVER (ORDER BY salaire) FROM salaireemp;
   <para>
    Les fonctions window ne sont autorisées que dans la liste
    <literal>SELECT</literal> et la clause <literal>ORDER BY</literal> de la
-   requête. Elles sont interdites ailleurs, comme  dans les clauses
+   requête. Elles sont interdites ailleurs, comme dans les clauses
    <literal>GROUP BY</literal>,<literal>HAVING</literal> et
    <literal>WHERE</literal>. La raison en est qu'elles sont exécutées après le
    traitement de ces clauses. Par ailleurs, les fonctions de fenêtrage
@@ -597,14 +597,14 @@ SELECT sum(salaire) OVER w, avg(salaire) OVER w
    <programlisting>CREATE TABLE capitales (
   nom        text,
   population real,
-  elevation  int,    -- (en pied)
+  elevation  int,    -- (en pieds)
   etat       char(2)
 );
 
 CREATE TABLE non_capitales (
   nom        text,
   population real,
-  elevation   int     -- (en pied)
+  elevation   int     -- (en pieds)
 );
 
 CREATE VIEW villes AS
@@ -622,7 +622,7 @@ CREATE VIEW villes AS
 <programlisting>CREATE TABLE villes (
   nom        text,
   population real,
-  elevation  int     -- (en pied)
+  elevation  int     -- (en pieds)
 );
 
 CREATE TABLE capitales (

--- a/postgresql/amcheck.xml
+++ b/postgresql/amcheck.xml
@@ -14,7 +14,7 @@
  <para>
   Les fonctions spécifiques aux B-Tree vérifient diverses <emphasis>propriétés
   invariantes</emphasis> dans la structure de la représentation de certaines
-  relations. La justesse des fonctions des accès aux données durant les
+  relations. La justesse des fonctions d'accès aux données durant les
   parcours d'index et d'autres opérations importantes reposent sur le fait
   que ces propriétés invariantes sont toujours vraies. Par exemple, certaines
   fonctions vérifient, entre autres choses, que tous les blocs d'index B-Tree
@@ -32,13 +32,13 @@
  </para>
 
  <para>
-  La vérification est réalisée en utilisant les même procédures que celles
+  La vérification est réalisée en utilisant les mêmes procédures que celles
   utilisées par les parcours d'index eux-mêmes, qui peuvent très bien être du
-  code pour une classe d'opérateur utilisateur. Par exemple, la vérification
+  code pour une classe d'opérateurs utilisateur. Par exemple, la vérification
   d'index B-Tree s'appuie sur les comparaisons faites avec une ou plusieurs
   routines pour la fonction de support 1. Voir <xref
-  linkend="xindex-support"/> pour plus de détail sur les fonctions de support
-  des classes d'opérateur.
+  linkend="xindex-support"/> pour plus de détails sur les fonctions de support
+  des classes d'opérateurs.
  </para>
 
  <para>
@@ -53,8 +53,8 @@
 
  <para>
   Le droit d'exécuter les fonctions <filename>amcheck</filename> peut être
-  accordée aux utilisateurs normaux, sans attribut
-  <literal>SUPERUSER</literal>, mais avant de donner ce permission, de
+  accordé aux utilisateurs normaux, sans attribut
+  <literal>SUPERUSER</literal>, mais avant de donner cette permission, de
   prudentes considérations doivent être prises concernant la sécurité des
   données et les problèmes de confidentialité. Bien que les rapports de
   corruption générés par ces fonctions ne se focalisent pas tant sur le
@@ -193,7 +193,7 @@ ORDER BY c.relpages DESC LIMIT 10;
       associée d'être traitée de manière concurrente par
       <command>VACUUM</command>, ainsi que toute autre commande
       d'administration. Il est à noter que cette fonction ne conserve les
-      verrous uniquement que durant son exécution et non pas durant
+      verrous que durant son exécution et non pas durant
       l'intégralité de la transaction.
      </para>
 
@@ -217,7 +217,7 @@ ORDER BY c.relpages DESC LIMIT 10;
    <para>
     Les fonctions <function>bt_index_check</function> et
     <function>bt_index_parent_check</function> journalisent toutes les deux
-    des messages sur la vérification, au niveau de sévérité
+    des messages sur la vérification, avec le niveau de sévérité
     <literal>DEBUG1</literal> et <literal>DEBUG2</literal>. Ces messages
     fournissent des informations détaillées sur la vérification, exploitables
     par les développeurs <productname>PostgreSQL</productname>. Les
@@ -311,7 +311,7 @@ SET client_min_messages = DEBUG1;
        <term><literal>startblock</literal></term>
        <listitem>
         <para>
-         Si indiquée, la vérication de corruption commence au bloc spécifié,
+         Si indiquée, la vérification de corruption commence au bloc spécifié,
          sautant tous les blocs précédents. Si <parameter>startblock</parameter>
          est spécifiée à une valeur en dehors de la plage des blocs de la
          table cible, une erreur est renvoyée.
@@ -326,7 +326,7 @@ SET client_min_messages = DEBUG1;
        <listitem>
         <para>
          Si indiquée, la vérification de corruption termine à ce bloc,
-         ignorant tous les blocs restant. Spécifier un
+         ignorant tous les blocs restants. Spécifier un
          <parameter>endblock</parameter> en dehors de la plage des blocs d'une
          table cible renvoie une erreur.
         </para>
@@ -437,7 +437,7 @@ SET client_min_messages = DEBUG1;
     <listitem>
      <para>
       Les incohérences dans la structure causées par des implémentations
-      incorrectes de classe d'opérateur.
+      incorrectes de classe d'opérateurs.
      </para>
 
      <para>
@@ -451,7 +451,7 @@ SET client_min_messages = DEBUG1;
       mises à jour des règles des collations du système d'exploitation
       peuvent causer ces problèmes. Plus généralement, une incohérence dans
       l'ordre de collation entre un serveur primaire et son réplica est
-      impliqué, peut-être parce que la version <emphasis>majeure</emphasis>
+      impliquée, peut-être parce que la version <emphasis>majeure</emphasis>
       du système d'exploitation utilisée est différente. De telles
       incohérences ne surviendront généralement que sur des serveurs
       secondaires, et ne pourront par conséquent être détectées que là.
@@ -526,7 +526,7 @@ SET client_min_messages = DEBUG1;
 
     <listitem>
      <para>
-      Les corruptions causée par une RAM défaillante, et plus largement le
+      Les corruptions causées par une RAM défaillante, et plus largement le
       sous-système mémoire et le système d'exploitation.
      </para>
 
@@ -563,7 +563,7 @@ SET client_min_messages = DEBUG1;
    Des pages de relation qui sont correctement formatées, internalement
    cohérentes, et correctes par rapport à leurs propres sommes de contrôle
    internes, peuvent encore contenir de la corruption logique. Par
-   conqéquent, ce type de corruption ne peut pas être détecté avec
+   conséquent, ce type de corruption ne peut pas être détecté avec
    <application>checksums</application>. Des exemples incluent les valeurs
    TOAST dans la table principale pour lesquelles il manque l'entrée
    correspondante dans la table TOAST, et les lignes dans la table principale
@@ -574,7 +574,7 @@ SET client_min_messages = DEBUG1;
   <para>
    De multiples causes de corruption logique ont été observées sur des
    systèmes en production, incluant des bugs dans le logiciel serveur
-   <productname>PostgreSQL</productname>, des erreurs ou mauvaises
+   <productname>PostgreSQL</productname>, des erreurs ou de mauvaises
    conceptions dans des outils de sauvegarde et restauration, et des erreurs
    utilisateur.
   </para>
@@ -583,7 +583,7 @@ SET client_min_messages = DEBUG1;
    Les relations corrompues sont plus préoccupantes sur des environnements de
    production en cours, plus particulièrement ceux où les risques d'activités
    fortes sont les moins tolérés. Pour cette raison,
-   <function>verify_heapam</function> a été conçue pour diagnotisquer la
+   <function>verify_heapam</function> a été conçue pour diagnostiquer la
    corruption sans risque. Elle ne peut pas protéger contre toutes les causes
    de crash de processus serveur, car même exécuter la requête appelante
    pourrait ne pas être sûr sur un système notablement corrompu. L'accès au

--- a/postgresql/appendix-obsolete.xml
+++ b/postgresql/appendix-obsolete.xml
@@ -4,9 +4,9 @@
 
  <para>
    Certaines fonctionnalités sont parfois supprimées de PostgreSQL. D'autres
-   fonctionnalités, noms de paramètres, noms de foncions peuvent changer. La
+   fonctionnalités, noms de paramètres, noms de fonctions peuvent changer. La
    documentation peut changer d'emplacement. Cette section dirige les
-   utilisateurs provenant de vieillesversions de la documentation ou de liens
+   utilisateurs provenant de vieilles versions de la documentation ou de liens
    externes vers le nouvel emplacement approprié pour l'information qu'ils
    recherchent.
  </para>

--- a/postgresql/archive-modules.xml
+++ b/postgresql/archive-modules.xml
@@ -27,9 +27,9 @@
  <para>
   Les modules d'archivage doivent au moins comporter une fonction
   d'initialisation (voir <xref linkend="archive-module-init"/>) ainsi que les
-  fonctions de support requis (voir <xref linkend="archive-module-callbacks"/>). Cependant,
+  fonctions de support requises (voir <xref linkend="archive-module-callbacks"/>). Cependant,
   les modules d'archivage peuvent également faire bien plus (par exemple,
-  déclarer des paramètres de configuration et démarrer des processus d'arrière plan).
+  déclarer des paramètres de configuration et démarrer des processus d'arrière-plan).
  </para>
 
  <para>
@@ -122,12 +122,12 @@ typedef bool (*ArchiveCheckConfiguredCB) (ArchiveModuleState *state);
 
    <note>
     <para>
-     Lorsqu'il renvoie <literal>false</literal>, il pourraît être utile
+     Lorsqu'il renvoie <literal>false</literal>, il pourrait être utile
      d'ajouter quelques informations supplémentaires au message
      d'avertissement générique. Pour cela, vous pouvez fournir un message à
      la macro <function>arch_module_check_errdetail</function> avant de
      renvoyer <literal>false</literal>. Tout comme <function>errdetail
-     ()</function>, cette macro accepte une chaîne de formatage suivi d'une
+     ()</function>, cette macro accepte une chaîne de formatage suivie d'une
      liste optionnelle d'arguments. La chaîne résultante sera émise sous la
      forme d'une ligne <literal>DETAIL</literal> du message d'avertissement.
     </para>
@@ -159,7 +159,7 @@ typedef bool (*ArchiveFileCB) (ArchiveModuleState *state, const char *file, cons
     <para>
      La fonction callback <function>archive_file_cb</function> est appelé dans
      un contexte mémoire succinct qui sera réinitialisé entre chaque appel.
-     Si vous avez besoin d'un stockage plus permanent, créer un contexte
+     Si vous avez besoin d'un stockage plus permanent, créez un contexte
      mémoire dans la fonction callback <function>startup_cb</function> du
      module.
     </para>

--- a/postgresql/array.xml
+++ b/postgresql/array.xml
@@ -57,7 +57,7 @@
  <para>
   De plus, l'implantation actuelle n'oblige pas non plus à déclarer le
   nombre de dimensions. Les tableaux d'un type d'élément particulier sont tous
-  considérés comme étant du même type, quels que soient leur taille ou le
+  considérés comme étant du même type, quelles que soient leur taille et leur
   nombre de dimensions. Déclarer la taille du tableau ou le nombre de dimensions
   dans <command>CREATE TABLE</command> n'a qu'un but documentaire. Le
   comportement de l'application n'en est pas affecté.

--- a/postgresql/auto-explain.xml
+++ b/postgresql/auto-explain.xml
@@ -79,8 +79,8 @@
       <literal>-1</literal> (correspondant à la valeur par défaut) trace les
       valeurs en complet. <literal>0</literal> désactive la trace des valeurs
       des paramètres. Une valeur supérieure à zéro tronque chaque valeur de
-      paramètre de ce nombre d'octets. Seuls les superutilisaters peuvent
-      modifier ce paramétrage..
+      paramètre de ce nombre d'octets. Seuls les superutilisateurs peuvent
+      modifier ce paramétrage.
      </para>
     </listitem>
    </varlistentry>
@@ -149,7 +149,7 @@
       <literal>WAL</literal>  pour la commande <command>EXPLAIN</command>. Ce
       paramètre n'a pas d'effet tant que
       <varname>auto_explain.log_analyze</varname> n'est pas activé. Ce
-      paramètre est désactivé par défault. Seuls les superutilisateurs peuvent
+      paramètre est désactivé par défaut. Seuls les superutilisateurs peuvent
       modifier la valeur de ce paramètre.
      </para>
     </listitem>
@@ -226,7 +226,7 @@
      <para>
       <varname>auto_explain.log_settings</varname> contrôle quelles
       informations sont affichées à propos des options de configuration
-      modifiées au moment où le plan est tracé. Ne sont inclues dans la sortie
+      modifiées au moment où le plan est tracé. Ne sont inclus dans la sortie
       que les options impactant la planification de requêtes avec des valeurs
       différentes des défauts intégrés à PostgreSQL. Ce paramètre est
       désactivé par défaut. Seuls les superutilisateurs peuvent le changer.

--- a/postgresql/backup-manifest.xml
+++ b/postgresql/backup-manifest.xml
@@ -16,7 +16,7 @@
  </para>
 
  <para>
-  Un manifeste de sauvegarde est un document JSON encodé en UTF-8.(Même si en
+  Un manifeste de sauvegarde est un document JSON encodé en UTF-8. (Même si en
   général, il est recommandé que les documents JSON soient en Unicode,
   PostgreSQL permet l'utilisation des types de données <type>json</type> et
   <type>jsonb</type> avec tout type d'encodage serveur supporté. Il n'y a,
@@ -51,7 +51,7 @@
      <para>
       L'identifiant système de la base de données de l'instance
       <productname>PostgreSQL</productname> où cette sauvegarde a été prise.
-      Ce chemp est présent seulement quand
+      Ce champ est présent seulement quand
       <literal>PostgreSQL-Backup-Manifest-Version</literal> vaut
       <literal>2</literal>.
      </para>
@@ -76,7 +76,7 @@
     <term><literal>WAL-Ranges</literal></term>
     <listitem>
      <para>
-      La valeur associée est toujours une liste d'objet, chacun décrivant un
+      La valeur associée est toujours une liste d'objets, chacun décrivant un
       intervalle d'enregistrements de journaux de transaction chronologiques
       pour utiliser la sauvegarde. La structure de ces objets est décrite dans
       <xref linkend="backup-manifest-wal-ranges" />.

--- a/postgresql/backup.xml
+++ b/postgresql/backup.xml
@@ -853,7 +853,7 @@ pg_restore -d <replaceable class="parameter">nom_base</replaceable> <replaceable
     peut être modifié par rechargement du fichier de configuration. Si vous
     archivez via le shell et souhaitez arrêter temporairement l'archivage, une
     façon de le faire est de peut placer une chaîne vide (<literal>''</literal>)
-    dans <varname>archive_command</varname>.  Les journaux de transaction sont
+    dans <varname>archive_command</varname>.  Les journaux de transactions sont
     alors accumulés dans <filename>pg_wal/</filename> jusqu'au rétablissement
     d'un paramètre <varname>archive_command</varname> fonctionnel.
    </para>

--- a/postgresql/basebackup-to-shell.xml
+++ b/postgresql/basebackup-to-shell.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="basebackup-to-shell" xreflabel="basebackup_to_shell">
- <title>basebackup_to_shell &mdash; module exemple "shell" pour pg_basebackup</title>
+ <title>basebackup_to_shell &mdash; module d'exemple "shell" pour pg_basebackup</title>
 
  <indexterm zone="basebackup-to-shell">
   <primary>basebackup_to_shell</primary>

--- a/postgresql/basic-archive.xml
+++ b/postgresql/basic-archive.xml
@@ -12,7 +12,7 @@
   module copie les fichiers de segment WAL complets vers le répertoire spécifié.
   Ce n'est pas spécialement utile, mais peut servir de point de
   départ au développement de votre propre module d'archivage. Pour plus
-  d'information à propos des modules d'archivage, voir
+  d'informations à propos des modules d'archivage, voir
   <xref linkend="archive-modules"/>.
  </para>
 

--- a/postgresql/bgworker.xml
+++ b/postgresql/bgworker.xml
@@ -22,7 +22,7 @@
  <warning>
   <para>
    Il y a de considérables risques de robustesse et sécurité lorsque l'on utilise
-   des processus background worker. En effet, ceux-ci étant écrit en langage
+   des processus background worker. En effet, ceux-ci étant écrits en langage
    <literal>C</literal>, ils ont un accès total aux données. Les administrateurs
    désirant activer des modules incluant des processus background worker devraient
    prendre énormément de précautions. Seuls les modules soigneusement testés
@@ -75,7 +75,7 @@ typedef struct BackgroundWorker
   sont des chaînes de caractères à utiliser
   dans les messages de trace, liste de processus et autres listes similaires.
   <structfield>bgw_type</structfield> devrait être identique pour tous les
-  processus en tâche de fond du même type pour qu'il soit possibl de grouper
+  processus en tâche de fond du même type pour qu'il soit possible de grouper
   ces processus avec une liste des processus par exemple. Par contre,
   <structfield>bgw_name</structfield> peut contenir des informations
   supplémentaires sur ce processus spécifique. (Typiquement, la chaîne de
@@ -173,7 +173,7 @@ typedef struct BackgroundWorker
  <para>
   Sur Windows (et partout où <literal>EXEC_BACKEND</literal> est défini) ou
   dans des processus en tâche de fond dynamiques, il n'est pas sûr de passer
-  un <type>Datum</type> par référence, il faut le passe par valeur. Si un
+  un <type>Datum</type> par référence, il faut le passer par valeur. Si un
   argument est requis, il est plus sûr de passer un int32 ou toute autre petite
   valeur et l'utiliser comme un index d'un tableau alloué en mémoire partagée.
   Si une valeur comme un <type>cstring</type> ou un <type>text</type> est

--- a/postgresql/bki.xml
+++ b/postgresql/bki.xml
@@ -23,7 +23,7 @@
   Il existe pour chaque catalogue un fichier d'en-tête nommé d'après le catalogue
   (par exemple, <filename>pg_class.h</filename> pour
   <structname>pg_class</structname>), qui définit l'ensemble des colonnes que
-  le catalogue a, ainsi que certaines autres propriétés basique telles que son
+  le catalogue a, ainsi que certaines autres propriétés basiques telles que son
   OID.
  </para>
 
@@ -71,7 +71,7 @@
   fonctionnalités non triviales ajoutées dans les processus clients
   nécessiteront de modifier les fichiers d'en-tête de catalogue et/ou les
   fichiers de données initiales.  Le reste de ce chapitre donne des informations
-  sur ce sujet, et par soucis de complétude décrit le format de fichier
+  sur ce sujet, et par souci de complétude décrit le format de fichier
   <acronym>BKI</acronym>.
  </para>
 
@@ -963,7 +963,7 @@ $ perl  rewrite_dat_with_prokind.pl  pg_proc.dat
       méthode d'accès nommée <replaceable class="parameter">nomam</replaceable>.
       Les champs à indexer sont appelés
       <replaceable class="parameter">nom1</replaceable>,
-      <replaceable class="parameter">nom2</replaceable> etc., et les classes d'opérateur à
+      <replaceable class="parameter">nom2</replaceable> etc., et les classes d'opérateurs à
       utiliser sont respectivement
       <replaceable class="parameter">classeop1</replaceable>,
       <replaceable class="parameter">classeop2</replaceable> etc.

--- a/postgresql/bloom.xml
+++ b/postgresql/bloom.xml
@@ -12,7 +12,7 @@
  </para>
 
  <para>
-  Un filtre Bloom est une structure de données efficace en terme d'espace
+  Un filtre Bloom est une structure de données efficace en termes d'espace
   disque, utilisée pour tester si un élément fait partie d'un ensemble. Dans
   le cas d'une méthode d'accès aux index, il permet une exclusion rapide des
   lignes ne correspondant pas à la recherche via des signatures dont la taille
@@ -20,8 +20,8 @@
  </para>
 
  <para>
-  Une signature est une représentation avec perte des attributs indexé(s) et, de ce
-  fait, est sujet à renvoyer des faux positifs&nbsp;; c'est-à-dire qu'il peut
+  Une signature est une représentation avec perte des attributs indexés et, de ce
+  fait, est susceptible de renvoyer des faux positifs&nbsp;; c'est-à-dire qu'il peut
   indiquer à tort qu'un élément fait partie d'un ensemble. De ce fait,
   les résultats d'une recherche doivent toujours être
   vérifiés en utilisant les valeurs réelles des attributs de la ligne
@@ -35,7 +35,7 @@
   attributs et que les requêtes en testent des combinaisons arbitraires.
   Un index btree traditionnel est plus rapide qu'un index bloom mais
   il en faut généralement plusieurs pour supporter toutes les requêtes que
-  gèrerait un seul index bloom. Noter que les index bloom ne supportent que les
+  gèrerait un seul index bloom. Notez que les index bloom ne supportent que les
   recherches par égalité, là où les index btree peuvent aussi
   réaliser des recherches d'inégalité et d'intervalles.
  </para>
@@ -223,12 +223,12 @@ CREATE INDEX
  </sect2>
 
  <sect2 id="bloom-operator-class-interface">
-  <title>Interface de la classe d'opérateur</title>
+  <title>Interface de la classe d'opérateurs</title>
 
   <para>
-   Une classe d'opérateur pour les index bloom ne requiert qu'une fonction de
+   Une classe d'opérateurs pour les index bloom ne requiert qu'une fonction de
    hachage pour le type de données indexé et un opérateur d'égalité pour la
-   recherche. Cet exemple définit la classe d'opérateur pour
+   recherche. Cet exemple définit la classe d'opérateurs pour
    le type de données <type>text</type>&nbsp;:
   </para>
 
@@ -247,7 +247,7 @@ DEFAULT FOR TYPE text USING bloom AS
    <itemizedlist>
     <listitem>
      <para>
-      Seules les classes d'opérateur pour <type>int4</type> et
+      Seules les classes d'opérateurs pour <type>int4</type> et
       <type>text</type> sont incluses avec le module.
      </para>
     </listitem>

--- a/postgresql/brin.xml
+++ b/postgresql/brin.xml
@@ -48,9 +48,9 @@
   <para>
    Les données spécifiques qu'un index <acronym>BRIN</acronym> va stocker, de
    même que les requêtes spécifiques auquel l'index va pouvoir répondre
-   dépendent de la classe d'opérateur choisie pour chaque colonne de l'index.
+   dépendent de la classe d'opérateurs choisie pour chaque colonne de l'index.
    Les types de données possédant un ordre de tri linéaire peuvent utiliser une
-   classe d'opérateur qui ne conserve que la valeur minimale et la valeur
+   classe d'opérateurs qui ne conserve que la valeur minimale et la valeur
    maximale dans chaque intervalle de bloc. Par exemple, un type géométrique
    peut stocker une <foreignphrase>bounding box</foreignphrase> pour tous les
    objets de l'intervalle de bloc.
@@ -74,8 +74,8 @@
     Lors de la création de l'index, toutes les pages de la table sont
     parcourues et un résumé des lignes de l'index est créé pour chaque
     intervalle, incluant certainement aussi un intervalle incomplet à la fin.
-    Lors de l'ajout de nouvelles données dans des pages déja incluses dans des
-    résumés, cela va entrainer la mise à jour du résumé, avec les informations
+    Lors de l'ajout de nouvelles données dans des pages déjà incluses dans des
+    résumés, cela va entraîner la mise à jour du résumé, avec les informations
     sur les nouvelles lignes insérées.
     Lorsqu'une nouvelle page est créée et qu'elle ne correspond à aucun des
     derniers intervalles résumés, l'intervalle auquel appartient la nouvelle
@@ -134,27 +134,27 @@
     Inversement, un intervalle peut se voir supprimer son résumé avec la
     fonction <function>brin_desummarize_range(regclass, bigint)</function>, qui
     est utile quand l'enregistrement de l'index n'est plus une très bonne
-    représentation car les valeurs existantes ont changées. Voir <xref
+    représentation car les valeurs existantes ont changé. Voir <xref
     linkend="functions-admin-index"/> pour les détails.
    </para>
   </sect3>
  </sect2>
 
  <sect2 id="brin-builtin-opclasses">
-  <title>Classes d'opérateur intégrées</title>
+  <title>classes d'opérateurs intégrées</title>
 
   <para>
    La distribution du noyau <productname>PostgreSQL</productname> inclut la
-   classe d'opérateur <acronym>BRIN</acronym> montrée dans <xref
+   classe d'opérateurs <acronym>BRIN</acronym> montrée dans <xref
    linkend="brin-builtin-opclasses-table"/>.
   </para>
 
   <para>
-   La classe d'opérateur <firstterm>minmax</firstterm> stocke les valeurs
+   La classe d'opérateurs <firstterm>minmax</firstterm> stocke les valeurs
    minimale et maximale apparaissant dans l'intervalle de la colonne indexée.
    L'opérateur de classe <firstterm>inclusion</firstterm> stocke une valeur
    qui est incluse dans les valeurs contenues dans l'intervalle de la colonne
-   indexée. Les classes d'opérateur <firstterm>bloom</firstterm> génèrent un
+   indexée. Les classes d'opérateurs <firstterm>bloom</firstterm> génèrent un
    filtre Bloom pour toutes les valeurs dans l'intervalle. Les classes
    d'opérateur <firstterm>minmax-multi</firstterm> conservent les multiples
    valeurs minimale et maximale, représentant les valeurs apparaissant dans
@@ -162,7 +162,7 @@
   </para>
 
   <table id="brin-builtin-opclasses-table">
-   <title>Classe d'opérateur <acronym>BRIN</acronym> intégrée</title>
+   <title>classe d'opérateurs <acronym>BRIN</acronym> intégrée</title>
    <tgroup cols="2">
     <thead>
      <row>
@@ -746,10 +746,10 @@
   </table>
 
   <sect3 id="brin-builtin-opclasses--parameters">
-   <title>Paramètres de classe d'opérateur</title>
+   <title>Paramètres de classe d'opérateurs</title>
 
    <para>
-    Certaines des classes d'opérateur intégrées permettent aux paramétres
+    Certaines des classes d'opérateurs intégrées permettent aux paramètres
     spécifiés d'affecter leurs comportements. Chaque opérateur de classe a
     son propre ensemble de paramètres autorisés. Seules les classes
     d'opérateur <literal>bloom</literal> et <literal>minmax-multi</literal>
@@ -757,7 +757,7 @@
    </para>
 
    <para>
-    Les classes d'opérateur bloom acceptent ces paramètres&nbsp;:
+    Les classes d'opérateurs bloom acceptent ces paramètres&nbsp;:
    </para>
 
    <variablelist>
@@ -796,7 +796,7 @@
    </variablelist>
 
    <para>
-    Les classes d'opérateur minmax-multi accepte ces paramètres&nbsp;:
+    Les classes d'opérateurs minmax-multi accepte ces paramètres&nbsp;:
    </para>
 
    <variablelist>
@@ -852,10 +852,10 @@
        <programlisting>
 typedef struct BrinOpcInfo
 {
-    /* Nombre de colonnes stockées dans une colonne indexée de cette classe d'opérateur */
+    /* Nombre de colonnes stockées dans une colonne indexée de cette classe d'opérateurs */
     uint16      oi_nstored;
 
-    /* Pointeur opaque pour l'utilisation privée de la classe d'opérateur */
+    /* Pointeur opaque pour l'utilisation privée de la classe d'opérateurs */
     void       *oi_opaque;
 
     /* Type des entrées cachées de la colonne stockées */
@@ -926,7 +926,7 @@ typedef struct BrinOpcInfo
     </varlistentry>
    </variablelist>
 
-   Une classe d'opérateur pour <acronym>BRIN</acronym> peut indiquer en option
+   Une classe d'opérateurs pour <acronym>BRIN</acronym> peut indiquer en option
    la méthode suivante&nbsp;:
 
    <variablelist>
@@ -935,11 +935,11 @@ typedef struct BrinOpcInfo
      <listitem>
       <para>
        Définit un ensemble de paramètres visibles aux utilisateurs qui
-       contrôlent le comportement d'une classe d'opérateur.
+       contrôlent le comportement d'une classe d'opérateurs.
       </para>
 
       <para>
-       La fonction <function>options</function> se voit donné un pointeur
+       La fonction <function>options</function> se voit donnée un pointeur
        vers une structure <structname>local_relopts</structname> qui doit
        être remplie avec un ensemble d'options spécifiques à la classe
        d'opérateur. Les options peuvent être accédées à partir des autres
@@ -978,19 +978,19 @@ typedef struct BrinOpcInfo
   </para>
 
   <para>
-   Pour écrire une classe d'opérateur pour un type de données qui implémente
-   un résultat complétement ordonné, il est possible d'utiliser les fonctions
+   Pour écrire une classe d'opérateurs pour un type de données qui implémente
+   un résultat complètement ordonné, il est possible d'utiliser les fonctions
    de support "minmax" avec les opérateurs correspondant tel que décrit dans
    <xref linkend="brin-extensibility-minmax-table"/>. Tous les membres de
    classe d'opérateurs (fonctions et opérateurs) sont obligatoires.
   </para>
 
   <table id="brin-extensibility-minmax-table">
-   <title>Fonctions et numéros de support pour les classes d'opérateur Minmax</title>
+   <title>Fonctions et numéros de support pour les classes d'opérateurs Minmax</title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Membre de classe d'opérateur</entry>
+      <entry>Membre de classe d'opérateurs</entry>
       <entry>Objet</entry>
      </row>
     </thead>
@@ -1048,12 +1048,12 @@ typedef struct BrinOpcInfo
   </para>
 
   <table id="brin-extensibility-inclusion-table">
-   <title>Fonctions et numéros de support pour les classes d'opérateur
+   <title>Fonctions et numéros de support pour les classes d'opérateurs
     d'inclusion</title>
    <tgroup cols="3">
     <thead>
      <row>
-      <entry>Membre de classe d'opérateur</entry>
+      <entry>Membre de classe d'opérateurs</entry>
       <entry>Objet</entry>
       <entry>Dépendance</entry>
      </row>
@@ -1189,7 +1189,7 @@ typedef struct BrinOpcInfo
    internes BRIN, de ce fait le niveau des fonctions SQL commence à 11. La
    fonction de support 11 est la principale fonction utilisée pour construire
    l'index. Elle doit accepter deux arguments, avec le même type de données que
-   la la classe d'opérateur, et renvoyer l'union des deux. La classe
+   la la classe d'opérateurs, et renvoyer l'union des deux. La classe
    d'opérateur inclusion peut stocker des valeurs unies de types différents si
    elles sont définies avec le paramètre <literal>STORAGE</literal> La valeur
    renvoyée par la fonction union doit correspondre au type de données
@@ -1209,7 +1209,7 @@ typedef struct BrinOpcInfo
   </para>
 
   <para>
-   Pour écrire une classe d'opérateur pour un type de données qui implémente
+   Pour écrire une classe d'opérateurs pour un type de données qui implémente
    seulement l'opérateur égalité et supporte le hachage, il est possible
    d'utiliser les procédures d'appui bloom aux côtés des opérateurs
    correspondants, comme montré dans <xref
@@ -1218,11 +1218,11 @@ typedef struct BrinOpcInfo
   </para>
 
   <table id="brin-extensibility-bloom-table">
-   <title>Procédures et numéros de support pour les classes d'opérateur Bloom</title>
+   <title>Procédures et numéros de support pour les classes d'opérateurs Bloom</title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Membre de la classe d'opérateur</entry>
+      <entry>Membre de la classe d'opérateurs</entry>
       <entry>Objet</entry>
      </row>
     </thead>
@@ -1264,28 +1264,28 @@ typedef struct BrinOpcInfo
    internes BRIN, ainsi les fonctions au niveau SQL débutent avec le numéro
    11. La fonction support numéro 11 est la principale fonction requise pour
    construire un index. Elle doit accepter un argument avec le même type de
-   données que la classe d'opérateur et retourner un hachage de la valeur.
+   données que la classe d'opérateurs et retourner un hachage de la valeur.
   </para>
 
   <para>
-   La classe d'opérateur minmax-multi est aussi prévue pour les types de
+   La classe d'opérateurs minmax-multi est aussi prévue pour les types de
    données implémentant un ensemble totalement ordonné, et peut être vue
-   comme une simple extension de la classe d'opérateur minmax. Tandis que la
-   classe d'opérateur minmax résume les valeurs pour chaque intervalle de
+   comme une simple extension de la classe d'opérateurs minmax. Tandis que la
+   classe d'opérateurs minmax résume les valeurs pour chaque intervalle de
    bloc dans un intervalle unique et contigu, minmax-multi permet de résumer
    dans de multiples intervalles plus petits pour améliorer la gestion des
    valeurs aberrantes. Il est possible d'utiliser les procédures support
    minmax-multi aux côtés des opérateurs correspondant, comme indiqué dans
    <xref linkend="brin-extensibility-minmax-multi-table"/>. Tous les membres
-   de classe d'opérateur (procédures et opérateurs) sont obligatoires.
+   de classe d'opérateurs (procédures et opérateurs) sont obligatoires.
   </para>
 
   <table id="brin-extensibility-minmax-multi-table">
-   <title>Procédure et numéros de support pour les classes d'opérateur minmax-multi</title>
+   <title>Procédure et numéros de support pour les classes d'opérateurs minmax-multi</title>
    <tgroup cols="2">
     <thead>
      <row>
-      <entry>Membre de classe d'opérateur</entry>
+      <entry>Membre de classe d'opérateurs</entry>
       <entry>Objet</entry>
      </row>
     </thead>
@@ -1339,18 +1339,18 @@ typedef struct BrinOpcInfo
   </table>
 
   <para>
-   Les classes d'opérateur minmax et inclusion supportent les opérateurs
+   Les classes d'opérateurs minmax et inclusion supportent les opérateurs
    utilisables sur des types de données croisés, même si cela complexifie la
-   gestion des dépendances. La classe d'opérateur minmax a besoin d'un
+   gestion des dépendances. La classe d'opérateurs minmax a besoin d'un
    ensemble complet d'opérateurs pour être définie avec deux arguments qui
    auraient le même type de données. Cela permet aux types de données
    additionnels d'être supportés en définissant un ensemble d'opérateurs
-   supplémentaires. Les opérateurs de la classe d'opérateur inclusion sont
+   supplémentaires. Les opérateurs de la classe d'opérateurs inclusion sont
    dépendants d'autres stratégies d'opérateur tel que décrit dans le <xref
-   linkend=" brin-extensibility-inclusion-table"/>, ou des mêmes stratégie
-   d'opérateur qu'eux-même. Cela nécessite que l'opérateur dépendant soit
+   linkend=" brin-extensibility-inclusion-table"/>, ou des même stratégie
+   d'opérateur qu'eux-mêmes. Cela nécessite que l'opérateur dépendant soit
    défini avec le type de données <literal>STORAGE</literal> pour l'argument
-   du côté gauche, et que l'autre type de données supportée se trouve du côté
+   du côté gauche, et que l'autre type de données supporté se trouve du côté
    droit de l'opérateur de support. Vous pouvez consulter
    <literal>float4_minmax_ops</literal> comme exemple pour minmax et
    <literal>box_inclusion_ops</literal> comme exemple pour inclusion.

--- a/postgresql/btree-gin.xml
+++ b/postgresql/btree-gin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="btree-gin" xreflabel="btree_gin">
- <title>btree_gin &mdash; classes d'opérateur GIN avec un comportement type
+ <title>btree_gin &mdash; classes d'opérateurs GIN avec un comportement de type
   B-tree</title>
 
  <indexterm zone="btree-gin">
@@ -29,7 +29,7 @@
   développer d'autres classes d'opérateurs GIN. Par ailleurs, pour des requêtes
   qui testent à la fois une colonne indexable via GIN et une colonne indexable
   par B-tree, il peut être plus efficace de créer un index GIN multi-colonnes
-  qui utilise une de ces classes d'opérateurs que de créer deux index séparés
+  qui utilise l'une de ces classes d'opérateurs que de créer deux index séparés
   qui devront être combinés par une opération de bitmap ET.
  </para>
 

--- a/postgresql/btree-gist.xml
+++ b/postgresql/btree-gist.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="btree-gist" xreflabel="btree_gist">
- <title>btree_gist &mdash; classes d'opérateur GiST pour un comportement type
+ <title>btree_gist &mdash; classes d'opérateurs GiST pour un comportement de type
   B-tree</title>
 
  <indexterm zone="btree-gist">
@@ -8,7 +8,7 @@
  </indexterm>
 
  <para>
-  <filename>btree_gist</filename> fournit des classes d'opérateur
+  <filename>btree_gist</filename> fournit des classes d'opérateurs
   GiST qui codent un comportement équivalent à celui du B-tree pour les
   types de données
   <type>int2</type>, <type>int4</type>, <type>int8</type>, <type>float4</type>,
@@ -23,15 +23,15 @@
  </para>
 
  <para>
-  En règle générale, ces classes d'opérateur ne sont pas plus performantes
-  que les méthodes d'indexage standard équivalentes du B-tree. Et il
+  En règle générale, ces classes d'opérateurs ne sont pas plus performantes
+  que les méthodes standard d'indexage équivalentes du B-tree. Et il
   leur manque une fonctionnalité majeure&nbsp;: la possibilité d'assurer
   l'unicité. Néanmoins, elles fournissent d'autres fonctionnalités qui ne sont
   pas disponibles avec un index B-tree, comme décrit ci-dessous. De plus, ces
-  classes d'opérateur sont utiles quand un index GiST multi-colonnes est
+  classes d'opérateurs sont utiles quand un index GiST multi-colonnes est
   nécessaire, quand certaines colonnes sont d'un type de données seulement
-  indexable avec GiST. Enfin, ces classes d'opérateur sont utiles pour tester
-  GiST et comme base de développement pour d'autres classes d'opérateur GiST.
+  indexable avec GiST. Enfin, ces classes d'opérateurs sont utiles pour tester
+  GiST et comme base de développement pour d'autres classes d'opérateurs GiST.
  </para>
 
  <para>

--- a/postgresql/btree.xml
+++ b/postgresql/btree.xml
@@ -21,19 +21,19 @@
   </para>
 
   <para>
-   Puisque chaque classe d'opérateur btree impose un ordre de tri sur son type
-   de données, les classes d'opérateur btree (ou, en réalité, les familles
-   d'opérateur) ont finies par être utilisées par
+   Puisque chaque classe d'opérateurs btree impose un ordre de tri sur son type
+   de données, les classes d'opérateurs btree (ou, en réalité, les familles
+   d'opérateur) ont fini par être utilisées par
    <productname>PostgreSQL</productname> comme représentation et connaissance
    générale des sémantiques de tri. En conséquence, elles ont acquis certaines
-   fonctionnalités qui vont au delà de ce qui serait nécessaire pour
-   simplement supporter les index btree, et des parties du systèmes qui sont
+   fonctionnalités qui vont au-delà de ce qui serait nécessaire pour
+   simplement supporter les index btree, et des parties du système qui sont
    éloignées des méthodes d'accès (<acronym>AM</acronym>) btree les utilisant.
   </para>
  </sect2>
 
  <sect2 id="btree-behavior">
-  <title>Comportement des classes d'opérateur B-Tree</title>
+  <title>Comportement des classes d'opérateurs B-Tree</title>
 
   <para>
    Comme montré dans <xref linkend="xindex-btree-strat-table"/>, une classe
@@ -44,11 +44,11 @@
    <literal>&gt;=</literal> et
    <literal>&gt;</literal>.
    On pourrait supposer que <literal>&lt;&gt;</literal> devraient également
-   faire partie de la classe d'opérateur, mais ce n'est pas le cas car cela ne
+   faire partie de la classe d'opérateurs, mais ce n'est pas le cas car cela ne
    serait presque jamais utile d'utiliser une clause WHERE
    <literal>&lt;&gt;</literal> dans une recherche d'index. (Dans certains
    cas, le planificateur traite <literal>&lt;&gt;</literal> comme s'il était
-   associé avec une classe d'opérateur btree&nbsp;; mais il trouve cet
+   associé avec une classe d'opérateurs btree&nbsp;; mais il trouve cet
    opérateur via le lien du négateur de l'opérateur <literal>=</literal>,
    plutôt que depuis <structname>pg_amop</structname>.)
   </para>
@@ -56,9 +56,9 @@
   <para>
    Quand plusieurs types de données partagent des sémantiques de tri presque
    identiques, leurs classes d'opérateurs peuvent être regroupées dans une
-   famille d'opérateur. Il est avantageux de procéder ainsi car cela permet
+   famille d'opérateurs. Il est avantageux de procéder ainsi car cela permet
    au planificateur de faire des déductions quant aux comparaisons entre
-   plusieurs types. Chaque classe d'opérateur au sein d'une famille devrait
+   plusieurs types. Chaque classe d'opérateurs au sein d'une famille devrait
    contenir les opérateurs concernant un seul type (et les fonctions de
    support associées), tandis que les opérateurs de comparaison inter-types et
    les fonctions de support sont <quote>libres</quote> dans la famille. Il
@@ -69,7 +69,7 @@
   </para>
 
   <para>
-   Il y a des supposition basiques qu'une famille d'opérateur btree doit
+   Il y a des suppositions basiques qu'une famille d'opérateurs btree doit
    satisfaire&nbsp;:
   </para>
 
@@ -175,7 +175,7 @@
   </para>
 
   <para>
-   Pour une famille d'opérateur supportant plusieurs types de données, les
+   Pour une famille d'opérateurs supportant plusieurs types de données, les
    lois définies auparavant doivent continuer à s'appliquer quand
    <replaceable>A</replaceable>, <replaceable>B</replaceable>,
    <replaceable>C</replaceable> sont pris de n'importe quel type de données de
@@ -183,7 +183,7 @@
    car, dans des situations inter-types, elles représentent des déclarations
    comme quoi les comportements de deux ou trois différents opérateurs sont
    cohérents. Comme exemple, mettre <type>float8</type> et
-   <type>numeric</type> dans la même famille d'opérateur ne fonctionnerait
+   <type>numeric</type> dans la même famille d'opérateurs ne fonctionnerait
    pas, du moins pas avec les sémantiques actuelles qui définissent que les
    valeurs de type <type>numeric</type> sont converties en <type>float8</type>
    pour la comparaison vers un <type>float8</type>. Du fait de la précision
@@ -196,7 +196,7 @@
   <para>
    Une autre exigence pour les familles contenant plusieurs types est que les
    transtypages implicites ou de coercition binaire qui sont définis entre les
-   types de données inclus dans la famille d'opérateur ne doivent pas changer
+   types de données inclus dans la famille d'opérateurs ne doivent pas changer
    l'ordre de tri associé.
   </para>
 
@@ -233,7 +233,7 @@
       <structname>pg_amproc</structname> avec la fonction de support 1 et
       <structfield>amproclefttype</structfield>/<structfield>amprocrighttype</structfield>
       égaux aux types de données gauche et droit pour la comparaison
-      (c'est-à-dire les même types de données que l'opérateur correspondant a
+      (c'est-à-dire les mêmes types de données que l'opérateur correspondant a
       inscrit dans <structname>pg_amop</structname>). La fonction de
       comparaison doit prendre en entrée deux valeurs non nulles
       <replaceable>A</replaceable> et <replaceable>B</replaceable> et
@@ -263,7 +263,7 @@
     <term><function>sortsupport</function></term>
     <listitem>
      <para>
-      De manière facultative, une famille d'opérateur btree peut fournir une
+      De manière facultative, une famille d'opérateurs btree peut fournir une
       ou plusieurs fonctions <firstterm>sort support</firstterm>, inscrites
       comme fonctions de support numéro 2. Ces fonctions permettent
       d'implémenter des comparaisons dans l'optique de tri de manière plus
@@ -286,11 +286,11 @@
      </indexterm>
 
      <para>
-      De manière facultative, une famille d'opérateur btree peut fournir une
+      De manière facultative, une famille d'opérateurs btree peut fournir une
       ou plusieurs fonctions de support <firstterm>in_range</firstterm>
       inscrites comme fonction de support numéro 3. Celles-ci ne sont pas
       utilisées durant les opérations d'index btree&nbsp;; mais plutôt, elles
-      étendent les sémantiques de la famille d'opérateur de telle manière
+      étendent les sémantiques de la famille d'opérateurs de telle manière
       qu'elles puissent supporter les clauses de fenêtrage contenant les types
       de limite de cadre <literal>RANGE</literal>
       <replaceable>décalage</replaceable> <literal>PRECEDING</literal> et
@@ -397,12 +397,12 @@ returns bool
       tels que <quote>infinity</quote> ou <quote>NaN</quote>, des précautions
       supplémentaires pourraient être nécessaires pour s'assurer que les
       résultats de <function>in_range</function> soient en accord avec l'ordre
-      de tri normal de la famille d'opérateur.
+      de tri normal de la famille d'opérateurs.
      </para>
 
      <para>
       Les résultats de la fonction <function>in_range</function> doivent être
-      cohérents avec l'ordre de tri imposé par la famille d'opérateur. Pour
+      cohérents avec l'ordre de tri imposé par la famille d'opérateurs. Pour
       être précis, pour n'importe quelles valeurs fixées de
       <replaceable>offset</replaceable> et <replaceable>sub</replaceable>,
       alors&nbsp;:
@@ -489,7 +489,7 @@ equalimage(<replaceable>opcintype</replaceable> <type>oid</type>) returns bool
       </synopsis>
       La valeur retournée est une information statique relative à une classe
       d'opérateur et une collation. Retourner <literal>true</literal> indique
-      que la fonction <function>order</function> pour la classe d'opérateur
+      que la fonction <function>order</function> pour la classe d'opérateurs
       est garantie de retourner seulement <literal>0</literal> (<quote>les
        arguments sont égaux</quote>) quand ses arguments
       <replaceable>A</replaceable> et <replaceable>B</replaceable> sont aussi
@@ -501,7 +501,7 @@ equalimage(<replaceable>opcintype</replaceable> <type>oid</type>) returns bool
      <para>
       L'argument <replaceable>opcintype</replaceable> est le
       <literal><structname>pg_type</structname>.oid</literal> du type de
-      données que la classe d'opérateur indexe. Ceci est une commodité qui
+      données que la classe d'opérateurs indexe. Ceci est une commodité qui
       permet de réutiliser la même fonction <function>equalimage</function>
       sous-jacente entre plusieurs classes d'opérateurs. Si
       <replaceable>opcintype</replaceable> est un type de données collationné,
@@ -511,7 +511,7 @@ equalimage(<replaceable>opcintype</replaceable> <type>oid</type>) returns bool
      </para>
 
      <para>
-      Tant que la classe d'opérateur est concernée, retourner
+      Tant que la classe d'opérateurs est concernée, retourner
       <literal>true</literal> indique que le dédoublement est sûr (ou sûr pour
       la collation dont l'identifiant a été passé à sa fonction
       <function>equalimage</function>). Cependant, le code du moteur
@@ -529,10 +529,10 @@ equalimage(<replaceable>opcintype</replaceable> <type>oid</type>) returns bool
       pas être identiques bit à bit, à cause des incohérences lors de
       l'application de la compression <acronym>TOAST</acronym> sur les données
       en entrée. Dans les règles, quand une fonction
-      <function>equalimage</function> d'une classe d'opérateur retourne
+      <function>equalimage</function> d'une classe d'opérateurs retourne
       <literal>true</literal>, on peut présumer sans se tromper que la
       fonction C <literal>datum_image_eq()</literal> correspondra avec la
-      fonction <function>order</function> de la classe d'opérateur (sous
+      fonction <function>order</function> de la classe d'opérateurs (sous
       réserve que le même identifiant de collation soit passé aux fonctions
       <function>equalimage</function> et <function>order</function>).
      </para>
@@ -540,25 +540,25 @@ equalimage(<replaceable>opcintype</replaceable> <type>oid</type>) returns bool
      <para>
       Le code du moteur est fondamentalement incapable de déduire quoi que ce
       soit au sujet du statut <quote>l'égalité implique l'égalité
-       d'image</quote> d'une classe d'opérateur incluse dans une famille de
+       d'image</quote> d'une classe d'opérateurs incluse dans une famille de
       types de données multiples en se basant sur les détails d'autres classes
       d'opérateur de la même famille. Aussi, il n'est pas pertinent pour une
       famille d'opérateurs d'inscrire une fonction
       <function>equalimage</function> inter-type, et essayer déclenchera une
       error. En effet, le statut de <quote>l'égalité implique l'égalité
        d'image</quote> ne dépend pas juste de la sémantique de l'ordre/égalité,
-      qui est plus ou moins définie au niveau de la famille d'opérateur. En
+      qui est plus ou moins définie au niveau de la famille d'opérateurs. En
       général, les sémantiques d'un type particulier de données doivent être
       considérées séparément.
      </para>
 
      <para>
-      La convention suivie par les classes d'opérateur incluses avec la
+      La convention suivie par les classes d'opérateurs incluses avec la
       distribution principale <productname>PostgreSQL</productname> est
       d'inscrire une fonction générique <function>equalimage</function>. La
-      plupart des classes d'opérateur inscrivent
+      plupart des classes d'opérateurs inscrivent
       <function>btequalimage()</function>, qui indique que le dédoublonnage
-      est sécurisé sans conditions. Les classes d'opérateur pour les types de
+      est sécurisé sans conditions. Les classes d'opérateurs pour les types de
       données collationnés comme <type>text</type> inscrivent
       <function>btvarstrequalimage()</function>, qui indique que le
       dédoublonnage est sécurisé avec les collations déterministes. La bonne
@@ -572,12 +572,12 @@ equalimage(<replaceable>opcintype</replaceable> <type>oid</type>) returns bool
     <term><function>options</function></term>
     <listitem>
      <para>
-      En option, une famille d'opérateur B-tree peut fournir des fonctions de
+      En option, une famille d'opérateurs B-tree peut fournir des fonctions de
       support des <function>options</function> (<quote>options spécifiques à
-       la classe d'opérateur</quote>), enregistrées sous le numéro 5 des
+       la classe d'opérateurs</quote>), enregistrées sous le numéro 5 des
       fonctions de support. Ces fonctions définissent un ensemble de
       paramètres visibles à l'utilisateur et contrôlant le comportement de la
-      classe d'opérateur.
+      classe d'opérateurs.
      </para>
 
      <para>
@@ -588,14 +588,14 @@ options(<replaceable>relopts</replaceable> <type>local_relopts *</type>) returns
       </synopsis>
       La fonction se voit fournie un pointeur vers une structure
       <structname>local_relopts</structname> qui doit être remplie avec un
-      ensemble d'options spécifiques à une classe d'opérateur. Les options
+      ensemble d'options spécifiques à une classe d'opérateurs. Les options
       sont accessibles à partir des autres fonctions de support en utilisant
       les macros <literal>PG_HAS_OPCLASS_OPTIONS()</literal> et
       <literal>PG_GET_OPCLASS_OPTIONS()</literal>.
      </para>
 
      <para>
-      Actuellement, aucune classe d'opérateur B-Tree n'a de fonction de
+      Actuellement, aucune classe d'opérateurs B-Tree n'a de fonction de
       support <function>options</function>. B-tree n'autorise pas une
       représentation flexible des clés comme GiST, SP-GiST, GIN et BRIN le
       font. Donc, <function>options</function> n'a probablement pas beaucoup
@@ -809,7 +809,7 @@ options(<replaceable>relopts</replaceable> <type>local_relopts *</type>) returns
      Le dédoublement B-Tree est tout aussi efficace avec des
      <quote>duplicats</quote> contenant une valeur NULL, même si les valeurs
      NULL ne sont jamais égales d'après l'opérateur <literal>=</literal> de
-     toute classe d'opérateur B-Tree. Pour toute implémentation comprenant la
+     toute classe d'opérateurs B-Tree. Pour toute implémentation comprenant la
      structure disque B-Tree, NULL est simplement une autre valeur du domaine
      des valeurs indexées.
     </para>
@@ -954,7 +954,7 @@ options(<replaceable>relopts</replaceable> <type>local_relopts *</type>) returns
 
    <para>
     Une autre restriction au niveau de l'implémentation s'applique quel que
-    soient les classes d'opérateur ou collations employées&nbsp;:
+    soient les classes d'opérateurs ou collations employées&nbsp;:
    </para>
 
    <para>

--- a/postgresql/catalogs.xml
+++ b/postgresql/catalogs.xml
@@ -7,7 +7,7 @@
   stocke les métadonnées des schémas, telles que les informations sur les tables
   et les colonnes, et des données de suivi interne.
   Les catalogues système de <productname>PostgreSQL</productname> sont de
-  simples tables. Elle peuvent être supprimées et recrées. Il est possible
+  simples tables. Elles peuvent être supprimées et recrées. Il est possible
   de leur ajouter des colonnes, d'y insérer et modifier des valeurs, et de
   mettre un joyeux bazar dans le système. En temps normal, l'utilisateur n'a aucune
   raison de modifier les catalogues
@@ -1012,7 +1012,7 @@
    notion de fonctions de support par <quote>défaut</quote> pour un index,
    fonctions pour lesquelles <structfield>amproclefttype</structfield> et
    <structfield>amprocrighttype</structfield> sont tous deux équivalents à
-   l'<structfield>opcintype</structfield> de la classe d'opérateur de l'index.
+   l'<structfield>opcintype</structfield> de la classe d'opérateurs de l'index.
   </para>
 
  </sect1>
@@ -2555,7 +2555,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
   <para>
    Dans la base de données <literal>template0</literal>, il pourrait
    être utile de créer les collationnement dont l'encodage ne correspond
-   pas à l'encodage de la base ded onnées car ils pourraient correspondre
+   pas à l'encodage de la base de données car ils pourraient correspondre
    aux encodages de bases de données créées par la suite à partir de ce
    modèle de base de données. Cela doit être fait manuellement
    actuellement.
@@ -4678,7 +4678,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
        </para>
        <para>
         Pour chaque colonne de la clé d'indexation (<structfield>indnkeyatts</structfield> values), contient l'OID de la
-        classe d'opérateur à utiliser. Voir
+        classe d'opérateurs à utiliser. Voir
         <link linkend="catalog-pg-opclass"><structname>pg_opclass</structname></link>
         pour plus de détails.
        </para></entry>
@@ -5299,7 +5299,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
    Le catalogue <structname>pg_opclass</structname> définit les classes
    d'opérateurs de méthodes d'accès aux index. Chaque classe d'opérateurs définit
    la sémantique pour les colonnes d'index d'un type particulier et d'une
-   méthode d'accès particulière. Une classe d'opérateur définit essentiellement
+   méthode d'accès particulière. Une classe d'opérateurs définit essentiellement
    qu'une famille d'opérateur particulier est applicable à un type de données
    indexable particulier. L'ensemble des opérateurs de la famille actuellement
    utilisables avec la colonne indexée sont tous ceux qui acceptent le type de
@@ -5381,7 +5381,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         (référence <link linkend="catalog-pg-opfamily"><structname>pg_opfamily</structname></link>.<structfield>oid</structfield>)
        </para>
        <para>
-        Famille d'opérateur contenant la classe d'opérateur
+        Famille d'opérateur contenant la classe d'opérateurs
        </para></entry>
      </row>
 
@@ -5881,7 +5881,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
        </para>
        <para>
         Pour chaque colonne de la clé de partitionnement, ceci contient l'OID
-        de la classe d'opérateur à utiliser. Voir <link
+        de la classe d'opérateurs à utiliser. Voir <link
         linkend="catalog-pg-opclass"><structname>pg_opclass</structname></link>
         pour les détails.
        </para></entry>
@@ -6808,7 +6808,7 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
         (référence <link linkend="catalog-pg-opclass"><structname>pg_opclass</structname></link>.<structfield>oid</structfield>)
        </para>
        <para>
-        OID de la classe d'opérateur du sous-type, utilisée pour les
+        OID de la classe d'opérateurs du sous-type, utilisée pour les
         comparaisons d'intervalles
        </para></entry>
      </row>

--- a/postgresql/citext.xml
+++ b/postgresql/citext.xml
@@ -130,10 +130,10 @@
    fidèle possible, il existe des versions spécifiques à <type>citext</type>
    de plusieurs opérateurs et fonctions de traitement de chaînes.
    Ainsi, par exemple, les opérateurs pour les expressions rationnelles
-   <literal>~</literal> and <literal>~*</literal> ont le même comportement quand
+   <literal>~</literal> et <literal>~*</literal> ont le même comportement quand
    ils sont appliqués au type <type>citext</type>&nbsp;: ils comparent tous
    les deux de manière insensible à la casse.
-   Cela est aussi vraie pour <literal>!~</literal> et <literal>!~*</literal>,
+   Cela est aussi vrai pour <literal>!~</literal> et <literal>!~*</literal>,
    et également pour les opérateurs
    <literal>LIKE</literal>, <literal>~~</literal>,
    <literal>~~*</literal>, et
@@ -256,9 +256,9 @@
 
    <listitem>
     <para>
-     <type>citext</type> n'aide pas réellement dans un certain conctexte.
+     <type>citext</type> n'aide pas réellement dans un certain contexte.
      Vos données doivent être comparées de manière sensible à la casse dans
-     certains contextes, et de manière sensible à la casse dans d'autres
+     certains contextes, et de manière insensible à la casse dans d'autres
      contextes. La réponse habituelle à cette question est d'utiliser le type
      <type>text</type> et d'utiliser manuellement la fonction
      <function>lower</function> lorsque vous avez besoin d'une comparaison

--- a/postgresql/client-auth.xml
+++ b/postgresql/client-auth.xml
@@ -31,7 +31,7 @@
   autorisée à se connecter avec le nom d'utilisateur de bases de données
   indiqué.</para>
 
- <para><productname>PostgreSQL</productname> offre quantité de méthodes
+ <para><productname>PostgreSQL</productname> offre une quantité de méthodes
   d'authentification différentes. La méthode utilisée pour authentifier une connexion
   client particulière peut être sélectionnée d'après l'adresse (du client), la base de
   données et l'utilisateur.</para>
@@ -100,12 +100,12 @@
    suivante en terminant la ligne avec un antislash. (Les antislashs ne sont
    pas spéciaux sauf à la fin d'une ligne.) Un enregistrement est constitué
    d'un certain nombre de champs séparés par des espace et/ou des
-   tabulations.Les champs peuvent contenir des espaces si la valeur du champ
+   tabulations. Les champs peuvent contenir des espaces si la valeur du champ
    est mise entre guillemets doubles. Mettre entre guillemets un des
    mots-clés dans un champ base de données, utilisateur ou adresse
    (par exemple, <literal>all</literal> ou <literal>replication</literal>)
    fait que le mot perd son interprétation spéciale, ou correspond à la base
-   de données, à l'utilisateur ou à l'hôte ayant ce nom. La continuaison
+   de données, à l'utilisateur ou à l'hôte ayant ce nom. La continuation
    d'une ligne avec un antislash s'applique même dans le texte entre
    guillemets et les commentaires.
   </para>
@@ -2001,7 +2001,7 @@ omicron       bryanh            guest1
      <listitem>
       <para>
        Le filtre de recherche à utiliser lors d'une authentification
-       search+bind.  Toutes les occurences de <literal>$username</literal>
+       search+bind.  Toutes les occurrences de <literal>$username</literal>
        seront remplacées par le nom d'utilisateur.  Cela permet des filtres de
        recherche plus flexibles que <literal>ldapsearchattribute</literal>.
       </para>

--- a/postgresql/color.xml
+++ b/postgresql/color.xml
@@ -8,14 +8,14 @@
 
  <para>
   Les programmes dans la distribution PostgreSQL peuvent produire une sortie
-  console colorée. Cet annexe décrit comment le configurer.
+  console colorée. Cette annexe décrit comment le configurer.
  </para>
 
  <sect1 id="color-when">
   <title>Quand les couleurs sont utilisées</title>
 
   <para>
-   Pour utiliser la sortie colorée, affecter la variable d'environment
+   Pour utiliser la sortie colorée, affecter la variable d’environnement
    <envar>PG_COLOR</envar><indexterm><primary>PG_COLOR</primary></indexterm>
    comme suit&nbsp;:
 
@@ -111,7 +111,7 @@
   <tip>
    <para>
     Le format des spécifications couleurs est aussi utilisé par d'autres
-    paquets de programme comme <productname>GCC</productname>, <productname>GNU
+    paquets de programmes comme <productname>GCC</productname>, <productname>GNU
      coreutils</productname> et <productname>GNU grep</productname>.
    </para>
   </tip>

--- a/postgresql/config.xml
+++ b/postgresql/config.xml
@@ -3895,7 +3895,7 @@ block : bloc vidé,  dirty bloc : bloc à vider ?
      c'est-à-dire le répertoire de données du cluster.)
      <literal>%%</literal> est utilisé pour intégrer un caractère
      <literal>%</literal> dans la commande.  Il est important que la
-     commande renvoit un code zéro seulement si elle a réussit l'archivage.
+     commande renvoie un code zéro seulement si elle a réussit l'archivage.
      Le processus d'archivage des journaux de transactions est redémarré par
      le postmaster quand ce paramètre est modifié.
      Pour plus d'informations, voir <xref linkend="backup-archiving-wal"/>.
@@ -7195,7 +7195,7 @@ local0.*    /var/log/postgresql
     <para>
      Ceci surcharge <xref linkend="guc-log-min-duration-sample"/>, ceci
      signifiant que les requêtes dont la durée dépasse cette configuration ne
-     sont pas sujet à l'échantillonage et sont toujours tracées.
+     sont pas sujet à l'échantillonnage et sont toujours tracées.
     </para>
 
     <para>
@@ -7227,7 +7227,7 @@ local0.*    /var/log/postgresql
    </term>
    <listitem>
     <para>
-     Permet l'échantillonage de la durée des requêtes traitées pour celles
+     Permet l'échantillonnage de la durée des requêtes traitées pour celles
      qui durent au moins la durée indiquée. Ceci produit le même type de
      traces que <xref linkend="guc-log-min-duration-statement"/>, mais
      seulement pour un sous-ensemble des requêtes exécutées, avec un taux
@@ -7293,7 +7293,7 @@ local0.*    /var/log/postgresql
      Initialise la fraction de transactions dont les requêtes seront toutes
      tracées en plus des requêtes tracées pour d'autres raisons. Cela
      s'applique à toute nouvelle transaction, quelque soit les durées des
-     requêtes. L'échantillonage est stochastique, par exemple
+     requêtes. L'échantillonnage est stochastique, par exemple
      <literal>0.1</literal> signifie qu'il y a statistiquement une chance sur
      dix qu'une transaction donnée soit tracée.
      <varname>log_transaction_sample_rate</varname> peut être utilisé pour

--- a/postgresql/contrib-spi.xml
+++ b/postgresql/contrib-spi.xml
@@ -21,7 +21,7 @@
  </para>
 
  <para>
-  Chaque groupe de fonctions décrits ci-dessous est fourni comme une extension
+  Chaque groupe de fonctions décrit ci-dessous est fourni comme une extension
   installable séparément.
  </para>
 

--- a/postgresql/contrib.xml
+++ b/postgresql/contrib.xml
@@ -22,8 +22,8 @@
  <para>
   Lors de la construction à partir des sources de la distribution, ces extensions
   optionnelles ne sont pas construites automatiquement, sauf si vous utilisez la cible
-  « world » (voir <xref linkend="build"/>). Ils peuvent être construits et
-  installés en exécutant&nbsp;:
+  « world » (voir <xref linkend="build"/>). Elles peuvent être construites et
+  installées en exécutant&nbsp;:
   <screen>
 <userinput>make</userinput>
 <userinput>make install</userinput>
@@ -85,7 +85,7 @@ CREATE EXTENSION <replaceable>nom_extension</replaceable>;
  </para>
 
  <para id="contrib-trusted-extensions">
-  Les extensions suivants sont de confiance dans une installation par
+  Les extensions suivantes sont de confiance dans une installation par
   défaut&nbsp;:
 
   <simplelist type="vert" columns="4">

--- a/postgresql/cube.xml
+++ b/postgresql/cube.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="cube" xreflabel="cube">
- <title>cube &mdash; un type de donnée cube multidimensionnel</title>
+ <title>cube &mdash; un type de données cube multidimensionnel</title>
 
  <indexterm zone="cube">
   <primary>cube (extension)</primary>
@@ -40,7 +40,7 @@
     <tbody>
      <row>
       <entry><literal><replaceable>x</replaceable></literal></entry>
-      <entry>point uni-dimensionnel (ou interval unidimensionnel de longueur
+      <entry>point uni-dimensionnel (ou intervalle unidimensionnel de longueur
        nulle)
       </entry>
      </row>
@@ -60,7 +60,7 @@
      </row>
      <row>
       <entry><literal>(<replaceable>x</replaceable>),(<replaceable>y</replaceable>)</literal></entry>
-      <entry>Interval uni-dimensionnel débutant à
+      <entry>Intervalle uni-dimensionnel débutant à
        <replaceable>x</replaceable> et finissant à
        <replaceable>y</replaceable> ou vice-versa&nbsp;; l'ordre n'importe pas
       </entry>
@@ -186,7 +186,7 @@
         * <parameter>k</parameter> indique la limite supérieure de la
         <parameter>k</parameter>-ième dimension. Un paramètre négatif
         <parameter>n</parameter> désigne la valeur inverse de la coordonnée
-        positive correspondante. Cette opérateur est conçu pour le support
+        positive correspondante. Cet opérateur est conçu pour le support
         KNN-GiST.
        </para></entry>
      </row>
@@ -237,7 +237,7 @@
   </para>
 
   <para>
-   Le module <filename>cube</filename> fournit aussi une classe d'opérateur
+   Le module <filename>cube</filename> fournit aussi une classe d'opérateurs
    pour index GiST pour les valeurs <type>cube</type>. Un index GiST peut être
    utilisé sur le type <type>cube</type> pour chercher des valeurs en
    utilisant les opérateurs <literal>=</literal>,
@@ -393,7 +393,7 @@ SELECT c FROM test ORDER BY c ~&gt; 3 DESC LIMIT 5;
         <returnvalue>integer</returnvalue>
        </para>
        <para>
-        Renvoie le nombe de dimensions du cube.
+        Renvoie le nombre de dimensions du cube.
        </para>
        <para>
         <literal>cube_dim('(1,2),(3,4)')</literal>

--- a/postgresql/custom-rmgr.xml
+++ b/postgresql/custom-rmgr.xml
@@ -20,7 +20,7 @@
   avec l'implémentation des méthodes du gestionnaire de ressources.
   Reportez-vous à
   <filename>src/backend/access/transam/README</filename> et
-  <filename>src/include/access/xlog_internal.h</filename> dans le source de
+  <filename>src/include/access/xlog_internal.h</filename> dans la source de
   <productname>PostgreSQL</productname>.
 <programlisting>
 /*
@@ -59,7 +59,7 @@ typedef struct RmgrData
  </para>
  <para>
   Le module <filename>src/test/modules/test_custom_rmgrs</filename> contient
-  un exemple fonctionnel démontrant l'utilisation de gestionnaires de
+  un exemple fonctionnel démontrant l'utilisation d'un gestionnaire de
   ressources pour les journaux de transactions.
  </para>
  <para>
@@ -67,7 +67,7 @@ typedef struct RmgrData
 
 <programlisting>
 /*
- * Enregistrer un nouveau gestionnaire de ressources WAL personnalisées.
+ * Enregistrer un nouveau gestionnaire de ressources WAL personnalisé.
  *
  * Les ID de gestionnaire de ressources doivent être uniques au monde pour
  * toutes les extensions. Se référer à

--- a/postgresql/custom-scan.xml
+++ b/postgresql/custom-scan.xml
@@ -40,7 +40,7 @@
   <title>Créer des parcours de chemin personnalisés</title>
 
   <para>
-   Un module de parcours personnalisé ajoutera classiquement des chemins pour
+   Un module de parcours personnalisé ajoutera habituellement des chemins pour
    une relation de base en mettant en place le hook suivant, qui est appelé
    après que le code de base ait généré tous les chemins d'accès possibles
    pour la relation (sauf les chemins Gather et Gather Merge, qui sont réalisés après cet
@@ -94,7 +94,7 @@ typedef struct CustomPath
    projections. (Si <literal>CUSTOMPATH_SUPPORT_PROJECTION</literal> n'est pas
    configuré, le nœud de parcours se verra seulement demandé de produire
    le Vars de la relation parcourue&nbsp;; alors que s'il est configuré, le
-   nœud du parcours doit être caoavle d'évaluer les expressions scalaires
+   nœud du parcours doit être capable d'évaluer les expressions scalaires
    sur ces Vars.) Une liste optionnelle <structfield>custom_paths</structfield>
    est une liste de nœuds <structname>Path</structname> utilisés par ce nœud de
    chemin personnalisé&nbsp;; ils seront transformés en nœuds
@@ -103,12 +103,12 @@ typedef struct CustomPath
    pour les relations de jointure. Dans un tel cas,
    <structfield>custom_restrictinfo</structfield> doit être utilisé pour
    enregistrer l'ensemble des clauses de jointure à appliquer à la jointure
-   que le chemin personnalisé remplace. Sinon, il vaudra NUL.
+   que le chemin personnalisé remplace. Sinon, il vaudra NULL.
    <structfield>custom_private</structfield> peut être utilisé pour stocker les
    données privées du chemin personnalisé. Les données privées devraient être
    stockées dans une forme qui puisse être traitée par
    <literal>nodeToString</literal>, de telle manière que les routines de
-   debuggage qui essaient d'imprimer le chemin personnalisé fonctionnent comme
+   débogage qui essaient d'imprimer le chemin personnalisé fonctionnent comme
    prévu. <structfield>methods</structfield> doit pointer vers un objet
    (généralement alloué statiquement) implémentant les méthodes obligatoires
    d'un chemin personnalisé, qui sont détaillées plus bas.
@@ -163,7 +163,7 @@ Plan *(*PlanCustomPath) (PlannerInfo *root,
     </programlisting>
     Convertit un chemin personnalisé en un plan finalisé. La valeur de
     retour sera généralement un objet <literal>CustomScan</literal>,
-    que la fonction callback doit alloué et initialisé. Voir <xref
+    que la fonction callback doit allouer et initialiser. Voir <xref
     linkend="custom-scan-plan"/> pour plus de détails.
    </para>
 

--- a/postgresql/datatype.xml
+++ b/postgresql/datatype.xml
@@ -597,8 +597,8 @@ NUMERIC(3, 1)
 <programlisting>
 NUMERIC(2, -3)
 </programlisting>
-     arrondira les valeurs au millier le plus proche et peut enregistre des
-     valeurs entre -99000 et 99000, values inclues.  Il est aussi autorisé de
+     arrondira les valeurs au millier le plus proche et peut enregistrer des
+     valeurs entre -99000 et 99000, values incluses. Il est aussi autorisé de
      déclarer une échelle plus grand que la précision déclarée.  Une telle
      colonne peut seulement contenir des valeurs fractionnelles, et elle
      nécessite le nombre de chiffres zéro juste à droite du point décimal pour
@@ -1222,7 +1222,7 @@ SELECT '52093.89'::money::numeric::float8;
     caractères en excès ne soient tous des espaces, auquel cas la chaîne
     est tronquée à la taille maximale (cette exception étrange est imposée
     par la norme <acronym>SQL</acronym>).
-    Néanmoins, si un utilisater convertit explicitement une valeur en
+    Néanmoins, si un utilisateur convertit explicitement une valeur en
     <type>character varying(<replaceable>n</replaceable>)</type> ou
     <type>character(<replaceable>n</replaceable>)</type>, alors toute valeur
     trop longue sera tronquée à <replaceable>n</replaceable> caractères sans

--- a/postgresql/datetime.xml
+++ b/postgresql/datetime.xml
@@ -184,7 +184,7 @@
 
      <tip>
       <para>
-       Les années du calendrier Grégorien AD 1&ndash;99 peuvent être saisie avec 4
+       Les années du calendrier Grégorien AD 1&ndash;99 peuvent être saisies avec 4
        chiffres, deux zéros en tête (<literal>0099</literal> pour
        AD 99, par exemple).
       </para>
@@ -220,7 +220,7 @@
    </programlisting>
    Comme ce jour était une transition vers l'avant pour ce fuseau horaire,
    l'heure 2:30AM n'existe pas&nbsp;; les horloges passent directement de 2h
-   à 3h EDT. <productname>PostgreSQL</productname> interpréte l'heure donnée
+   à 3h EDT. <productname>PostgreSQL</productname> interprète l'heure donnée
    comme s'il s'agissait de l'heure standard (UTC-5), qui se décline donc en
    3:30 EDT (UTC-4).
   </para>
@@ -270,7 +270,7 @@
  </sect1>
 
  <sect1 id="datetime-keywords">
-  <title>Mots clés Date/Heure</title>
+  <title>Mots-clés Date/Heure</title>
 
   <para>
    <xref linkend="datetime-month-table"/> présente les lexèmes
@@ -435,7 +435,7 @@
   <title>Fichiers de configuration date/heure</title>
 
   <indexterm>
-   <primary>fuseau horaire</primary>
+   <primary>fuseaux horaires</primary>
    <secondary>saisie d'abréviations</secondary>
   </indexterm>
 
@@ -479,7 +479,7 @@
   <para>
    Un <replaceable>abréviation_fuseau_horaire</replaceable> n'est que
    l'abréviation définie. Le <replaceable>décalage</replaceable> est un entier
-   donner le décalage en secondes à partir d'UTC, une valeur positive
+   donnant le décalage en secondes à partir d'UTC, une valeur positive
    signifiant à l'est de Greenwich, une valeur négative à l'ouest. Ainsi,
    -18000 représente cinq heures à l'ouest de Greenwich, soit l'heure standard
    de la côte ouest nord américaine. <literal>D</literal> indique que le nom
@@ -819,10 +819,10 @@
 
   <para>
    L'erreur grandissante du calendrier poussa le Pape
-   Gregoire XIII a réformé le calendrier en accord avec les
+   Grégoire XIII a réformé le calendrier en accord avec les
    instructions du Concile de Trent.
    Dans le calendrier Grégorien, l'année tropicale est arrondie à
-   365 + 97/400 jours, soit 365,2425 jours. Il faut donc à peu prés 3300
+   365 + 97/400 jours, soit 365,2425 jours. Il faut donc à peu près 3300
    ans pour que l'année tropicale subissent un décalage d'un an dans le
    calendrier Grégorien.
   </para>
@@ -890,7 +890,7 @@ di lu ma me je ve sa
    Par exemple,
    les débuts du calendrier chinois peuvent être évalués aux alentours du 14ème
    siècle avant J.-C. La légende veut que l'empereur Huangdi inventa le
-   calendrier en 2637 avant J-C.
+   calendrier en 2637 avant J.-C.
 
    La République de Chine utilise le calendrier Grégorien pour les besoins
    civils. Le calendrier chinois est utilisé pour déterminer les festivals.
@@ -930,7 +930,7 @@ di lu ma me je ve sa
   <para>
    Bien que <productname>PostgreSQL</productname> accepte la saisie et
    l'affichage des dates en notation de date Julien (et les utilise aussi pour
-   quelques calculs internes de date et heure), il n'utilise pas le coup
+   quelques calculs internes de date et heure), il n'utilise pas le compte
    des dates de midi à midi. <productname>PostgreSQL</productname> traite une
    date Julien comme allant de minuit heure locale à minuit heure locale,
    de la même façon que pour une date normale.

--- a/postgresql/dblink.xml
+++ b/postgresql/dblink.xml
@@ -13,7 +13,7 @@
  </para>
 
  <para>
-  <filename>dblink</filename> peut indiquer les attentes d'événement suivants
+  <filename>dblink</filename> peut indiquer les attentes d'événements suivants
   sous le type <literal>Extension</literal>.
  </para>
 
@@ -146,7 +146,7 @@
 
    <para>
     Si des utilisateurs non dignes de confiance, ont accès à
-    une base de données qui n'a pas adoptée une <link
+    une base de données qui n'a pas adopté une <link
     linkend="ddl-schemas-patterns">méthode sécurisée d'usage des
      schémas</link>, commencez chaque session en supprimant les schémas
     modifiables par tout le monde du paramètre <varname>search_path</varname>.
@@ -1421,7 +1421,7 @@ SELECT dblink_close('foo');
   <refnamediv>
    <refname>dblink_get_notify</refname>
    <refpurpose>récupère les notifications asynchrones sur une
-    connection</refpurpose>
+    connexion</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -1462,7 +1462,7 @@ SELECT dblink_close('foo');
 
   <refsect1>
    <title>Valeur de retour</title>
-   <para>Renvoit <type>setof (notify_name text, be_pid int, extra text)</type>
+   <para>Renvoie <type>setof (notify_name text, be_pid int, extra text)</type>
     ou un ensemble vide.</para>
   </refsect1>
 
@@ -1585,7 +1585,7 @@ SELECT * FROM dblink_get_notify();
     Lorsqu'on utilise <function>dblink_send_query</function> et
     <function>dblink_get_result</function>, <application>dblink</application> récupère
     l'intégralité de la requête avant de les renvoyer au système local. Si la requête
-    renvoit un grand nombre de lignes, cela peut conduire à une surcharge temporaire
+    renvoie un grand nombre de lignes, cela peut conduire à une surcharge temporaire
     de la mémoire dans la session locale. Il peut être préférable d'ouvrir un curseur
     avec <function>dblink_open</function> puis de récupérer un nombre gérable de lignes.
     Sinon, vous pouvez utiliser un simple <function>dblink()</function>, qui évite la
@@ -1684,7 +1684,7 @@ contrib_regression=# SELECT * FROM dblink_get_result('dtest1') AS t1(f1 int, f2 
     en cours d'exécution sur la connexion nommée. La réussite de
     la fonction n'est pas assurée (la requête distante pourrait, par exemple,
     être déjà terminée). Une demande d'annulation augmente simplement
-    la probabilité que la requête échoue rapidement. Le protocoel de requête
+    la probabilité que la requête échoue rapidement. Le protocole de requête
     normal doit toujours être terminé, par exemple en appelant
     <function>dblink_get_result</function>.
    </para>
@@ -2102,7 +2102,7 @@ SELECT dblink_build_sql_delete('"MyFoo"', '1 2', 2, '{"1", "b"}');
 
    <para>
     <function>dblink_build_sql_update</function> peut être utile pour réaliser
-    une réplication sélective d'une table locale vers une base de donnée
+    une réplication sélective d'une table locale vers une base de données
     distante. Elle sélectionne une ligne à partir de la table locale en se
     basant sur la clé primaire, puis construit une commande SQL
     <command>UPDATE</command> qui duplique cette ligne, mais avec pour valeurs

--- a/postgresql/ddl.xml
+++ b/postgresql/ddl.xml
@@ -34,7 +34,7 @@
    papier&nbsp;: elle est constituée de lignes et de colonnes. Le nombre et
    l'ordre des colonnes sont fixes et chaque colonne a un nom. Le nombre de
    lignes est variable &mdash; il représente le nombre de données stockées à
-   un instant donné. Le SQL n'apporte aucune garantie sur l'ordre des lignes
+   un instant donné. Le SQL n'apporte aucune garantit sur l'ordre des lignes
    dans une table. Quand une table est lue, les lignes apparaissent dans un
    ordre non spécifié, sauf si un tri est demandé explicitement. Tout cela
    est expliqué dans le <xref linkend="queries"/>. De plus, le SQL n'attribue
@@ -53,7 +53,7 @@
    n'accepte pas les chaînes textuelles&nbsp;; les données stockées dans une
    telle colonne peuvent être utilisées dans des calculs mathématiques. Par
    opposition, une colonne déclarée de type chaîne de caractères accepte
-   pratiquement n'importe quel type de donnée, mais ne se prête pas aux
+   pratiquement n'importe quel type de données, mais ne se prête pas aux
    calculs mathématiques. D'autres types d'opérations, telle la concaténation
    de chaînes, sont cependant disponibles.
   </para>
@@ -356,7 +356,7 @@ INSERT INTO people (id, name, address) VALUES (<emphasis>DEFAULT</emphasis>, 'C'
 
   <para>
    Les partitions héritent des colonnes d'identité de la table partitionnée.
-   Elles ne peuvent pas avoir leur propres colonnes d'identité. Les propriétés
+   Elles ne peuvent pas avoir leurs propres colonnes d'identité. Les propriétés
    d'une colonne d'identité donnée sont cohérentes sur toutes les partitions
    d'une hiérarchie de partitions.
   </para>

--- a/postgresql/dfunc.xml
+++ b/postgresql/dfunc.xml
@@ -26,7 +26,7 @@
  <para>
   La création de bibliothèques partagées est un
   processus analogue à celui utilisé pour lier des exécutables&nbsp;:
-  les fichiers sources sont d'abord compilés en fichiers objets puis sont liées ensemble.
+  les fichiers sources sont d'abord compilés en fichiers objets puis sont liés ensemble.
   Les fichiers objets doivent être compilés sous la forme de <firstterm>code
    indépendant de sa position</firstterm> (<acronym>PIC</acronym>, acronyme de
   <foreignphrase>position-independent code</foreignphrase>)

--- a/postgresql/dict-int.xml
+++ b/postgresql/dict-int.xml
@@ -9,7 +9,7 @@
 
  <para>
   <filename>dict_int</filename> est un exemple de modèle de dictionnaire pour
-  la recherche plein texte. La création de ce dictionnaire à été motivée par la
+  la recherche plein texte. La création de ce dictionnaire a été motivée par la
   volonté de pouvoir contrôler l'indexage d'entiers (signés et non signés),
   pour permettre à de tels nombres d'être indexés sans
   grossissement excessif du nombre de mots uniques, ce qui affecte

--- a/postgresql/dict-xsyn.xml
+++ b/postgresql/dict-xsyn.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="dict-xsyn" xreflabel="dict_xsyn">
  <title>dict_xsyn &mdash; dictionnaire d'exemple pour la recherche de
- synonyme avec la recherche plein texte</title>
+ synonymes avec la recherche plein texte</title>
 
  <indexterm zone="dict-xsyn">
   <primary>dict_xsyn</primary>
@@ -67,7 +67,7 @@
     <para>
      chaque ligne représente un groupe de synonymes pour un mot simple,
      donné en premier sur la ligne. Les synonymes sont séparés par
-     une espace&nbsp;:
+     un espace&nbsp;:
     </para>
     <programlisting>
 mot syn1 syn2 syn3

--- a/postgresql/dml.xml
+++ b/postgresql/dml.xml
@@ -24,7 +24,7 @@
   <para>
    Quand une table est créée, elle ne contient aucune donnée. La première
    chose à faire, c'est d'y insérer des données. Sans quoi la base de données
-   n'est pas d'une grande utilité. Les données sont  insérées ligne par
+   n'est pas d'une grande utilité. Les données sont insérées ligne par
    ligne. Vous pouvez aussi insérer plus d'une ligne en une seule commande,
    mais il n'est pas possible d'insérer une ligne partielle. Même lorsque
    seules les valeurs d'une partie des colonnes sont connues, une ligne
@@ -34,7 +34,7 @@
   <para>
    Pour créer une nouvelle ligne, la commande <xref
    linkend="sql-insert"/> est utilisée.
-   La commande a besoin du nom de la table et des valeurs de
+   La commande a besoin du nom de la table et des valeurs des
    colonnes.
   </para>
   <para>

--- a/postgresql/docguide.xml
+++ b/postgresql/docguide.xml
@@ -9,7 +9,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     le texte brut, pour les information de pré-installation&nbsp;;
+     le texte brut, pour les informations de pré-installation&nbsp;;
     </para>
    </listitem>
    <listitem>
@@ -58,7 +58,7 @@
    à se soucier du détail de la présentation. Un style de
    document définit le rendu du contenu dans un des
    formats de sortie finaux. DocBook est maintenu par le groupe
-   <ulink url="https://www.oasis-open.org">OASIS</ulink> . Le <ulink
+   <ulink url="https://www.oasis-open.org">OASIS</ulink>. Le <ulink
    url="https://www.oasis-open.org/docbook">site officiel de
     DocBook</ulink> présente une bonne documentation d'introduction et
    de référence ainsi qu'un livre complet de chez O'Reilly disponible à la
@@ -104,7 +104,7 @@
 
       <para>
        La version minimale requise est actuellement la 1.77.0, mais il est
-       recommandé d'utiliser la dernière version disponibles pour de meilleurs
+       recommandé d'utiliser la dernière version disponible pour de meilleurs
        résultats.
       </para>
      </listitem>
@@ -129,7 +129,7 @@
      <listitem>
       <para>
        <command>xsltproc</command> est un processeur XSLT, c'est-à-dire, un
-       programme pour convertir le XML vers d'autres formats en utilisant de
+       programme pour convertir le XML vers d'autres formats en utilisant des
        fichiers de style XSLT.
       </para>
      </listitem>
@@ -153,7 +153,7 @@
    les divers outils nécessaires au
    traitement de la documentation. Il peut exister d'autres types de
    distributions empaquetées de ces outils. Tout
-   changement du statut d'un paquetage peut être rapportée auprès de
+   changement du statut d'un paquetage peut être rapporté auprès de
    la liste de discussion de la
    documentation, afin d'inclure ces informations ici-même.
   </para>
@@ -595,7 +595,7 @@ LOGLEVEL=-Dorg.apache.commons.logging.simplelog.defaultlog=WARN
         </varlistentry>
 
         <varlistentry id="docguide-style-ref-pages-diagnostics">
-         <term>Diagnostiques</term>
+         <term>Diagnostics</term>
          <listitem>
           <para>
            C'est ici que l'ont trouve l'explication de tout message inhabituel

--- a/postgresql/earthdistance.xml
+++ b/postgresql/earthdistance.xml
@@ -116,7 +116,7 @@
        </para>
        <para>
         Convertit la distance en ligne droite (sécant) entre deux
-        points à la surface de la Terre en distane circulaire.
+        points à la surface de la Terre en distance circulaire.
        </para></entry>
      </row>
 

--- a/postgresql/ecpg.xml
+++ b/postgresql/ecpg.xml
@@ -12,7 +12,7 @@
   (<email>linus@epact.se</email>) et Michael Meskes (<email>
    meskes@postgresql.org</email>). Initialement, il a été écrit pour fonctionner
   avec le <acronym>C</acronym>. Il fonctionne aussi avec le <acronym>C++</acronym>,
-  mais il ne reconnait pas encore toutes les syntaxes du <acronym>C++</acronym>.
+  mais il ne reconnaît pas encore toutes les syntaxes du <acronym>C++</acronym>.
  </para>
 
  <para>
@@ -33,7 +33,7 @@
    afin qu'il puisse ensuite être traité par un compilateur C. (Pour les détails sur la compilation
    et l'édition de lien dynamique voyez <xref linkend="ecpg-process"/>).
    Les applications ECPG converties appellent les fonctions de la librairie libpq au travers
-   de la librairie SQL embarquée (ecpgli), et communique avec le server PostgreSQL au travers du
+   de la librairie SQL embarquée (ecpgli), et communique avec le serveur PostgreSQL au travers du
    protocole client-serveur normal.
   </para>
 
@@ -162,7 +162,7 @@ EXEC SQL CONNECT TO <replaceable>cible</replaceable> <optional>AS <replaceable>n
 
    <para>
     Si vous spécifiez la chaîne de connexion de façon littérale (c'est-à-dire, pas
-    par une chaîne littérale ou une réference à une variable), alors
+    par une chaîne littérale ou une référence à une variable), alors
     les constituants de la chaîne suivent les règles de grammaire de SQL normal&nbsp;;
     par exemple, le <replaceable>hostname</replaceable> doit être similaire
     à un ou plusieurs identifiants SQL séparés par des points, et ces identifiants
@@ -754,7 +754,7 @@ EXEC SQL DEALLOCATE PREPARE <replaceable>nom</replaceable>;
    <para>
     Passer des données entre le programme en C et les ordres SQL est
     particulièrement simple en SQL embarqué. Plutôt que d'avoir
-    un programme qui conne des données dans un ordre SQL, ce qui
+    un programme qui donne des données dans un ordre SQL, ce qui
     entraîne des complications variées, comme protéger correctement la
     valeur, vous pouvez simplement écrire le nom d'une variable C
     dans un ordre SQL, préfixée par un deux-points. Par exemple&nbsp;:

--- a/postgresql/errcodes-table.xml
+++ b/postgresql/errcodes-table.xml
@@ -193,7 +193,7 @@
 
 
 <row>
-<entry spanname="span12"><emphasis role="bold">Classe 0Z &mdash; Exception de diagnostique</emphasis></entry>
+<entry spanname="span12"><emphasis role="bold">Classe 0Z &mdash; Exception de diagnostic</emphasis></entry>
 </row>
 
 <row>

--- a/postgresql/errcodes.xml
+++ b/postgresql/errcodes.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appendix id="errcodes-appendix">
- <title>Codes d'erreurs de <productname>PostgreSQL</productname></title>
+ <title>Codes d'erreur de <productname>PostgreSQL</productname></title>
 
  <indexterm zone="errcodes-appendix">
-  <primary>codes d'erreurs</primary>
+  <primary>codes d'erreur</primary>
   <secondary>liste de</secondary>
  </indexterm>
 
@@ -15,7 +15,7 @@
  <para>
   Les applications qui souhaitent connaître la condition d'erreur
   survenue peuvent tester le code d'erreur plutôt que récupérer
-  le message d'erreur textuel. Les codes d'erreurs sont moins sujets à
+  le message d'erreur textuel. Les codes d'erreur sont moins sujets à
   changement au fil des versions de <productname>PostgreSQL</productname> et ne
   dépendent pas de la localisation des messages d'erreur.
   Seuls certains codes d'erreur produits par
@@ -33,7 +33,7 @@
  </para>
 
  <para>
-  <xref linkend="errcodes-table"/> liste tous les codes d'erreurs définis dans
+  <xref linkend="errcodes-table"/> liste tous les codes d'erreur définis dans
   <productname>PostgreSQL</productname> &version;. (Certains ne sont pas
   réellement utilisés mais sont définis par le standard SQL.) Les classes
   d'erreurs sont aussi affichées. Pour chaque classe d'erreur, il y a un code
@@ -43,7 +43,7 @@
  </para>
 
  <para>
-  Les symboles affichées dans la colonne <quote>Nom de condition</quote> sont
+  Les symboles affichés dans la colonne <quote>Nom de condition</quote> sont
   aussi le nom de la condition à utiliser dans <application>PL/pgSQL</application>.
   Les noms de conditions peuvent être écrits en minuscule ou en majuscule. Notez
   que <application>PL/pgSQL</application> ne fait pas la distinction entre

--- a/postgresql/event-trigger.xml
+++ b/postgresql/event-trigger.xml
@@ -50,7 +50,7 @@
    simple-utilisateur. L'événement <literal>login</literal> se déclenchera
    aussi sur les serveurs secondaires. Pour empêcher les serveurs de devenir
    inaccessibles, de tels triggers doivent éviter d'écrire quoi que ce soit
-   dans le base s'ils sont exécutés sur un serveur secondaire. De plus, il
+   dans la base s'ils sont exécutés sur un serveur secondaire. De plus, il
    est recommendé d'éviter les requêtes longues à exéciter dans des triggers
    sur événement <literal>login</literal>. Notez que, par exemple, annuler
    une connexion dans <application>psql</application> n'annulera pas le

--- a/postgresql/extend.xml
+++ b/postgresql/extend.xml
@@ -375,7 +375,7 @@
     appel de fonction donné, elles doivent toutes avoir le
     <emphasis>même</emphasis> type réel. Chaque occurrence déclarée comme
     <type>anyarray</type> peut prendre n'importe quel type de données tableau.
-    De façon similaire, les occurences déclarées en tant que
+    De façon similaire, les occurrences déclarées en tant que
     <type>anyrange</type> doivent toutes être du même type.
     <type>anymultirange</type>.
    </para>
@@ -935,7 +935,7 @@ RETURNS anycompatible AS ...
       la propriété <literal>search_path</literal>.
       Pour de telles extensions, il faut définir <literal>relocatable = false</literal> dans
       son fichier de contrôle, et utiliser <literal>@extschema@</literal> pour référencer
-      le schéma cible dans le fichier de script. Toutes les occurences de cette chaîne dans le
+      le schéma cible dans le fichier de script. Toutes les occurrences de cette chaîne dans le
       fichier de script seront remplacées par le nom du schéma choisi (entre guillemets doubles
       si nécessaire) avant son exécution.
       Le nom du schéma choisi peut être fixé par l'option <literal>SCHEMA</literal> de la

--- a/postgresql/external-projects.xml
+++ b/postgresql/external-projects.xml
@@ -24,8 +24,8 @@
     <listitem>
      <para>
       <link linkend="libpq">libpq</link>, car il s'agit de
-      l'interface principal pour le langage C et parce que de nombreux
-      interfaces clients sont construits par dessus&nbsp;;
+      l'interface principale pour le langage C et parce que de nombreuses
+      interfaces clients sont construites par dessus&nbsp;;
      </para>
     </listitem>
 

--- a/postgresql/fdwhandler.xml
+++ b/postgresql/fdwhandler.xml
@@ -12,9 +12,9 @@
   wrapper de données distantes. Ce dernier est un ensemble de fonctions
   que PostgreSQL appelle. Le wrapper de données
   distantes est responsable de la récupération des données à partir de
-  le source de données distante et de leur renvoi à l'exécuteur
+  la source de données distante et de leur renvoi à l'exécuteur
   <productname>PostgreSQL</productname>. Si la mise à jour de tables distantes
-  doit être supporté, le wrapper doit aussi gérer cela.
+  doit être supportée, le wrapper doit aussi gérer cela.
   Ce chapitre indique comment
   écrire un nouveau wrapper de données distantes.
  </para>
@@ -22,7 +22,7 @@
  <para>
   Les wrappers de données distantes incluent dans la distribution
   standard sont de bons exemples lorsque vous essayez d'écrire les
-  votres. Regardez dans le sous-répertoire
+  vôtres. Regardez dans le sous-répertoire
   <filename>contrib</filename> du répertoire des sources. La
   page de référence <xref linkend="sql-createforeigndatawrapper"/>
   contient aussi des détails utiles.
@@ -1632,7 +1632,7 @@ ImportForeignSchema (ImportForeignSchemaStmt *stmt, Oid serverOid);
     ensembles de taille fixe de mémoire partagée dynamique. Cette mémoire
     partagée n'est pas garantie d'être placée à la même adresse pour chaque
     processus, donc il ne doit pas contenir de pointeurs. Les fonctions
-    suivantes sont toutes optionnelles général, mais elles sont requises si
+    suivantes sont toutes optionnelles généralement, mais elles sont requises si
     une exécution parallèle doit être supportée.
    </para>
 

--- a/postgresql/features.xml
+++ b/postgresql/features.xml
@@ -85,8 +85,8 @@
   &laquo;&nbsp;centrale&nbsp;&raquo; complète (<foreignphrase>full Core
    conformance</foreignphrase>), PostgreSQL se conforme à plus de
   170. De plus, il existe une longue liste de
-  fonctionnalités optionelles supportées. À la date de rédaction de ce
-  document, aucune version de quelque système de gestion de bases de
+  fonctionnalités optionnelles supportées. À la date de rédaction de ce
+  document, aucune version de quelques systèmes de gestion de bases de
   données que ce soit n'affiche une totale conformité au cœur de SQL:2023.
  </para>
 
@@ -319,11 +319,11 @@
         Contrairement à une séquence XQuery/XPath, qui peut contenir
         n'importe quel élément voulu dans n'importe quel ordre voulu, un
         nœud-ensemble XPath 1.0 n'a aucune garantie sur l'ordre et, comme
-        n'importe quel ensemble, n'autorise pas de multiples occurences d'un
+        n'importe quel ensemble, n'autorise pas de multiples occurrences d'un
         même élément.
         <note>
          <para>
-          La bilbiothèque <application>libxml2</application> semble toujours
+          La bibliothèque <application>libxml2</application> semble toujours
           retourner des nœud-ensembles à <productname>PostgreSQL</productname>
           avec leurs membres dans le même ordre relatif qu'ils avaient dans
           le document en entrée. Sa documentation ne valide pas ce
@@ -386,7 +386,7 @@
         (c'est-à-dire exactement un élément de premier niveau, avec
         uniquement des commentaires et des instructions de traitement en
         dehors de celui-ci) ou une forme de contenu (avec ces contraintes
-        relachées). Son équivalent dans XPath 1.0, le
+        relâchées). Son équivalent dans XPath 1.0, le
         <firstterm>nœud racine</firstterm>, ne peut être que dans une forme de
         document. C'est en partie la raison pour laquelle une valeur
         <type>xml</type> passée comme objet de contexte à n'importe laquelle
@@ -430,7 +430,7 @@
      <productname>PostgreSQL</productname> part simplement du principe que
      le type de données XML chaîne de caractère XPath 1.0 sera valide en tant
      que forme d'entrée texte du type de données SQL, et réciproquement.
-     Cette règle à l'avantage d'être simple tout en produisant, pour de
+     Cette règle a l'avantage d'être simple tout en produisant, pour de
      nombreux types de données, des résultats similaires aux correspondances
      spécifiées dans le standard.
     </para>
@@ -489,7 +489,7 @@ SELECT XMLQUERY('$a is $b' PASSING BY VALUE <replaceable>x</replaceable> AS a, <
      <literal>BY VALUE</literal> ou <literal>BY REF</literal> dans une
      construction <function>XMLEXISTS</function> ou
      <function>XMLTABLE</function>, mais les ignorera. Le type de données
-     <type>xml</type> a une représentation sérialisée en chaine de caractères,
+     <type>xml</type> a une représentation sérialisée en chaîne de caractères,
      il n'y a donc pas d'identité de nœud à préserver, et le passage est dans
      les faits toujours <literal>BY VALUE</literal>.
     </para>

--- a/postgresql/file-fdw.xml
+++ b/postgresql/file-fdw.xml
@@ -11,7 +11,7 @@
   Le module <filename>file_fdw</filename> fournit le wrapper de données distantes
   <function>file_fdw</function>, qui peut être utilisé pour accéder à des fichiers de
   données situées sur le système de fichiers du serveur, ou pour exécuter des
-  programme sur le serveur et lire leur sortie.  Les fichiers de données or
+  programmes sur le serveur et lire leur sortie. Les fichiers de données ou
   program output doivent être dans un format qui puisse être lu par
   <command>COPY FROM</command>; voyez <xref linkend="sql-copy"/> pour les
   détails.  L'accès à ce type de fichier se fait uniquement en lecture seule.
@@ -54,12 +54,12 @@
 
    <listitem>
     <para>
-     C'est une option booléenne.Si elle vaut vrai, cela signifie que les valeurs
+     C'est une option booléenne. Si elle vaut vrai, cela signifie que les valeurs
      de la colonne qui correspondent à la chaîne NULL sont retournées comme
      <literal>NULL</literal> même si la valeur est entourée de guillemets. Sans
      cette option, seules les valeurs non entourées de guillemets qui correspondent
      à la chaîne NULL seront retournées comme <literal>NULL</literal>.
-     Cela a le même effet que de spécifier les colonne dans l'option
+     Cela a le même effet que de spécifier les colonnes dans l'option
      <literal>FORCE_NULL</literal> de la commande <command>COPY</command>.
     </para>
    </listitem>
@@ -184,7 +184,7 @@
   Ces options ne peuvent être spécifiées que pour une table distante ou ses
   colonnes,
   pas comme options du wrapper de données distantes <literal>file_fdw</literal>,
-  pas plus cque comme des options d'un serveur ou d'un mapping d'utilisateur
+  pas plus que comme des options d'un serveur ou d'un mapping d'utilisateur
   utilisant le wrapper.
  </para>
 
@@ -201,7 +201,7 @@
 
  <para>
   Lorsque l'option <literal>program</literal> est spécifiée, gardez à l'esprit
-  que la chaîne de texte est exécutée par le shell.  Si vous devez passez des
+  que la chaîne de texte est exécutée par le shell.  Si vous devez passer des
   arguments à la commande qui viennent d'une source non approuvée, vous devez
   prendre soin de supprimer ou échapper des caractères qui pourraient avoir une
   signification spéciale pour le shell.  Pour raisons de sécurité, il est

--- a/postgresql/frenchtranslation.xml
+++ b/postgresql/frenchtranslation.xml
@@ -62,6 +62,7 @@
    <listitem><para>Marc Cousin</para></listitem>
    <listitem><para>Mathieu Lafage</para></listitem>
    <listitem><para>Matthieu Clavier</para></listitem>
+   <listitem><para>Nicolas Coudert</para></listitem>
    <listitem><para>Nicolas Gollet</para></listitem>
    <listitem><para>Philippe Rimbault</para></listitem>
    <listitem><para>Pierre Jarillon</para></listitem>

--- a/postgresql/func.xml
+++ b/postgresql/func.xml
@@ -15,7 +15,7 @@
   et d'opérateurs pour les types de données natifs. Ce chapitre en décrit la
   plupart, bien que certaines fonctions spéciales apparaissent dans des
   sections plus adéquates du manuel. Les utilisateurs peuvent aussi définir
-  leur propres fonctions et opérateurs, comme décrit dans <xref
+  leurs propres fonctions et opérateurs, comme décrit dans <xref
   linkend="server-programming"/>. Les méta-commandes <command>\df</command>
   et <command>\do</command> de <application>psql</application> peuvent être
   utilisées pour lister, respectivement, toutes les fonctions et tous les
@@ -3654,7 +3654,7 @@ SELECT NOT(ROW(table.*) IS NOT NULL) FROM TABLE; -- detect at least one null in 
        <returnvalue>text</returnvalue>
       </para>
       <para>
-       Divise <parameter>string</parameter> à chaque occurence de
+       Divise <parameter>string</parameter> à chaque occurrence de
        <parameter>delimiter</parameter> et renvoie le
        <parameter>n</parameter>-ième champ (en comptant à partir de 1),
        ou quand <parameter>n</parameter> est négatif, renvoie le
@@ -3697,7 +3697,7 @@ SELECT NOT(ROW(table.*) IS NOT NULL) FROM TABLE; -- detect at least one null in 
      <returnvalue>text[]</returnvalue>
     </para>
     <para>
-     Divise <parameter>string</parameter> à chaque occurence
+     Divise <parameter>string</parameter> à chaque occurrence
      de <parameter>delimiter</parameter> et retourne les champs résultants
      dans un tableau de type <type>text</type>.
      Si <parameter>delimiter</parameter> vaut <literal>NULL</literal>,
@@ -3725,7 +3725,7 @@ SELECT NOT(ROW(table.*) IS NOT NULL) FROM TABLE; -- detect at least one null in 
      <returnvalue>setof text</returnvalue>
     </para>
     <para>
-     Divise <parameter>string</parameter> à chaque occurence
+     Divise <parameter>string</parameter> à chaque occurrence
      de <parameter>delimiter</parameter> et retourne les champs résultants
      dans un ensemble de lignes de type <type>text</type>.
      Si <parameter>delimiter</parameter> vaut <literal>NULL</literal>,
@@ -3994,7 +3994,7 @@ SELECT NOT(ROW(table.*) IS NOT NULL) FROM TABLE; -- detect at least one null in 
    comment le résultat doit être formaté. Le texte de la chaîne de formatage
    est copié directement dans le résultat, à l'exception des
    <firstterm>jokers de format</firstterm>. Les jokers de format agissent
-   comme des espaces réservés dans le chaîne définissant comment les
+   comme des espaces réservés dans la chaîne définissant comment les
    arguments de la fonction doivent être formatés et insérés dans le
    résultat. Chaque argument <parameter>formatarg</parameter> est converti
    en texte suivant les règles d'affichage habituel pour son type de
@@ -5708,7 +5708,7 @@ substring(<replaceable>string</replaceable>, <replaceable>pattern</replaceable>,
    correspondre à la chaîne de données entière. Dans le cas contraire, la
    fonction échoue et renvoie NULL. Pour indiquer la partie du motif pour
    laquelle la sous-chaîne de données correspondante est intéressante, le
-   motif doit contenir deux occurences du caractère d'échappement suivi par
+   motif doit contenir deux occurrences du caractère d'échappement suivi par
    un guillemet double (<literal>"</literal>). <!-- " font-lock sanity --> Le
    texte correspondant à la portion du motif entre ces séparateurs est
    renvoyé quand la correspondance est réussie.
@@ -6307,7 +6307,7 @@ SELECT foo FROM regexp_split_to_table('the quick brown fox', '\s*') AS foo;
   </para>
 
   <para>
-   La fonction <function>regexp_substr</function> renvoit la sous-chaîne
+   La fonction <function>regexp_substr</function> renvoie la sous-chaîne
    correspondant à un motif d'expression rationnelle POSIX, ou
    <literal>NULL</literal> s'il n'y a pas de correspondances. Voici sa
    syntaxe&nbsp;:
@@ -7734,7 +7734,7 @@ SELECT regexp_match('abc01234xyz', '(?:(.*?)(\d+)(.*)){1,1}');
     <itemizedlist>
      <listitem>
       <para>
-       La soustraction de classe d'opérateur XQuery n'est pas supportée. Un
+       La soustraction de classe d'opérateurs XQuery n'est pas supportée. Un
        exemple de cette fonctionnalité est l'utilisation de la syntaxe
        suivante pour établir une correspondance avec uniquement des consonnes
        anglaises&nbsp;: <literal>[a-z-[aeiou]]</literal>.
@@ -13682,7 +13682,7 @@ CREATE TYPE rainbow AS ENUM ('red', 'orange', 'yellow', 'green', 'blue', 'purple
       <para>
        Assigne le poids (<parameter>weight</parameter>) spécifié aux éléments
        des <parameter>vector</parameter> qui sont listés dans les
-       <parameter>lexemes</parameter>.  Le chaînes dans
+       <parameter>lexemes</parameter>.  La chaînes dans
        <parameter>lexemes</parameter> sont prises ainsi, sans autre traitement.
        Les chaînes qui ne correspondent à aucun lexeme dans
        <parameter>vector</parameter> sont ignorées.
@@ -15709,7 +15709,7 @@ table2-mapping
   <para>
    Pour fournir un support natif des types de données JSON dans un
    environnement SQL, <productname>PostgreSQL</productname> implémente le
-   <firstterm>modèle de données SQL/JSON</firstterm>. Ce modèle comprends
+   <firstterm>modèle de données SQL/JSON</firstterm>. Ce modèle comprend
    des séquences d'éléments. Chaque élément peut contenir des valeurs SQL
    scalaires, avec une valeur null SQL/JSON supplémentaire, et des structures
    de données composites qui utilisent les tableaux et objets JSON. Le modèle
@@ -20463,7 +20463,7 @@ SELECT NULLIF(value, '(none)') ...
       <returnvalue>integer</returnvalue>
      </para>
      <para>
-      Renvoie l'indice de la première occurence du second argument dans le
+      Renvoie l'indice de la première occurrence du second argument dans le
       tableau, ou <literal>NULL</literal> s'il n'est pas présent. Si le
       troisième argument est donné, la recherche commence à cet indice. Le
       tableau doit être d'une dimension. Les comparaisons se font en
@@ -23700,7 +23700,7 @@ WHERE EXISTS (SELECT 1 FROM tab2 WHERE col2 = tab1.col2);
  <token>IN</token> vaut <quote>true</quote> si au moins une ligne identique
  est trouvée dans la sous-requête. Le résultat est <quote>false</quote> si
  aucune ligne identique n'a été trouvée (y compris dans le cas où la
- sous-requête ne renvoit aucune ligne).
+ sous-requête ne renvoie aucune ligne).
 </para>
 
 <para>
@@ -24166,8 +24166,8 @@ AND
  doivent avoir le même nombre de champs. L'<replaceable>operator</replaceable>
  indiqué est appliqué à chaque partie de champs correspondants. (Comme les
  champs peuvent être de type différent, cela signifie qu'un opérateur différent spécifique peut être sélectionné pour chaque paire.) Tous les opérateurs
- sélectionnés doivent être des membres d'une classe d'opérateur B-tree,
- ou être la négation d'un membre <literal>=</literal> d'une classe d'opérateur
+ sélectionnés doivent être des membres d'une classe d'opérateurs B-tree,
+ ou être la négation d'un membre <literal>=</literal> d'une classe d'opérateurs
  B-tree, signifiant que la comparaison du constructeur de lignes est seulement
  possible quand l'opérateur <replaceable>operator</replaceable> est
  <literal>=</literal>,
@@ -24259,8 +24259,8 @@ AND
  <literal>&gt;=</literal>,
  ou a une sémantique similaire à ces derniers. (Pour être précis, un
  opérateur peut être un opérateur de comparaison de ligne s'il est membre
- d'une classe d'opérateur B-tree, ou s'il est la négation du membre
- <literal>=</literal> d'une classe d'opérateur B-tree.) Le comportement par
+ d'une classe d'opérateurs B-tree, ou s'il est la négation du membre
+ <literal>=</literal> d'une classe d'opérateurs B-tree.) Le comportement par
  défaut des opérateurs ci-dessus est identique à celui de <literal>IS [ NOT
   ] DISTINCT FROM</literal> pour les constructeurs de lignes (voir <xref
  linkend="row-wise-comparison"/>).
@@ -24268,7 +24268,7 @@ AND
 
 <para>
  Pour supporter la comparaison des lignes qui incluent des éléments sans une
- classe d'opérateur B-tree par défaut, les opérateurs suivants sont définis
+ classe d'opérateurs B-tree par défaut, les opérateurs suivants sont définis
  pour la comparaison de type composite&nbsp;:
  <literal>*=</literal>,
  <literal>*&lt;&gt;</literal>,
@@ -25803,7 +25803,7 @@ le nom et la méthode d'accès associé de l'index sont considérés.
      <returnvalue>boolean</returnvalue>
     </para>
     <para>
-     La classe d'opérateur est-elle visible dans le chemin de recherche&nbsp;?
+     La classe d'opérateurs est-elle visible dans le chemin de recherche&nbsp;?
     </para></entry>
   </row>
 

--- a/postgresql/fuzzystrmatch.xml
+++ b/postgresql/fuzzystrmatch.xml
@@ -62,7 +62,7 @@
   <para>
    La fonction <function>soundex</function> convertit une chaîne en son code
    Soundex. La fonction <function>difference</function> convertit deux chaînes
-   en leur codes Soundex, puis rapporte le nombre de positions de code
+   en leurs codes Soundex, puis rapporte le nombre de positions de code
    correspondant. Comme les codes Soundex ont quatre caractères, le résultat
    va de zéro à quatre. Zéro correspond à aucune correspondance, quatre à une
    correspondance exacte. (Du coup, la fonction est mal nommée &mdash;
@@ -181,8 +181,8 @@ SELECT daitch_mokotoff('Schwartzenegger');
 
   <para>
    Pour une correspondance entre des noms simples, les tableaux de texte renvoyés
-   peuvent être comparés direction en utilisant l'opérateur
-   <literal>&amp;&amp;</literal>&nbsp;: toute surcharge peut être considéré comme
+   peuvent être comparés directement en utilisant l'opérateur
+   <literal>&amp;&amp;</literal>&nbsp;: toute surcharge peut être considérée comme
    une correspondance. Un index GIN pourrait être utilisé pour plus
    de performances, voir  <xref linkend="gin"/> et cet exemple&nbsp;:
   </para>
@@ -273,7 +273,7 @@ levenshtein_less_equal(source text, target text, max_d int) returns int
    sont des chaînes quelconques non NULL de 255 caractères. Les paramètres de coût
    indiquent respectivement le coût d'une insertion, suppression ou
    substitution d'un paramètre. Vous pouvez omettre les paramètres de coût,
-   comme dans la deuxième version de la version. Dans ce cas, elles ont 1 comme
+   comme dans la deuxième version. Dans ce cas, elles ont 1 comme
    valeur par défaut.
   </para>
 

--- a/postgresql/generic-wal.xml
+++ b/postgresql/generic-wal.xml
@@ -47,8 +47,8 @@
      contenu du tampon.) Le troisième argument est un masque de bits pour les
      drapeaux applicables à l'opération. Actuellement, le seul drapeau
      disponible est <literal>GENERIC_XLOG_FULL_IMAGE</literal>, qui indique
-     qu'une image d'une page complète doit être inclue dans l'enregistrement
-     WAL, plutôt qu'un delta. Typiquement, ce drapeau doit être configurée si
+     qu'une image d'une page complète doit être incluse dans l'enregistrement
+     WAL, plutôt qu'un delta. Typiquement, ce drapeau doit être configuré si
      le bloc est nouveau ou s'il a été complètement réécrit.
      <function>GenericXLogRegisterBuffer</function> peut être répété si
      l'action tracée doit modifier plusieurs blocs.
@@ -162,7 +162,7 @@
     <para>
      La fonction de rejeu des enregistrements génériques acquiert des verrous
      exclusifs sur les tampons dans le même ordre qu'ils ont été enregistrés.
-     Après l'exécution du rejeu, les verrous sont relachés dans le même
+     Après l'exécution du rejeu, les verrous sont relâchés dans le même
      ordre.
     </para>
    </listitem>
@@ -171,7 +171,7 @@
     <para>
      Si <literal>GENERIC_XLOG_FULL_IMAGE</literal> n'est pas spécifié pour un
      tampon enregistré, l'enregistrement générique contient un delta entre
-     les ancienne et nouvelle images. Ce delta est basé sur une comparaison
+     les anciennes et les nouvelles images. Ce delta est basé sur une comparaison
      octet par octet. Ceci n'est pas spécialement compact dans le cas d'un
      déplacement de données dans une page, et pourrait être amélioré dans le
      futur.

--- a/postgresql/geqo.xml
+++ b/postgresql/geqo.xml
@@ -88,7 +88,7 @@
    <firstterm>sélection</firstterm>) permet de trouver de nouvelles
    générations de points de recherche qui présentent une meilleure adaptation
    moyenne que leurs ancêtres. <xref linkend="geqo-figure"/>
-   illustre ces steps.
+   illustre ces étapes.
   </para>
 
   <figure id="geqo-figure">
@@ -198,7 +198,7 @@
     trois stratégies de jointure sont considérées&nbsp;; et tous les plans de
     parcours initiaux sont disponibles. Le coût estimé est le moins coûteux.)
     Les séquences dont le coût est moindre sont considérées <quote>plus
-     adaptée</quote> que celle de coût plus élevé. L'algorithme génétique
+     adaptées</quote> que celle de coût plus élevé. L'algorithme génétique
     élimine les candidats les moins adaptés. De nouveaux candidats sont alors
     engendrés par combinaison de gènes de candidats à forte valeur
     d'adaptation &mdash; par l'utilisation de portions aléatoires de plans

--- a/postgresql/gin.xml
+++ b/postgresql/gin.xml
@@ -27,7 +27,7 @@
    une valeur composite qui doit être indexée, et le mot
    <firstterm>clé</firstterm> (<foreignphrase>clé</foreignphrase> en version originale) pour
    désigner une des valeurs d'un élément. <acronym>GIN</acronym> stocke et
-   recherche toujours des clés, jamais des éléments eux même.
+   recherche toujours des clés, jamais des éléments eux-mêmes.
   </para>
 
   <para>
@@ -69,7 +69,7 @@
  </sect2>
 
  <sect2 id="gin-builtin-opclasses">
-  <title>Classes d'opérateur natives</title>
+  <title>classes d'opérateurs natives</title>
 
   <para>
    La distribution <productname>PostgreSQL</productname> inclut les classes
@@ -80,7 +80,7 @@
   </para>
 
   <table id="gin-builtin-opclasses-table">
-   <title>Classes d'opérateur <acronym>GIN</acronym> natives</title>
+   <title>classes d'opérateurs <acronym>GIN</acronym> natives</title>
    <tgroup cols="2">
     <thead>
      <row>
@@ -140,7 +140,7 @@
   </table>
 
   <para>
-   Des deux classes d'opérateur pour le type <type>jsonb</type>,
+   Des deux classes d'opérateurs pour le type <type>jsonb</type>,
    <literal>jsonb_ops</literal> est l'opérateur par défaut.
    <literal>jsonb_path_ops</literal> supporte moins d'opérateurs mais offre
    de meilleures performances pour ces opérateurs. Voir <xref
@@ -164,12 +164,12 @@
    il suffit d'implanter quelques méthodes utilisateur. Celles-ci définissent
    le comportement des clés dans l'arbre et les relations entre clés, valeurs
    d'éléments indexées et requêtes indexables. En résumé,
-   <acronym>GIN</acronym> combine extensibilité, généricité, ré-utilisation
+   <acronym>GIN</acronym> combine extensibilité, généricité, réutilisation
    du code, et une interface claire.
   </para>
 
   <para>
-   Voici les deux méthodes qu'une classe d'opérateur <acronym>GIN</acronym>
+   Voici les deux méthodes qu'une classe d'opérateurs <acronym>GIN</acronym>
    doit fournir sont&nbsp;:
   </para>
 
@@ -203,7 +203,7 @@
       c'est-à-dire que <literal>query</literal> est la valeur du côté droit
       d'un opérateur indexable dont le côté gauche est la colonne indexée.
       <literal>n</literal> est le numéro de stratégie de l'opérateur dans la
-      classe d'opérateur (voir <xref linkend="xindex-strategies"/>). Souvent,
+      classe d'opérateurs (voir <xref linkend="xindex-strategies"/>). Souvent,
       <function>extractQuery</function> doit consulter <literal>n</literal>
       pour déterminer le type de données de <literal>query</literal> et la
       méthode à utiliser pour extraire les valeurs des clés. Le nombre de
@@ -239,7 +239,7 @@
       lent que les deux autres, mais il peut être nécessaire pour implanter
       des cas exceptionnels correctement. Un opérateur qui a besoin de ce
       mode dans la plupart des cas n'est probablement pas un bon candidat
-      pour une classe d'opérateur GIN.) Les symboles à utiliser pour
+      pour une classe d'opérateurs GIN.) Les symboles à utiliser pour
       configurer ce mode sont définis dans
       <filename>access/gin.h</filename>.
      </para>
@@ -280,7 +280,7 @@
   </variablelist>
 
   <para>
-   Une classe d'opérateur doit aussi fournir une fonction pour vérifier si un
+   Une classe d'opérateurs doit aussi fournir une fonction pour vérifier si un
    élément indexé correspond à la requête. Elle vient en deux versions, une
    fonction booléenne <function>consistent</function> et une fonction
    ternaire <function>triConsistent</function>. Cette dernière couvre les
@@ -391,7 +391,7 @@
 
   <para>
    De plus, GIN doit avoir un moyen de trier les valeurs des clés stockées
-   dans l'index. La classe d'opérateur peut définir l'ordre de tri en
+   dans l'index. La classe d'opérateurs peut définir l'ordre de tri en
    spécifiant une méthode de comparaison&nbsp;:
 
    <variablelist>
@@ -408,13 +408,13 @@
     </varlistentry>
    </variablelist>
 
-   Sinon, si la classe d'opérateur ne fournit pas de méthode
-   <function>compare</function>, GIN cherchera la classe d'opérateur B-Tree
+   Sinon, si la classe d'opérateurs ne fournit pas de méthode
+   <function>compare</function>, GIN cherchera la classe d'opérateurs B-Tree
    par défaut pour le type de donnée de la clé d'index, et utilisera sa
    fonction de comparaison. Il est recommandé de spécifier la fonction de
-   comparaison dans une classe d'opérateur GIN destinée à un seul type de
-   donnée, car rechercher la classe d'opérateur B-Tree coûte quelques cycles
-   CPU. Cependant, les classes d'opérateur GIN polymorphiques (telle que
+   comparaison dans une classe d'opérateurs GIN destinée à un seul type de
+   donnée, car rechercher la classe d'opérateurs B-Tree coûte quelques cycles
+   CPU. Cependant, les classes d'opérateurs GIN polymorphiques (telle que
    <literal>array_ops</literal>) ne peuvent typiquement pas spécifier une
    seule fonction de comparaison.
   </para>
@@ -452,13 +452,13 @@
     <listitem>
      <para>
       Définit un ensemble de paramètres visibles aux utilisateurs qui contrôle
-      le comportement d'une classe d'opérateur.
+      le comportement d'une classe d'opérateurs.
      </para>
 
      <para>
       La fonction <function>options</function> se voit donner un pointeur vers
       une structure <structname>local_relopts</structname> qui doit être
-      remplie avec un ensemble d'options spécifiques à la classe d'opérateur.
+      remplie avec un ensemble d'options spécifiques à la classe d'opérateurs.
       Les options peuvent être accédées à partir des autres fonctions de
       support en utilisant les macros <literal>PG_HAS_OPCLASS_OPTIONS
       ()</literal> et <literal>PG_GET_OPCLASS_OPTIONS()</literal>.
@@ -475,7 +475,7 @@
 
   <para>
    Pour supporter des requêtes à <quote>correspondance partielle</quote>, une
-   classe d'opérateur doit fournir la méthode
+   classe d'opérateurs doit fournir la méthode
    <function>comparePartial</function>, et sa méthode
    <function>extractQuery</function> doit positionner le paramètre
    <literal>pmatch</literal> quand une requête à correspondance partielle est
@@ -486,7 +486,7 @@
    Le type de données réel des différentes valeurs <literal>Datum</literal>
    mentionnées ci-dessus varient en fonction de la classe d'opérateurs. Les
    valeurs d'élément passées à <function>extractValue</function> sont
-   toujours du type en entrée de la classe d'opérateur, et toutes les valeurs
+   toujours du type en entrée de la classe d'opérateurs, et toutes les valeurs
    de clé doivent être du type <literal>STORAGE</literal> de la classe. Le
    type de l'argument <literal>query</literal> passé aux fonctions
    <function>extractQuery</function>, <function>consistent</function> et
@@ -495,7 +495,7 @@
    Ce n'est pas nécessairement le même que l'élément indexé, tant que des
    valeurs de clés d'un type correct peuvent en être extraites. Néanmoins, il
    est recommandé que les déclarations SQL de ces trois fonctions de support
-   utilisent le type de données indexé de la classe d'opérateur pour
+   utilisent le type de données indexé de la classe d'opérateurs pour
    l'argument <literal>query</literal>, même si le type réel pourrait être
    différent suivant l'opérateur.
   </para>
@@ -735,7 +735,7 @@
 
   <para>
    Le noyau de la distribution <productname>PostgreSQL</productname> inclut la
-   classe d'opérateur <acronym>GIN</acronym> précédemment montrée dans <xref
+   classe d'opérateurs <acronym>GIN</acronym> précédemment montrée dans <xref
    linkend="gin-builtin-opclasses-table"/>. Les modules
    <filename>contrib</filename> suivants contiennent aussi des classes
    d'opérateurs <acronym>GIN</acronym>&nbsp;:

--- a/postgresql/gist.xml
+++ b/postgresql/gist.xml
@@ -43,18 +43,18 @@
  </sect2>
 
  <sect2 id="gist-builtin-opclasses">
-  <title>Classes d'opérateur internes</title>
+  <title>classes d'opérateurs internes</title>
 
   <para>
    La distribution de <productname>PostgreSQL</productname> inclut les classes
    d'opérateur <acronym>GiST</acronym> indiquées dans <xref
    linkend="gist-builtin-opclasses-table"/>.
    (Quelques modules optionnels décrits dans <xref linkend="contrib"/>
-   fournissent des classes d'opérateur <acronym>GiST</acronym> supplémentaires.)
+   fournissent des classes d'opérateurs <acronym>GiST</acronym> supplémentaires.)
   </para>
 
   <table id="gist-builtin-opclasses-table">
-   <title>Classes d'opérateur <acronym>GiST</acronym> internes</title>
+   <title>classes d'opérateurs <acronym>GiST</acronym> internes</title>
    <tgroup cols="3">
     <colspec colname="col1" colwidth="2*"/>
     <colspec colname="col2" colwidth="3*"/>
@@ -209,7 +209,7 @@
   </table>
 
   <para>
-   Pour des raisons historiques, la classe d'opérateur <literal>inet_ops</literal>
+   Pour des raisons historiques, la classe d'opérateurs <literal>inet_ops</literal>
    n'est pas la classe par défaut pour les types <type>inet</type> et
    <type>cidr</type>. Pour l'utiliser, mentionnez le nom de la classe dans la
    commande <command>CREATE INDEX</command>, par exemple
@@ -276,7 +276,7 @@ CREATE INDEX ON ma_table USING GIST (ma_colonne_inet inet_ops);
   </para>
 
   <para>
-   Une classe d'opérateur d'index <acronym>GiST</acronym> doit fournir cinq
+   Une classe d'opérateurs d'index <acronym>GiST</acronym> doit fournir cinq
    méthodes, et six supplémentaires optionnelles. La précision de l'index
    est assurée par l'implantation des méthodes <function>same</function>,
    <function>consistent</function> et <function>union</function> alors que
@@ -293,12 +293,12 @@ CREATE INDEX ON ma_table USING GIST (ma_colonne_inet inet_ops);
    type de données interne de l'arbre existe au niveau SQL, l'option
    <literal>STORAGE</literal> de la commande <command>CREATE OPERATOR
    CLASS</command> peut être utilisée. La huitième méthode, optionnelle, est
-   <function>distance</function>, qui est nécessaire si la classe d'opérateur
+   <function>distance</function>, qui est nécessaire si la classe d'opérateurs
    souhaite supporter les parcours ordonnées (intéressant dans le cadre des
    recherches du voisin-le-plus-proche,
    <foreignphrase>nearest-neighbor</foreignphrase>). La neuvième méthode,
    optionnelle, nommée <function>fetch</function>, est nécessaire si la
-   classe d'opérateur souhaite supporter les parcours d'index seuls, sauf
+   classe d'opérateurs souhaite supporter les parcours d'index seuls, sauf
    quand la méthode <function>compress</function> est omise. La dixième
    méthode, optionnelle, est <function>options</function> et est nécessaire
    si l'opérateur de classe a des paramètres définis par l'utilisateur.
@@ -382,7 +382,7 @@ my_consistent(PG_FUNCTION_ARGS)
       Ici, <varname>key</varname> est un élément dans l'index et
       <varname>query</varname> la valeur la recherchée dans l'index. Le
       paramètre <literal>StrategyNumber</literal> indique l'opérateur
-      appliqué de votre classe d'opérateur. Il correspond à un des nombres
+      appliqué de votre classe d'opérateurs. Il correspond à un des nombres
       d'opérateurs dans la commande <command>CREATE OPERATOR CLASS</command>.
      </para>
 
@@ -396,7 +396,7 @@ my_consistent(PG_FUNCTION_ARGS)
       l'argument <varname>query</varname> pourrait devoir dépendre de
       l'opérateur.) Il est recommendé que la déclaration SQL de la fonction
       <function>consistent</function> utilise le type de la donnée indexée de
-      la classe d'opérateur pour l'argument <varname>query</varname>, même si
+      la classe d'opérateurs pour l'argument <varname>query</varname>, même si
       le type réel pourrait être différent suivant l'opérateur.
      </para>
 
@@ -785,7 +785,7 @@ my_picksplit(PG_FUNCTION_ARGS)
     <term><function>same</function></term>
     <listitem>
      <para>
-      Renvoit true si les deux entrées de l'index sont identiques, faux sinon.
+      Renvoie true si les deux entrées de l'index sont identiques, faux sinon.
       (Un <quote>enregistrement d'index</quote> est une valeur du type de
       stockage de l'index, pas nécessairement le type original de la colonne
       indexée.)
@@ -836,7 +836,7 @@ my_same(PG_FUNCTION_ARGS)
       À partir d'une entrée d'index <literal>p</literal> et une valeur
       recherchée <literal>q</literal>, cette fonction détermine la
       <quote>distance</quote> entre l'entrée de l'index et la valeur
-      recherchée. Cette fonction doit être fournie si la classe d'opérateur
+      recherchée. Cette fonction doit être fournie si la classe d'opérateurs
       contient des opérateurs de tri. Une requête utilisant l'opérateur de
       tri sera implémentée en renvoyant les entrées d'index dont les valeurs
       de <quote>distance</quote> sont les plus petites, donc les résultats
@@ -947,9 +947,9 @@ LANGUAGE C STRICT;
       une donnée non NULL compressée. La valeur de retour est une autre
       structure <structname>GISTENTRY</structname> dont le champ <structfield>key</structfield>
       contient la même donnée que l'original, mais non compressée. Si la
-      fonction de compression de la classe d'opérateur ne fait rien pour les
+      fonction de compression de la classe d'opérateurs ne fait rien pour les
       enregistrements feuilles, la méthode <function>fetch</function> peut renvoyer l'argument
-      tel quel. Ou, si la classe d'opérateur n'a pas de fonction de
+      tel quel. Ou, si la classe d'opérateurs n'a pas de fonction de
       compression, la méthode <function>fetch</function> peut aussi être
       omise car elle ne ferait rien de toute façon.
      </para>
@@ -987,7 +987,7 @@ my_fetch(PG_FUNCTION_ARGS)
 
      <para>
       Si la méthode de compression est à perte pour les entrées feuilles, la
-      classe d'opérateur ne supporte pas les parcours d'index seuls, et ne
+      classe d'opérateurs ne supporte pas les parcours d'index seuls, et ne
       doit pas définir une fonction <function>fetch</function>.
      </para>
 
@@ -999,7 +999,7 @@ my_fetch(PG_FUNCTION_ARGS)
     <listitem>
      <para>
       Permet la définition des paramètres visibles par l'utilisateur et contrôlant
-      le comportement des classes d'opérateur.
+      le comportement des classes d'opérateurs.
      </para>
 
      <para>
@@ -1016,7 +1016,7 @@ LANGUAGE C STRICT;
      <para>
       La fonction est passée sous forme de pointeur à une structure
       <structname>local_relopts</structname>, qui doit être nécessairement alimentée
-      avec un ensemble d'options spécifiques de classe d'opérateur. Les options peuvent
+      avec un ensemble d'options spécifiques de classe d'opérateurs. Les options peuvent
       être accédées par d'autres fonctions support en utilisant les macros
       <literal>PG_HAS_OPCLASS_OPTIONS()</literal> et
       <literal>PG_GET_OPCLASS_OPTIONS()</literal>.
@@ -1286,7 +1286,7 @@ my_sortsupport(PG_FUNCTION_ARGS)
     de l'index résultant. L'utilisation de tampons peut aussi influencer la
     qualité de l'index résultant, de façon positive et négative. Cette
     influence dépend de plusieurs facteurs, comme la distribution des données
-    en entrée et de l'implémentation de la classe d'opérateur.
+    en entrée et de l'implémentation de la classe d'opérateurs.
    </para>
 
    <para>
@@ -1313,7 +1313,7 @@ my_sortsupport(PG_FUNCTION_ARGS)
    <type>tsquery</type>) ainsi que des fonctionnalités équivalentes aux R-Tree
    pour certains types de données géométriques
    (voir <filename>src/backend/access/gist/gistproc.c</filename>). Les modules
-   <filename>contrib</filename> suivants contiennent aussi des classes d'opérateur
+   <filename>contrib</filename> suivants contiennent aussi des classes d'opérateurs
    <acronym>GiST</acronym>&nbsp;:
   </para>
 

--- a/postgresql/glossary.xml
+++ b/postgresql/glossary.xml
@@ -94,7 +94,7 @@
      les opérations <glossterm linkend="glossary-vacuum">vacuum</glossterm>
      et <glossterm linkend="glossary-analyze">analyze</glossterm>.
      Le <glossterm linkend="glossary-auxiliary-proc">processus auxiliaire</glossterm>
-     qui coordonne le travail est est toujours présent (sauf si autovacuum
+     qui coordonne le travail est toujours présent (sauf si autovacuum
      est désactivé) est connu sous le nom de <firstterm>autovacuum launcher</firstterm>,
      et les processus qui font le boulot sont appelés
      <firstterm>autovacuum workers</firstterm>.

--- a/postgresql/hash.xml
+++ b/postgresql/hash.xml
@@ -12,7 +12,7 @@
 
  <para>
   <productname>PostgreSQL</productname> propose une implémentation d'index
-  hash sur disque, qui sont résistants aux crashs. Tout type de données peut
+  hash sur disque, qui est résistant aux crashs. Tout type de données peut
   être indexé par un index hash, y compris les types de données qui n'ont pas
   un ordre linéaire bien défini. Les index hash stockent seulement la valeur
   hachée de la donnée en cours d'indexation. De ce fait, il n'y a pas de
@@ -27,7 +27,7 @@
  <para>
   Les index hash acceptent uniquement l'opérateur <literal>=</literal>, donc
   les clauses WHERE qui spécifient des opérations sur des intervalles ne
-  seront pas capable de tirer avantages des index hash.
+  seront pas capables de tirer avantages des index hash.
  </para>
 
  <para>
@@ -49,7 +49,7 @@
   L'équivalent du bloc feuille dans un index hash est appelé un bloc bucket.
   Dans le cas d'un index hash, l'accès à ce bloc bucket est direct, réduisant
   ainsi le temps d'accès dans les tables volumineuses. Cette réduction des
-  I/O logiques est encore plus prononcé sur les index/données qui sont plus
+  I/O logiques est encore plus prononcée sur les index/données qui sont plus
   volumineuses que le cache (shared_buffers) et la RAM.
  </para>
 
@@ -69,7 +69,7 @@
  <para>
   En résultat des cas d'overflow, nous pouvons dire que les index hash sont
   préférables dans le cas de données uniques, ou tout du moins pratiquement
-  unique, ou de données avec un petit nombre de lignes par bucket. Une façon
+  uniques, ou de données avec un petit nombre de lignes par bucket. Une façon
   d'éviter les problèmes est d'exclure les valeurs très fréquentes de l'index
   en utilisant une condition d'index partiel mais ceci n'est pas réalisable
   dans beaucoup de cas.
@@ -132,7 +132,7 @@
  <para>
   À la fois le parcours de l'index et l'insertion de lignes nécessitent de
   localiser le bucket où une ligne donnée doit être située. Pour faire cela,
-  nous avons du nombre de buckets, de la valeur haute
+  nous avons besoin du nombre de buckets, de la valeur haute
   (<foreignphrase>highmask</foreignphrase>) et de la valeur basse
   (<foreignphrase>lowmask</foreignphrase>) partir de le bloc de
   méta-données&nbsp;; néanmoins, il n'est pas souhaitable pour des raisons de
@@ -150,12 +150,12 @@
  </para>
 
  <para>
-  Chaque ligne dans la table indexé est représentée par un seul enregistrement
+  Chaque ligne dans la table indexée est représentée par un seul enregistrement
   dans l'index hash. Les enregistrements de l'index hash sont stockés dans
   des blocs buckets et, s'ils existent, dans des blocs overflow. Nous
   accélérons les recherches en conservant les entrées d'index de tout bloc
   d'index triées par son code de hachage, permettant ainsi l'utilisation de
-  recherche binaire dans un bloc d'index. Notez néanmoins qu'il n'y pas de
+  recherche binaire dans un bloc d'index. Notez néanmoins qu'il n'y a pas de
   garantie d'un ordre des codes de hachage sur plusieurs blocs d'index d'un
   bucket.
  </para>

--- a/postgresql/high-availability.xml
+++ b/postgresql/high-availability.xml
@@ -37,7 +37,7 @@
   Ce problème de synchronisation représente la difficulté fondamentale à la
   collaboration entre serveurs. Comme la solution au problème de
   synchronisation n'est pas unique pour tous les cas pratiques, plusieurs
-  solutions co-existent. Chacune répond de façon différente et minimise
+  solutions coexistent. Chacune répond de façon différente et minimise
   cet impact au regard d'une charge spécifique.
  </para>
 
@@ -1172,7 +1172,7 @@ primary_slot_name = 'node_a_slot'
    <para>
     Lorsque la réplication synchrone est utilisée, chaque validation portant
     sur une écriture va nécessiter d'attendre la confirmation
-    de l'écriture de cette validation dans les journaux de transaction sur les disques
+    de l'écriture de cette validation dans les journaux de transactions sur les disques
     du serveur primaire et des serveurs secondaires. Le seul moyen possible pour que des données
     soient perdues est que les serveur primaire et secondaire soient hors service au
     même moment. Ce mécanisme permet d'assurer un niveau plus élevé de robustesse, en admettant que

--- a/postgresql/history.xml
+++ b/postgresql/history.xml
@@ -10,7 +10,7 @@
  <para>
   Le système de bases de données relationnelles objet
   <productname>PostgreSQL</productname> est issu de
-  <productname>POSTGRES</productname>, programme écrit à l'université de
+  <productname>POSTGRES</productname>, programme écrit à l'Université de
   Californie à Berkeley. Après plus d'une vingtaine d'années de développement,
   <productname>PostgreSQL</productname> annonce être devenu la base de données
   libre de référence.

--- a/postgresql/hstore.xml
+++ b/postgresql/hstore.xml
@@ -16,7 +16,7 @@
 
  <para>
   Ce module est considéré comme <quote>trusted</quote>, c'est-à-dire qu'il peut
-  être installé par des  utilisateurs simples (sans attribut
+  être installé par des utilisateurs simples (sans attribut
   <literal>SUPERUSER</literal>) ayant le droit <literal>CREATE</literal> sur la
   base de données courante.
  </para>
@@ -766,7 +766,7 @@ CREATE INDEX hidx ON testhstore USING GIN (h);
   </programlisting>
 
   <para>
-   La classe d'opérateur GiST <literal>gist_hstore_ops</literal>
+   La classe d'opérateurs GiST <literal>gist_hstore_ops</literal>
    opère une approximation d'un ensemble de clés/valeurs avec une signature bitmap.
    Son paramètre optionnel entier, <literal>siglen</literal>,
    détermine la longueur de la signature en octets.

--- a/postgresql/indexam.xml
+++ b/postgresql/indexam.xml
@@ -13,7 +13,7 @@
  <para>
   Ce chapitre définit l'interface entre le cœur du système de
   <productname>PostgreSQL</productname> et les <firstterm>méthodes d'accès
-  aux index</firstterm>, qui gérent chaque type d'index. Le système principal
+  aux index</firstterm>, qui gèrent chaque type d'index. Le système principal
   ne sait rien des index en dehors de ce qui est spécifié ici. Il est donc
   possible de développer des types d'index entièrement nouveaux en écrivant du code
   supplémentaire.
@@ -272,7 +272,7 @@ typedef struct IndexAmRoutine
  </sect1>
 
  <sect1 id="index-functions">
-  <title>Fonctions des méthode d'accès aux index</title>
+  <title>Fonctions des méthodes d'accès aux index</title>
 
   <para>
    Les fonctions de construction et de maintenance que doit fournir
@@ -472,7 +472,7 @@ amcanreturn (Relation indexRelation, int attno);
    seul</firstterm></link> sur la colonne indiquée, en renvoyant la valeur
    originale indexée de la colonne. Le numéro d'attribut est indexé à partir
    de 1, c'est-à-dire que le champ attno de la première colonne est 1. Renvoie
-   true si supporté, false sinon. Cette fonction renvoit toujours true pour
+   true si supporté, false sinon. Cette fonction renvoie toujours true pour
    les colonnes inclues (si elles sont supportées) car il y a peu d'intérêt à
    une colonne inclue qui ne peut pas être récupérée. Si la méthode d'accès ne
    supporte pas du tout les parcours d'index seul, le champ
@@ -555,13 +555,13 @@ amproperty (Oid index_oid, int attno,
    <function>pg_strcasecmp</function> pour être cohérent
    avec le code principal)&nbsp;; pour les noms connus du code principal,
    il est préférable d'inspecter <parameter>prop</parameter>. Si
-   la méthode <structfield>amproperty</structfield> renvoit
+   la méthode <structfield>amproperty</structfield> renvoie
    <literal>true</literal>, alors elle a passé le test de
    propriété&nbsp;: elle doit renvoyer le booléen <literal>*res</literal>
    ou mettre <literal>*isnull</literal> à
    <literal>true</literal> pour renvoyer un NULL. (Les deux variables
    référencées sont initialisées à <literal>false</literal> avant l'appel.) Si
-   la méthode <structfield>amproperty</structfield> renvoit
+   la méthode <structfield>amproperty</structfield> renvoie
    <literal>false</literal>, alors le code principal continuera avec sa
    logique habituelle pour tester la propriété.
   </para>
@@ -595,11 +595,11 @@ ambuildphasename (int64 phasenum);
 bool
 amvalidate (Oid opclassoid);
    </programlisting>
-   Valide les entrées du catalogue pour la classe d'opérateur indiquée, à
+   Valide les entrées du catalogue pour la classe d'opérateurs indiquée, à
    condition que la méthode d'accès puisse le faire raisonnablement. Par
    exemple, ceci pourrait inclure le test de la présence de toutes les
    fonctions de support. La fonction
-   <function>amvalidate</function> doit renvoyer false si la classe d'opérateur
+   <function>amvalidate</function> doit renvoyer false si la classe d'opérateurs
    est invalide. Les problèmes devraient être rapportés avec les messages
    <function>ereport</function>, typiquement au niveau <literal>INFO</literal>.
   </para>
@@ -636,7 +636,7 @@ amadjustmembers (Oid opfamilyoid,
    ajuster ces champs si d'autres comportements sont plus appropriés. Par
    exemple, GIN, GiST et SP-GiST configurent toujours les membres opérateurs
    pour avoir des dépendances douces sur la famille d'opérateur car la
-   connexion entre un opérateur et une classe d'opérateur est relativement
+   connexion entre un opérateur et une classe d'opérateurs est relativement
    faible dans ces types d'index&nbsp;; donc il est raisonnable de permettre
    l'ajout et la suppression libres de membres d'opérateurs. Les fonctions
    d'appui optionnelles ont typiquement des dépendances douces, pour être
@@ -726,11 +726,11 @@ amgettuple (IndexScanDesc scan,
   <para>
    Si l'index supporte les <link linkend="indexes-index-only-scans">parcours
    d'index seul</link> (c'est-à-dire que <function>amcanreturn</function>
-   renvoit true pour chacune de ces colonnes), alors, en cas de succès, la
+   renvoie true pour chacune de ces colonnes), alors, en cas de succès, la
    méthode d'accès doit aussi vérifier
    <literal>scan-&gt;xs_want_itup</literal>, et si ce dernier est true, elle
    doit renvoyer les données indexées originales de cette entrée d'index. Les
-   colonnes pour lesquelles <function>amcanreturn</function> renvoit false
+   colonnes pour lesquelles <function>amcanreturn</function> renvoie false
    peuvent êre renvoyées comme NULL. Les données peuvent être retournées sous
    la forme d'un pointeur d'<structname>IndexTuple</structname> stocké dans
    <literal>scan-&gt;xs_itup</literal>, avec un descripteur de lignes dans

--- a/postgresql/indices.xml
+++ b/postgresql/indices.xml
@@ -97,14 +97,14 @@
    Ici, la <replaceable>colonne-indexee</replaceable> est n'importe quel colonne
    ou expression de la définition de l'index.
    L'<replaceable>operateur-indexable</replaceable> est un opérateur qui est un
-   membre de la <firstterm>classe d'opérateur</firstterm> de l'index pour la
+   membre de la <firstterm>classe d'opérateurs</firstterm> de l'index pour la
    colonne indexée. (Plus de détails là-dessus ci-dessous.) et la
    <replaceable>valeur-comparaison</replaceable> peut être toute expression qui
    n'est pas volatile et ne fait pas référence à la table de l'index.
   </para>
 
   <para>
-   Dans certains case, l'optimiseur de requêtes peut extraire une clause
+   Dans certains cas, l'optimiseur de requêtes peut extraire une clause
    indexable de cette forme à partir d'une autre construction SQL. Un exemple
    simple qui, si la clause originale est
 
@@ -114,7 +114,7 @@
 
    alors elle peut être inversée dans une forme indexable si
    l'<replaceable>operateur</replaceable> original a un opérateur de commutation
-   qui est un membre de la classe d'opérateur de l'index.
+   qui est un membre de la classe d'opérateurs de l'index.
   </para>
 
   <para>
@@ -198,7 +198,7 @@ CREATE INDEX <replaceable>name</replaceable> ON <replaceable>table</replaceable>
    <literal>col LIKE 'foo%'</literal> ou <literal>col ~ '^foo'</literal>, mais
    pas <literal>col LIKE '%bar'</literal>. Toutefois, si la base de données
    n'utilise pas la locale C, il est nécessaire de créer l'index avec
-   une classe d'opérateur spéciale pour supporter l'indexation à correspondance
+   une classe d'opérateurs spéciale pour supporter l'indexation à correspondance
    de modèles. Voir la <xref linkend="indexes-opclass"/> ci-dessous. Il est
    aussi possible d'utiliser des index B-tree pour <literal>ILIKE</literal> et
    <literal>~*</literal>, mais seulement si le modèle débute par des caractères
@@ -315,7 +315,7 @@ SELECT * FROM places ORDER BY location <-> point '(101,456)' LIMIT 10;
 
    (Voir <xref linkend="functions-geometry"/> pour la signification de ces
    opérateurs.)
-   Les classes d'opérateur SP-GiST incluses dans la distribution standard sont
+   Les classes d'opérateurs SP-GiST incluses dans la distribution standard sont
    documentées dans <xref linkend="spgist-builtin-opclasses-table"/>.
    Pour plus d'informations, voir <xref linkend="spgist"/>.
   </para>
@@ -835,7 +835,7 @@ CREATE INDEX test3_desc_index ON test3 (id DESC NULLS LAST);
    valeur courante (qui correspond à plus de quelques pour cents de toutes
    les lignes) n'utilise, de toute façon, pas cet index, il ne sert à rien
    de garder ces lignes dans l'index. Cela réduit la taille de l'index,
-   ce qui accélèrera les requêtes qui l'utilisent. Cela accélère aussi nombre
+   ce qui accélérera les requêtes qui l'utilisent. Cela accélère aussi nombre
    d'opérations de mise à jour de la table, car l'index n'a pas à être
    mis à jour à chaque fois. L'<xref linkend="indexes-partial-ex1"/> montre une
    application possible de cette idée.

--- a/postgresql/information_schema.xml
+++ b/postgresql/information_schema.xml
@@ -28,8 +28,8 @@
    contraintes soient uniques dans un même schéma mais
    <productname>PostgreSQL</productname> ne force pas cette
    restriction. Les noms de contraintes créés automatiquement par
-   <productname>PostgreSQL</productname> évitent les doublons dans le
-   le même schéma mais les utilisateurs peuvent spécifier explicitement
+   <productname>PostgreSQL</productname> évitent les doublons dans
+   le même schéma, mais les utilisateurs peuvent spécifier explicitement
    des noms existant déjà.
   </para>
 
@@ -187,7 +187,7 @@
 
   <para>
    La vue <literal>administrable_role_authorizations</literal>
-   identifie tous les rôles pour lesquelles l'utilisateur courant possède l'option
+   identifie tous les rôles pour lesquels l'utilisateur courant possède l'option
    ADMIN.
   </para>
 
@@ -245,7 +245,7 @@
   <para>
    La vue <literal>applicable_roles</literal> identifie tous les rôles dont
    l'utilisateur courant peut utiliser les droits. Cela signifie qu'il y a
-   certaines chaînes de donnation des droits de l'utilisateur courant au
+   certaines chaînes de délégation des droits de l'utilisateur courant au
    rôle en question. L'utilisateur lui-même est un rôle applicable.
    L'ensemble de rôles applicables est habituellement utilisé pour la
    vérification des droits.
@@ -945,7 +945,7 @@
    de vérification avec une expression <literal>CHECK
    (<replaceable>nom_colonne</replaceable> IS NOT
    NULL)</literal>. Donc les contraintes NOT NULL sont aussi inclus ici, et
-   n'ont pas de vue séparée..
+   n'ont pas de vue séparée.
   </para>
 
   <table>
@@ -7999,7 +7999,7 @@ ORDER BY c.ordinal_position;
    Dans PostgreSQL, les séquences supportent aussi les droits
    <literal>SELECT</literal> et <literal>UPDATE</literal> en plus du droit
    <literal>USAGE</literal>. Ils ne sont pas dans le standard et du coup ils
-   ne sont pas visibles dans le schéma d'informations.
+   ne sont pas visibles dans le schéma d'information.
   </para>
 
   <table>

--- a/postgresql/intagg.xml
+++ b/postgresql/intagg.xml
@@ -53,7 +53,7 @@
 
   <para>
    Un grand nombre de bases de données utilisent la notion de table
-   <quote>plusieurs vers plusieurs</quote> (<foreignphrase>many to
+   <quote>plusieurs-à-plusieurs</quote> (<foreignphrase>many to
    many</foreignphrase>). Ce type de table
    se trouve habituellement entre deux tables indexées, par exemple&nbsp;:
   </para>
@@ -85,7 +85,7 @@ WHERE many_to_many.id_left = <replaceable>item</replaceable>;
    table <structname>many_to_many</structname>. Souvent, une jointure
    de ce type résulte en un parcours d'index et une récupération de chaque
    enregistrement de la table de droite pour une entrée de la table de gauche.
-   Sur un système très dynamique, il n'y a pas grand chose à faire. Au contraire,
+   Sur un système très dynamique, il n'y a pas grand-chose à faire. Au contraire,
    lorsqu'une partie des données est statique, une table de résumé peut être
    créée par agrégation.
   </para>

--- a/postgresql/intarray.xml
+++ b/postgresql/intarray.xml
@@ -19,8 +19,8 @@
  </para>
 
  <para>
-  La plupart des opérations sont seulement intéressants pour des tableaux à
-  une dimension. Bien qu'elles accepteront des tableaux à plusieurs dimensions,
+  La plupart des opérations sont seulement intéressantes pour des tableaux à
+  une dimension. Bien qu'elles acceptent des tableaux à plusieurs dimensions,
   les données sont traitées comme s'il y avait un tableau linéaire.
  </para>
 
@@ -260,7 +260,7 @@
         <returnvalue>integer</returnvalue>
        </para>
        <para>
-        Retourne le nombre d'élements dans le tableau.
+        Retourne le nombre d'éléments dans le tableau.
        </para></entry>
      </row>
 
@@ -402,7 +402,7 @@
   </para>
 
   <para>
-   Deux classes d'opérateur pour index GiST, avec paramètres, sont fournies&nbsp;:
+   Deux classes d'opérateurs pour index GiST, avec paramètres, sont fournies&nbsp;:
    <literal>gist__int_ops</literal> (utilisé par défaut) convient pour des
    tableaux d'ensembles de données de petites et moyennes tailles alors que
    <literal>gist__intbig_ops</literal> utilise une signature plus importante
@@ -435,7 +435,7 @@
   </para>
 
   <para>
-   Il y a aussi une classe d'opérateur GIN,<literal>gin__int_ops</literal>
+   Il y a aussi une classe d'opérateurs GIN,<literal>gin__int_ops</literal>
    supportant les mêmes opérateurs ainsi que <literal>&lt;@</literal>,
    mais qui n'est pas disponible par défaut.
   </para>
@@ -453,7 +453,7 @@
 -- un message peut être dans un ou plusieurs <quote>sections</quote>
 CREATE TABLE message (mid INT PRIMARY KEY, sections INT[], ...);
 
--- crée un index spécialisé with sigature length of 32 bytes
+-- crée un index spécialisé avec une signature de longueur 32 octets
 CREATE INDEX message_rdtree_idx ON message USING GIST (sections gist__intbig_ops (siglen=32));
 
 -- sélectionne les messages dans la section 1 ou 2 - opérateur OVERLAP
@@ -500,7 +500,7 @@ SELECT message.mid FROM message WHERE message.sections @@ '1&amp;2'::query_int;
    et Oleg Bartunov (<email>oleg@sai.msu.su</email>). Voir le
    <ulink url="http://www.sai.msu.su/~megera/postgres/gist">site de
     GiST</ulink> pour des informations supplémentaires. Andrey Oktyabrski a fait
-   un gros travail en ajoutant des nouvelles fonctions et opérateurs.
+   un gros travail en ajoutant de nouvelles fonctions et opérateurs.
   </para>
  </sect2>
 

--- a/postgresql/jit.xml
+++ b/postgresql/jit.xml
@@ -111,7 +111,7 @@
    Pour déterminer si la compilation <acronym>JIT</acronym> doit être
    utilisée, le coût total estimé d'une requête (voir <xref
    linkend="planner-stats-details"/> et <xref
-   linkend="runtime-config-query-constants"/>) est utilisée. Le coût estimé de
+   linkend="runtime-config-query-constants"/>) est utilisé. Le coût estimé de
    la requête sera comparé à la configuration du paramètre <xref
    linkend="guc-jit-above-cost"/>. Si le coût est supérieur, une compilation
    <acronym>JIT</acronym> sera opérée. Deux décisions supplémentaires sont
@@ -201,7 +201,7 @@ SET
    activé, les variables de configuration <xref
    linkend="guc-jit-above-cost"/>, <xref linkend="guc-jit-inline-above-cost"/>
    et <xref linkend="guc-jit-optimize-above-cost"/> déterminent si la
-   compilation <acronym>JIT</acronym> est réalisée our une requête et combien
+   compilation <acronym>JIT</acronym> est réalisée pour une requête et combien
    d'effort est dépensé pour le faire.
   </para>
 

--- a/postgresql/json.xml
+++ b/postgresql/json.xml
@@ -424,7 +424,7 @@ SELECT doc-&gt;'site_name' FROM websites
    fournies, offrant différents compromis entre performances et flexibilité.
   </para>
   <para>
-   La classe d'opérateur GIN par défaut pour <type>jsonb</type> supporte les
+   La classe d'opérateurs GIN par défaut pour <type>jsonb</type> supporte les
    requêtes avec des opérateurs clé-existe <literal>?</literal>,
    <literal>?|</literal> et <literal>?&amp;</literal> et l'opérateur de
    contenance <literal>@&gt;</literal> et les opérations de correspondance
@@ -532,22 +532,22 @@ SELECT jdoc->'guid', jdoc->'name' FROM api WHERE jdoc @? '$.tags[*] ? (@ == "qui
    la recherche d'index en se basant sur les clés et valeurs mentionnées dans
    ces clauses. La chaîne des accesseurs peut être les accesseurs
    <literal>.key</literal>, <literal>[*]</literal>, et
-   <literal>[<replaceable>index</replaceable>]</literal>.  La classe d'opérateur
+   <literal>[<replaceable>index</replaceable>]</literal>.  La classe d'opérateurs
    <literal>jsonb_ops</literal> accepte aussi les accesseurs
    <literal>.*</literal> et <literal>.**</literal>, contrairement à la classe
    d'opérateur <literal>jsonb_path_ops</literal>.
   </para>
   <para>
-   Bien que la classe d'opérateur <literal>jsonb_path_ops</literal> ne supporte
+   Bien que la classe d'opérateurs <literal>jsonb_path_ops</literal> ne supporte
    que les requêtes avec les opérateurs <literal>@&gt;</literal>, <literal>@?</literal>
    et <literal>@@</literal>, elle a des
-   avantages de performances notables par rapport à la classe d'opérateur par
+   avantages de performances notables par rapport à la classe d'opérateurs par
    défaut <literal>jsonb_ops</literal>.  Un index <literal>jsonb_path_ops</literal>
    est généralement bien plus petit qu'un index <literal>jsonb_ops</literal>
    pour les mêmes données, et la spécificité de la recherche est meilleure,
    particulièrement quand les requêtes contiennent des clés qui apparaissent
    fréquemment dans les données. Par conséquent, les opérations de recherche
-   sont généralement plus performantes qu'avec la classe d'opérateur par défaut.
+   sont généralement plus performantes qu'avec la classe d'opérateurs par défaut.
   </para>
 
   <para>
@@ -638,7 +638,7 @@ SELECT jdoc->'guid', jdoc->'name' FROM api WHERE jdoc @? '$.tags[*] ? (@ == "qui
    suivant les mêmes règles que l'argument <literal>path</literal> dans la
    fonction <literal>jsonb_set</literal>. Si une valeur <type>jsonb</type>
    est un tableau, les indices numériques commencent à zéro, et les nombres
-   négatifs comptent àpartir du dernier élément du tableau. Les expressions
+   négatifs comptent à partir du dernier élément du tableau. Les expressions
    d'intervalle ne sont pas acceptées. Le résultat d'une expression par
    indice est toujours du type de données jsonb.
   </para>
@@ -653,7 +653,7 @@ SELECT jdoc->'guid', jdoc->'name' FROM api WHERE jdoc @? '$.tags[*] ? (@ == "qui
    ['a']</literal> et <literal>val['a']['b']</literal> sont des objets. Si
    <literal>val['a']</literal> ou <literal>val['a']['b']</literal> ne sont
    pas définis, il sera créé comme un objet vide et rempli comme nécessaire.
-   Néanoins, si <literal>val</literal> lui-même ou une des valeurs
+   Néanmoins, si <literal>val</literal> lui-même ou une des valeurs
    intermédiaires est défini comme un non-objet (une chaîne, un nombre ou le
    <literal>null</literal> <literal>jsonb</literal>), la traversée ne peut
    pas continuer, donc une erreur est levée et la transaction est annulée.

--- a/postgresql/keywords.xml
+++ b/postgresql/keywords.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appendix id="sql-keywords-appendix">
- <title>Mots-clé <acronym>SQL</acronym></title>
+ <title>Mots-clés <acronym>SQL</acronym></title>
 
  <indexterm zone="sql-keywords-appendix">
   <primary>mot-clé</primary>
@@ -9,25 +9,25 @@
 
  <para>
   La <xref linkend="keywords-table"/> liste tous les éléments qui sont
-  des mots-clé dans le standard SQL et dans
+  des mots-clés dans le standard SQL et dans
   <productname>PostgreSQL</productname> &version;.  Des informations
   sous-jacentes peuvent être trouvées dans
   <xref linkend="sql-syntax-identifiers"/>.
-  (Par soucis d'économie d'espace, seules les deux dernières versions du standard SQL, et
+  (Par souci d'économie d'espace, seules les deux dernières versions du standard SQL, et
   de SQL-92 par comparaison, sont incluses. Les différences entre ces deux versions
   et les versions intermédiaires du standard SQL sont minimes.)
  </para>
 
  <para>
-  SQL distingue les mots-clé <firstterm>réservés</firstterm> et
+  SQL distingue les mots-clés <firstterm>réservés</firstterm> et
   <firstterm>non réservés</firstterm>. Selon le standard,
-  les mots-clé réservés sont réellement les seuls mots-clé&nbsp;; ils ne
-  sont jamais autorisés comme identifiants. Les mots-clé non réservés
+  les mots-clés réservés sont réellement les seuls mots-clés&nbsp;; ils ne
+  sont jamais autorisés comme identifiants. Les mots-clés non réservés
   ont seulement un sens spécial dans certains contextes et peuvent
   être utilisés comme identifiants dans d'autres contextes. La
-  plupart des mots-clé non réservés sont en fait les noms des tables
+  plupart des mots-clés non réservés sont en fait les noms des tables
   et des fonctions prédéfinies spécifiés par SQL.  Le concept de
-  mots-clé non réservés existe seulement pour indiquer que certains
+  mots-clés non réservés existe seulement pour indiquer que certains
   sens prédéfinis sont attachés à un mot dans certains contextes.
  </para>
 
@@ -37,7 +37,7 @@
   allant de ceux que l'on ne peut jamais utiliser comme identifiants à
   ceux qui n'ont absolument aucun statut spécial dans l'analyseur, mais
   sont considérés comme des identifiants ordinaires (c'est généralement le cas
-  pour les fonctions spécifiées par SQL). Même les mots-clé réservés ne
+  pour les fonctions spécifiées par SQL). Même les mots-clés réservés ne
   sont pas complètement réservés dans
   <productname>PostgreSQL</productname> et peuvent être utilisés
   comme noms des colonnes (par exemple, <literal>SELECT 55 AS
@@ -47,16 +47,16 @@
  <para>
   Dans <xref linkend="keywords-table"/>, dans la colonne pour
   <productname>PostgreSQL</productname>, nous classons comme
-  <quote>non réservé</quote> les mots-clé qui sont explicitement
+  <quote>non réservé</quote> les mots-clés qui sont explicitement
   connus par l'analyseur mais qui sont autorisés en tant que noms de colonnes
-  ou de tables.  Certains mots-clé qui sont
+  ou de tables. Certains mots-clés qui sont
   non réservés et qui ne peuvent pas être utilisés comme un nom de
   fonction ou un type de données sont marqués en conséquence. (La
   plupart des mots représentent des fonctions prédéfinies ou des types
   de données avec une syntaxe spéciale. La fonction ou le type est
   toujours disponible mais il ne peut pas être redéfini par un
   utilisateur.)  Les <quote>réservés</quote> sont des éléments qui ne sont pas
-  autorisés en tant que noms de colonne ou de table. Certains mots-clé
+  autorisés en tant que noms de colonne ou de table. Certains mots-clés
   réservés sont autorisés comme noms pour les fonctions et les types de
   données&nbsp;; cela est également montré dans le tableau. Dans le cas
   contraire, un mot clé réservé est seulement autorisé dans un label de

--- a/postgresql/libpgtcl.xml
+++ b/postgresql/libpgtcl.xml
@@ -134,7 +134,7 @@
      large</primary><secondary>en pgctl</secondary></indexterm> Les fonctions sont conçues pour imiter les
    fonctions analogues du système de fichier dans l'interface standard des
    systèmes de fichiers Unix. Les commandes <function>pg_lo_*</function>
-   devraient être utiliser à l'intérieur d'un bloc de transaction
+   devraient être utilisées à l'intérieur d'un bloc de transaction
    <command>BEGIN</command>/<command>COMMIT</command> car le descripteur
    renvoyé par <function>pg_lo_open</function> n'est valide que pour la
    transaction en cours. <function>pg_lo_import</function> et
@@ -151,7 +151,7 @@
   <para>
    Avant d'utiliser les commandes <application>pgtcl</application>, vous devez
    charger la bibliothèque <filename>libpgtcl</filename> dans votre application Tcl.
-   Ceci se fait normalement avec la commande <literal>load</literal> command. Voici un
+   Ceci se fait normalement avec la commande <literal>load</literal>. Voici un
    exemple&nbsp;:
 
    <programlisting>load libpgtcl[info sharedlibextension]

--- a/postgresql/libpq.xml
+++ b/postgresql/libpq.xml
@@ -119,7 +119,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
        des paramètres peut être étendu sans changer la signature de la fonction
        donc son utilisation (ou ses versions non bloquantes, à savoir
        <xref linkend="libpq-PQconnectStartParams"/> et
-       <function>PQconnectPoll</function>) est recommendée pour les nouvelles
+       <function>PQconnectPoll</function>) est recommandée pour les nouvelles
        applications.
       </para>
 
@@ -150,7 +150,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
        (<literal>=</literal>) ou si elle commence avec un désignateur de
        schéma URI. (Vous trouverez plus de détails sur les formats de chaîne
        de connexion dans <xref linkend="libpq-connstring"/>.) Seule la première
-       occurence de <parameter>dbname</parameter> est traitée de cette
+       occurrence de <parameter>dbname</parameter> est traitée de cette
        façon&nbsp;; tout paramètre <parameter>dbname</parameter>
        supplémentaire est traité comme un simple nom de base.
       </para>
@@ -177,7 +177,7 @@ PGconn *PQconnectdbParams(const char * const *keywords,
        configurés sont remplis avec leur valeurs par défaut. Si une variable
        d'environnement d'un paramètre non configuré (voir <xref
        linkend="libpq-envars"/>) est configuré, sa valeur est utilisée. Si la
-       variable denvironnement n'est pas configurée, alors la valeur par
+       variable d'environnement n'est pas configurée, alors la valeur par
        défaut interne du paramètre est utilisée.
       </para>
 
@@ -672,7 +672,7 @@ typedef struct
      <term><function>PQconninfoParse</function><indexterm><primary>PQconninfoParse</primary></indexterm></term>
      <listitem>
       <para>
-       Renvoit les options de connexions analysées d'après la chaîne de
+       Renvoie les options de connexions analysées d'après la chaîne de
        connexion fournie.
 
        <synopsis>
@@ -682,7 +682,7 @@ typedef struct
 
       <para>
        Analyse une chaîne de connexion et renvoie les options résultantes
-       dans un tableau&nbsp;; renvoit <symbol>NULL</symbol> si un problème a été détecté avec
+       dans un tableau&nbsp;; renvoie <symbol>NULL</symbol> si un problème a été détecté avec
        la chaîne de connexion. Ceci peut être utilisé pour déterminer les
        options de <xref linkend="libpq-PQconnectdb"/> dans la chaîne de connexion
        fournie. La valeur de retour pointe vers un tableau de structures
@@ -1058,7 +1058,7 @@ PQsslKeyPassHook_OpenSSL_type PQgetSSLKeyPassHook_OpenSSL(void);
  postgresql://autre@localhost/autre_base?connect_timeout=10&amp;application_name=mon_appli
  postgresql://host1:123,host2:456/somedb?target_session_attrs=any&amp;application_name=myapp
      </programlisting>
-     Les valeurs qui apparaitraient normalement dans la partie hiérarchique de
+     Les valeurs qui apparaîtraient normalement dans la partie hiérarchique de
      l'<acronym>URI</acronym> peuvent être aussi données sous la forme de
      paramètres nommés. Par exemple&nbsp;:
      <programlisting>
@@ -1143,7 +1143,7 @@ postgresql://user@localhost:5433/mydb?options=-c%20synchronous_commit%3Doff
     </para>
 
     <para>
-     Quelque soit le format, un simple nom
+     Quel que soit le format, un simple nom
      d'hôte peut aussi se traduire en plusieurs adresses réseau. Un exemple
      habituel est un hôte qui a à la fois une adresse IPv4 et une adresse
      IPv6.
@@ -2376,7 +2376,7 @@ postgresql://user@localhost:5433/mydb?options=-c%20synchronous_commit%3Doff
         et adresses disponibles. Une fois qu'une tentative réussit, aucun autre
         hôte ou adresse ne sera testé. Ce paramètre est typiquement utilisé en
         combinaison avec plusieurs noms d'hôtes ou un enregistement DSN qui
-        renvoit plusieurs IP. Ce paramètre peut être utiliser avec
+        renvoie plusieurs IP. Ce paramètre peut être utiliser avec
         <xref linkend="libpq-connect-target-session-attrs"/> pour réaliser de
         la répartition de charge uniquement sur les serveurs secondaires. Une
         fois connecté avec succès, les requêtes suivants sur cette connexion
@@ -4744,7 +4744,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       </para>
 
       <para>
-       En cas d'erreur, <xref linkend="libpq-PQescapeLiteral"/> renvoit
+       En cas d'erreur, <xref linkend="libpq-PQescapeLiteral"/> renvoie
        <symbol>NULL</symbol> et
        un message adéquat est stocké dans l'objet
        <parameter>conn</parameter>.
@@ -4796,7 +4796,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       </para>
 
       <para>
-       <xref linkend="libpq-PQescapeIdentifier"/> renvoit une version du paramètre
+       <xref linkend="libpq-PQescapeIdentifier"/> renvoie une version du paramètre
        <parameter>str</parameter> échappée comme doit l'être un identifiant SQL,
        dans une mémoire allouée avec <function>malloc()</function>. Cette
        mémoire doit être libérée en utilisant <function>PQfreemem()</function>
@@ -4813,7 +4813,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       </para>
 
       <para>
-       En cas d'erreur, <xref linkend="libpq-PQescapeIdentifier"/> renvoit
+       En cas d'erreur, <xref linkend="libpq-PQescapeIdentifier"/> renvoie
        <symbol>NULL</symbol> et
        un message d'erreur adéquat est stocké dans l'objet
        <parameter>conn</parameter>.
@@ -4882,7 +4882,7 @@ char *PQresultVerboseErrorMessage(const PGresult *res,
       </para>
 
       <para>
-       <xref linkend="libpq-PQescapeStringConn"/> renvoit le nombre d'octets écrits
+       <xref linkend="libpq-PQescapeStringConn"/> renvoie le nombre d'octets écrits
        dans <parameter>to</parameter>, sans inclure l'octet zéro final.
       </para>
      </listitem>
@@ -6125,8 +6125,8 @@ UPDATE mytable SET x = x + 1 WHERE id = 42;
    réussi à <xref linkend="libpq-PQsendQuery"/> (ou une fonction similaire).
    Cette sélection de mode ne fonctionne que pour la requête en cours
    d'exécution. Puis appelez <xref linkend="libpq-PQgetResult"/> de façon répétée,
-   jusqu'à ce qu'elle renvoit NULL, comme documenté dans <xref
-   linkend="libpq-async"/>. Si la requête renvoit des lignes, elles sont renvoyées
+   jusqu'à ce qu'elle renvoie NULL, comme documenté dans <xref
+   linkend="libpq-async"/>. Si la requête renvoie des lignes, elles sont renvoyées
    en tant qu'un ou plusieurs objets <structname>PGresult</structname>, qui ressemblent
    à des résultats de requêtes standards en dehors du fait qu'elles ont le code
    de statut <literal>PGRES_SINGLE_TUPLE</literal> pour le mode ligne simple ou
@@ -6136,11 +6136,11 @@ UPDATE mytable SET x = x + 1 WHERE id = 42;
    <literal>PGRES_TUPLES_CHUNK</literal> contient au moins une ligne mais pas
    plus du nombre spécifié de lignes par morceau. Après la
    dernière ligne, ou immédiatement
-   si la requête ne renvoit aucune ligne, un objet à zéro ligne avec le statut
+   si la requête ne renvoie aucune ligne, un objet à zéro ligne avec le statut
    <literal>PGRES_TUPLES_OK</literal> est renvoyé&nbsp;; c'est le signal
    qu'aucune autre ligne ne va arriver. (Notez cependant qu'il est toujours
    nécessaire de continuer à appeler <xref linkend="libpq-PQgetResult"/> jusqu'à
-   ce qu'elle renvoit NULL.) Tous les objets <structname>PGresult</structname>
+   ce qu'elle renvoie NULL.) Tous les objets <structname>PGresult</structname>
    contiendront les mêmes données de description de lignes (noms de colonnes,
    types, etc.) qu'un objet <structname>PGresult</structname> standard aurait
    pour cette requête. Chaque objet doit être libéré avec la fonction
@@ -6210,7 +6210,7 @@ int PQsetChunkedRowsMode(PGconn *conn, int chunkSize);
        <xref linkend="libpq-PQconsumeInput"/> ou
        <xref linkend="libpq-PQgetResult"/>. Si elle est appelée au bon moment,
        la fonction active le mode ligne-à-ligne pour la requête en cours et
-       renvoit 1. Sinon, le mode reste inchangé et la fonction renvoit 0. Dans
+       renvoie 1. Sinon, le mode reste inchangé et la fonction renvoie 0. Dans
        tous les cas, le mode retourne à la normale après la fin de la requête
        en cours.
       </para>
@@ -6224,7 +6224,7 @@ int PQsetChunkedRowsMode(PGconn *conn, int chunkSize);
     Lors du traitement d'une requête, le serveur peut renvoyer quelques
     lignes puis rencontrer une erreur, causant l'annulation de la requête.
     D'ordinaire, la bibliothèque partagée <application>libpq</application>
-    jette ces lignes et renvoit une erreur. Avec le mode ligne-à-ligne ou le
+    jette ces lignes et renvoie une erreur. Avec le mode ligne-à-ligne ou le
     mode par morceau,
     certaines lignes ont déjà pu être envoyées à l'application. Du coup, l'application
     verra quelques objets <structname>PGresult</structname> de statut
@@ -7873,7 +7873,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
      <para>
       C'est une fonction interne de la <application>libpq</application> pour
       allouer et initialiser un objet <structname>PGresult</structname> vide.
-      Cette fonction renvoit NULL si la mémoire n'a pas pu être allouée. Elle
+      Cette fonction renvoie NULL si la mémoire n'a pas pu être allouée. Elle
       est exportée car certaines applications trouveront utiles de générer
       elles-mêmes des objets de résultat (tout particulièrement ceux avec des
       statuts d'erreur). Si <parameter>conn</parameter> n'est pas <symbol>NULL</symbol> et que
@@ -7898,7 +7898,7 @@ char *PQencryptPassword(const char *passwd, const char *user);
      <para>
       Déclenche un événement <literal>PGEVT_RESULTCREATE</literal> (voir <xref
       linkend="libpq-events"/>) pour chaque procédure d'événement enregistrée
-      dans l'objet <structname>PGresult</structname>. Renvoit autre chose que
+      dans l'objet <structname>PGresult</structname>. Renvoie autre chose que
       zéro en cas de succès, zéro si une des procédures d'événement échoue.
 
       <synopsis>
@@ -8321,7 +8321,7 @@ pg_usec_time_t PQgetCurrentTimeUSec(void);
        <structname>PGconn</structname> qui doit être dans le statut
        <literal>CONNECTION_OK</literal>&nbsp;; garanti si
        <xref linkend="libpq-PQregisterEventProc"/> est appelé juste après avoir
-       obtenu un bon <structname>PGconn</structname>. Lorsqu'elle renvoit
+       obtenu un bon <structname>PGconn</structname>. Lorsqu'elle renvoie
        un code d'erreur, le nettoyage doit être réalisé car aucun événement
        <literal>PGEVT_CONNDESTROY</literal> ne sera envoyé.
       </para>
@@ -8592,7 +8592,7 @@ pg_usec_time_t PQgetCurrentTimeUSec(void);
        l'<literal>instanceData</literal> de la connexion
        <parameter>conn</parameter> pour la
        procédure <parameter>proc</parameter>.
-       Cette fonction renvoit zéro en cas d'échec et autre chose en cas de réussite.
+       Cette fonction renvoie zéro en cas d'échec et autre chose en cas de réussite.
        (L'échec est seulement possible si <parameter>proc</parameter> n'a pas
        été correctement enregistré dans <parameter>conn</parameter>.)
 
@@ -8626,7 +8626,7 @@ pg_usec_time_t PQgetCurrentTimeUSec(void);
        Initialise avec <parameter>data</parameter>
        l'<literal>instanceData</literal> du résultat pour la
        procédure <parameter>proc</parameter>.
-       Cette fonction renvoit zéro en cas d'échec et autre chose en cas de réussite.
+       Cette fonction renvoie zéro en cas d'échec et autre chose en cas de réussite.
        (L'échec est seulement possible si <parameter>proc</parameter> n'a pas
        été correctement enregistré dans le résultat.)
 

--- a/postgresql/limits.xml
+++ b/postgresql/limits.xml
@@ -57,7 +57,7 @@
     <row>
      <entry>colonnes par table</entry>
      <entry>1600</entry>
-     <entry>aussi limité par la taille des lignes contenues dans un simple bloc&nbsp;; voir la note ci dessous
+     <entry>aussi limité par la taille des lignes contenues dans un simple bloc&nbsp;; voir la note ci-dessous
      </entry>
     </row>
 
@@ -74,7 +74,7 @@
     </row>
 
     <row>
-     <entry>taille d'un champs</entry>
+     <entry>taille d'un champ</entry>
      <entry>1 Go</entry>
      <entry></entry>
     </row>
@@ -120,7 +120,7 @@
 
  <para>
   Le nombre maximum de colonnes pour une table est d'autant plus réduit que la
-  ligne stockée doit être contenu dans un simple bloc de 8192 octets.
+  ligne stockée doit être contenue dans un simple bloc de 8192 octets.
   Par exemple, sans compter l'entête d'une ligne, une ligne constituée de 1600 colonnes de type
   <type>int</type> consommera 6400 octets et peut être stocké dans un bloc, mais une ligne
   constituée de 1600 colonnes de type <type>bigint</type> consommera 12800 octets et
@@ -155,12 +155,12 @@
  <para>
   Chaque table peut enregistrer un maximum théorique de 2^32 valeurs hors
   ligne&nbsp;; voir <xref linkend="storage-toast" /> pour une discussion
-  détaillée du stockahe hors ligne. Cette limitevient de l'utilisation d'un
+  détaillée du stockage hors ligne. Cette limite vient de l'utilisation d'un
   OID sur 32 bits pour identifier chaque valeur. La limite pratique est
   significativement moindre que la limite théorique parce qu'au fur et à mesure
-  que l'espace OID se remplit, trouver nu OID toujours libre devient coûteux,
+  que l'espace OID se remplit, trouver un OID toujours libre devient coûteux,
   ralentissant de ce fait les instructions INSERT/UPDATE. Typiquement, c'est
-  seulement un problème pour les tables contenant plusieurs téra-octets de
+  seulement un problème pour les tables contenant plusieurs téraoctets de
   données&nbsp;; partitionner est un contournement possible.
  </para>
 </appendix>

--- a/postgresql/lo.xml
+++ b/postgresql/lo.xml
@@ -51,7 +51,7 @@
    Le module <filename>lo</filename> permet de corriger ceci en attachant un
    trigger aux tables contenant des colonnes de référence des LO. Le trigger
    fait essentiellement un <function>lo_unlink</function> quand vous supprimez
-   ou modifiez une valeur référence un <quote>Large Object</quote>. Quand vous
+   ou modifiez une valeur référencée un <quote>Large Object</quote>. Quand vous
    utilisez ce trigger, vous supposez que, dans toute la base de données, il
    n'existe qu'une seule référence d'un <quote>Large Object</quote> référencé
    dans une colonne contrôlée par un trigger&nbsp;!
@@ -126,7 +126,7 @@
 
    <listitem>
     <para>
-     Quelques interfaces peuvent créer leur propres tables et n'ajouteront pas
+     Quelques interfaces peuvent créer leurs propres tables et n'ajouteront pas
      les triggers associés. De plus, les utilisateurs peuvent oublier de créer
      les triggers, ou ne pas savoir le faire.
     </para>

--- a/postgresql/lobj.xml
+++ b/postgresql/lobj.xml
@@ -107,7 +107,7 @@
    Cette section décrit les possibilités de la bibliothèque d'interface client
    <application>libpq</application> de <productname>PostgreSQL</productname>
    permettant d'accéder aux « Large Objects ». L'interface des « Large
-   Objects » de <productname>PostgreSQL</productname> est modelé d'après
+   Objects » de <productname>PostgreSQL</productname> est modelée d'après
    l'interface des systèmes de fichiers <acronym>Unix</acronym> avec des
    analogies pour les fonctions <function>open</function>,
    <function>read</function>, <function>write</function>,
@@ -125,7 +125,7 @@
 
   <para>
    Si une erreur survient lors de l'exécution de ces fonctions, la fonction
-   renverra une valeur autrement impossible, typiquement 0 or -1. Un message
+   renverra une valeur autrement impossible, typiquement 0 ou -1. Un message
    décrivant l'erreur est stocké dans l'objet de connexion et peut être
    récupéré avec la fonction <xref linkend="libpq-PQerrorMessage"/>.
   </para>
@@ -292,7 +292,7 @@
     le descripteur et la donnée lue à partir de ce dernier, reflètera le
     contenu du «&nbsp;Large Object&nbsp;» au moment où
     <function>lo_open</function> a été exécuté dans la transaction active,
-    quelques soient les possibles écritures par cette transaction ou par
+    quelles que soient les possibles écritures par cette transaction ou par
     d'autres. Lire à partir d'un descripteur ouvert avec
     <symbol>INV_WRITE</symbol> renvoie des données reflétant toutes les
     écritures des autres transactions validées ainsi que les écritures de la
@@ -463,8 +463,8 @@
     <parameter>len</parameter> est plus grande que la longueur actuelle du
     «&nbsp;Large Object&nbsp;», ce dernier est étendu à la longueur spécifiée
     avec des octets nuls ('\0'). En cas de succès,
-    <function>lo_truncate</function> renvoit 0. En cas d'erreur, il
-    renvoit -1.
+    <function>lo_truncate</function> renvoie 0. En cas d'erreur, il
+    renvoie -1.
    </para>
 
    <para>

--- a/postgresql/logical-replication.xml
+++ b/postgresql/logical-replication.xml
@@ -1831,7 +1831,7 @@ CONTEXT:  processing remote data for replication origin "pg_16395" during "INSER
      que les opérations <literal>UPDATE</literal> et <literal>DELETE</literal>
      ne peuvent être appliquées aux abonnés si les tables incluent des
      attributs avec les types de données (tels que point ou box) qui n'ont pas
-     une classe d'opérateur par défaut pour les méthodes B-tree ou Hash.
+     une classe d'opérateurs par défaut pour les méthodes B-tree ou Hash.
      Néanmoins, cette limitation peut être contournée en s'assurant que la
      table a une clé primaire ou une identité de réplica.
     </para>

--- a/postgresql/logicaldecoding.xml
+++ b/postgresql/logicaldecoding.xml
@@ -366,7 +366,7 @@ postgres=# select * from pg_logical_slot_get_changes('regression_slot', NULL, NU
 
    <caution>
     <para>
-     Les slots de réplications persistent après un arrêt brutal et ne
+     Les slots de réplication persistent après un arrêt brutal et ne
      connaissent rien de l'état de leur(s) consommateur(s). Ils empêcheront
      la suppression automatique des ressources nécessaires même si aucune
      connexion ne les utilise. Cela consomme de l'espace car aucun des
@@ -696,7 +696,7 @@ CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);<
     cas d'utilisation, comme la visualisation des changements en SQL, le
     renvoi des données dans un type de données qui peut contenir des données
     arbitraires (par exemple du <type>bytea</type>) est complexe. Si le
-    plugin en sortie renvoit seulement les données au format texte dans
+    plugin en sortie renvoie seulement les données au format texte dans
     l'encodage du serveur, il peut déclarer cela en configurant
     <literal>OutputPluginOptions.output_type</literal> à
     <literal>OUTPUT_PLUGIN_TEXTUAL_OUTPUT</literal> au lieu de
@@ -763,7 +763,7 @@ CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);<
                                         OutputPluginOptions *options,
                                         bool is_init);</programlisting>
 
-     Le paramètre <literal>is_init</literal> sera positioné à true quand le
+     Le paramètre <literal>is_init</literal> sera positionné à true quand le
      slot de réplication est créé, et à false sinon.
      <parameter>options</parameter> pointe vers une structure d'options que
      le plugin de sortie peut positionner&nbsp;:
@@ -929,7 +929,7 @@ CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);<
     <para>
      Ceci est utile pour implémenter des solutions de réplication en cascade
      ou des solutions de réplication multi-directionnelles. Filtrer par
-     rapport à l'origine perment d'empêcher la réplication dans les deux
+     rapport à l'origine permet d'empêcher la réplication dans les deux
      sens des mêmes modifications dans ce type de configuration. Quand les
      transactions et les modifications contiennent aussi des informations sur
      l'origine, le filtre via cette fonction est beaucoup plus efficace.
@@ -1040,7 +1040,7 @@ CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);<
     <para>
      La fonction callback requise <function>prepare_cb</function> est appelée
      à chaque fois qu'une transaction préparée pour une validation en deux
-     pahses a été décodée. La fonction callback
+     phrases a été décodée. La fonction callback
      <function>change_cb</function> sera appelée avant celle-ci pour toutes
      les lignes modifiées, à condition que des lignes aient été modifiées. Le
      champ <parameter>gid</parameter>, qui fait partie du paramètre
@@ -1080,7 +1080,7 @@ CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);<
      utilisé dans cette fonction callback. Les paramètres
      <parameter>prepare_end_lsn</parameter> et
      <parameter>prepare_time</parameter> peuvent être utilisés pour vérifier
-     si le plugin a reça la commande <command>PREPARE TRANSACTION</command>
+     si le plugin a reçu la commande <command>PREPARE TRANSACTION</command>
      auquel cas il peut appliquer l'annulation. Sinon, il peut ignorer
      l'opération d'annulation. Le paramètre <parameter>gid</parameter> seul
      n'est pas suffisant parce que le nœud en amont peut avoir une
@@ -1183,7 +1183,7 @@ CREATE TABLE autre_table_catalogue(data text) WITH (user_catalog_table = true);<
     <title>Fonction de message du flux</title>
 
     <para>
-     La fonction callback <function>stream_message_cb</function> optionnalle
+     La fonction callback <function>stream_message_cb</function> optionnelle
      est appelée
      lors de l'envoi d'un message générique dans un bloc de changements en
      flux (démarqué par des appels à <function>stream_start_cb</function> et
@@ -1332,7 +1332,7 @@ OutputPluginWrite(ctx, true);</programlisting>
       <para>
        <command>PREPARE TRANSACTION</command> après une commande
        <command>LOCK</command> sur <structname>pg_class</structname> et
-       autoriser le décodage logiques des transactions en deux phases&nbsp;;
+       autoriser le décodage logique des transactions en deux phases&nbsp;;
       </para>
      </listitem>
 
@@ -1340,7 +1340,7 @@ OutputPluginWrite(ctx, true);</programlisting>
       <para>
        <command>PREPARE TRANSACTION</command> après une commande
        <command>CLUSTER</command> sur <structname>pg_trigger</structname> et
-       autoriser le décodage logiques des transactions en deux phases. Ceci
+       autoriser le décodage logique des transactions en deux phases. Ceci
        amènera un deadlock seulement quand la table publiée a un trigger&nbsp;;
       </para>
      </listitem>

--- a/postgresql/ltree.xml
+++ b/postgresql/ltree.xml
@@ -26,7 +26,7 @@
    Un <firstterm>label</firstterm> est une séquence de caractères alphanumériques,
    tirets bas, et traits d'union. L'ensemble des caractères alphanumériques
    valides est dépendant de la locale de la base. Par exemple, dans la locale C,
-   les caractères <literal>A-Za-z0-9_-</literal> sont autorisées. Les labels ne
+   les caractères <literal>A-Za-z0-9_-</literal> sont autorisés. Les labels ne
    doivent pas avoir plus de 1000 caractères.
   </para>
 
@@ -39,7 +39,7 @@
    ou plusieurs labels séparés par des points, par exemple
    <literal>L1.L2.L3</literal>, ce qui représente le chemin de la racine
    jusqu'à un nœud particulier. La longueur d'un chemin
-   est limité à 65535 labels.
+   est limitée à 65535 labels.
   </para>
 
   <para>
@@ -264,7 +264,7 @@ a.  b.     c.      d.                   e.
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
-        Est-ce que <type>ltree</type> établie une correspondance avec
+        Est-ce que <type>ltree</type> établit une correspondance avec
         <type>lquery</type>&nbsp;??
        </para></entry>
      </row>
@@ -279,7 +279,7 @@ a.  b.     c.      d.                   e.
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
-        Est-ce que <type>ltree</type> établie une correspondance avec au moins un
+        Est-ce que <type>ltree</type> établit une correspondance avec au moins un
         <type>lquery</type> dans ce tableau&nbsp;?
        </para></entry>
      </row>
@@ -294,7 +294,7 @@ a.  b.     c.      d.                   e.
         <returnvalue>boolean</returnvalue>
        </para>
        <para>
-        Est-ce que <type>ltree</type> établie une correspondance avec
+        Est-ce que <type>ltree</type> établit une correspondance avec
         <type>ltxtquery</type>&nbsp;?
        </para></entry>
      </row>
@@ -446,7 +446,7 @@ a.  b.     c.      d.                   e.
   </table>
 
   <para>
-   Lesopérateurs operators <literal>&lt;@</literal>, <literal>@&gt;</literal>,
+   Les opérateurs operators <literal>&lt;@</literal>, <literal>@&gt;</literal>,
    <literal>@</literal> et <literal>~</literal> ont des versions analogues
    <literal>^&lt;@</literal>, <literal>^@&gt;</literal>, <literal>^@</literal>,
    <literal>^~</literal>, qui sont identiques sauf qu'elles n'utilisent pas les
@@ -553,7 +553,7 @@ a.  b.     c.      d.                   e.
         <returnvalue>integer</returnvalue>
        </para>
        <para>
-        Retourne la position de la première occurence de <parameter>b</parameter>
+        Retourne la position de la première occurrence de <parameter>b</parameter>
         dans <parameter>a</parameter>, ou -1 si non trouvé.
        </para>
        <para>
@@ -568,7 +568,7 @@ a.  b.     c.      d.                   e.
         <returnvalue>integer</returnvalue>
        </para>
        <para>
-        Retourne la position de la première occurence de <parameter>b</parameter>
+        Retourne la position de la première occurrence de <parameter>b</parameter>
         dans <parameter>a</parameter>, ou -1 si non trouvé. La recherche débute à
         la position <parameter>offset</parameter>&nbsp;; un <parameter>offset</parameter> négatif
         indique un départ à <parameter>-offset</parameter> label depuis la fin du chemin.
@@ -639,7 +639,7 @@ a.  b.     c.      d.                   e.
   <title>Index</title>
   <para>
    <filename>ltree</filename> accepte différents types d'index pouvant
-   améliorer les performances des oopérateurs indiqués&nbsp;:
+   améliorer les performances des opérateurs indiqués&nbsp;:
   </para>
 
   <itemizedlist>
@@ -660,7 +660,7 @@ a.  b.     c.      d.                   e.
 
    <listitem>
     <para>
-     Index GiST sur <type>ltree</type> (classe d'opérateur
+     Index GiST sur <type>ltree</type> (classe d'opérateurs
      <literal>gist_ltree_ops</literal>)&nbsp;:
      <literal>&lt;</literal>, <literal>&lt;=</literal>, <literal>=</literal>,
      <literal>&gt;=</literal>, <literal>&gt;</literal>,
@@ -668,11 +668,11 @@ a.  b.     c.      d.                   e.
      <literal>@</literal>, <literal>~</literal>, <literal>?</literal>
     </para>
     <para>
-     La classe d'opérateur GiST <literal>gist_ltree_ops</literal> effectue une
+     La classe d'opérateurs GiST <literal>gist_ltree_ops</literal> effectue une
      approximation sur un ensemble de chemins de labels sous format de
      signature bitmap. La taille de la signature par défaut est 8 octets.
      La longueur doit être un multiple positif de l'alignement d'un type
-     <type>int</type> (4 octets sur la plupart des most machines) jusqu'à 2024.
+     <type>int</type> (4 octets sur la plupart des machines) jusqu'à 2024.
      Des tailles de signatures plus longues permettent une recherche plus précise (en
      parcourant une fraction plus petite de l'index et moins de pages heap), au coût
      d'un plus large index.
@@ -694,13 +694,13 @@ CREATE INDEX path_gist_idx ON test USING GIST (path gist_ltree_ops(siglen=100));
    </listitem>
    <listitem>
     <para>
-     Index GiST sur <type>ltree[]</type> (classe d'opérateur
+     Index GiST sur <type>ltree[]</type> (classe d'opérateurs
      <literal>gist__ltree_ops</literal>&nbsp;:
      <literal>ltree[] &lt;@ ltree</literal>, <literal>ltree @&gt; ltree[]</literal>,
      <literal>@</literal>, <literal>~</literal>, <literal>?</literal>
     </para>
     <para>
-     La classe d'opérateur GiST <literal>gist__ltree_ops</literal> fonctionne
+     La classe d'opérateurs GiST <literal>gist__ltree_ops</literal> fonctionne
      de façon similaire à <literal>gist_ltree_ops</literal> et aussi prend
      une taille de signature en paramètre. La valeur par défaut de
      <literal>siglen</literal> dans <literal>gist__ltree_ops</literal> est 28
@@ -843,7 +843,7 @@ ltreetest=&gt; SELECT subpath(path,0,2)||'Space'||subpath(path,2) FROM test WHER
 
   <para>
    Nous pouvons simplifier ceci en créant une fonction SQL qui insère un
-   label à une position spécifié dans un chemin&nbsp;:
+   label à une position spécifiée dans un chemin&nbsp;:
   </para>
   <screen>
 CREATE FUNCTION ins_label(ltree, int, text) RETURNS ltree
@@ -873,7 +873,7 @@ ltreetest=&gt; SELECT ins_label(path,2,'Space') FROM test WHERE path &lt;@ 'Top.
 
   <caution>
    <para>
-    Il est fortement recommandée que l'extension de transformation soit
+    Il est fortement recommandé que l'extension de transformation soit
     installée dans le même schéma que <filename>ltree</filename>. Sinon il
     existe un risque au moment de l'installation si le schéma de l'extension de
     transformation contient des objets définis par un utilisateur hostile.

--- a/postgresql/maintenance.xml
+++ b/postgresql/maintenance.xml
@@ -346,7 +346,7 @@
     les autres en fonction des besoins de l'application. Quoi qu'il en soit,
     dans la pratique, il est généralement mieux de simplement analyser la
     base entière car il s'agit d'une opération rapide.
-    <command>ANALYZE</command> utilise un système d'échantillonage des lignes
+    <command>ANALYZE</command> utilise un système d'échantillonnage des lignes
     d'une table, ce qui lui évite de lire chaque ligne.
    </para>
 
@@ -1053,7 +1053,7 @@ limite insertion vacuum = limite insertion base vacuum + facteur échelle insert
    <para>
     Les tables partitionnées ne contiennent pas de lignes et ne sont donc
     pas traitées par l'autovacuum. (L'autovacuum traite les partitions
-    comme n'importe quel autre table.)) Malheureusement, ceci signifie
+    comme toute autre table.)) Malheureusement, ceci signifie
     que l'autovacuum n'exécute pas d'<command>ANALYZE</command> sur les tables
     partitionnées, et ceci peut occasionner des plans non optimaux pour les
     requêtes qui référencent les statistiques de la table partitionnée. Vous
@@ -1135,7 +1135,7 @@ limite insertion vacuum = limite insertion base vacuum + facteur échelle insert
   </para>
 
   <para>
-   Les blocs devenues complètement vides d'un index B-tree sont réclamées pour
+   Les blocs devenus complètement vides d'un index B-tree sont réclamées pour
    leur ré-utilisation. Mais, il existe toujours une possibilité
    d'utilisation peu efficace de l'espace&nbsp;: si, sur un bloc, seulement
    quelques clés d'index ont été supprimés, le bloc reste alloué. En
@@ -1204,7 +1204,7 @@ limite insertion vacuum = limite insertion base vacuum + facteur échelle insert
    volumineux (tout spécialement à des niveaux de débogage importants) et
    vous ne voulez pas les sauvegarder indéfiniment. Vous avez besoin de faire
    une <quote>rotation</quote> des journaux pour que les nouveaux journaux
-   sont commencés et que les anciens soient supprimés après une période de
+   soient commencés et que les anciens soient supprimés après une période de
    temps raisonnable.
   </para>
 

--- a/postgresql/manage-ag.xml
+++ b/postgresql/manage-ag.xml
@@ -25,7 +25,7 @@
   <para>
    Un petit nombre d'objets, comme les rôles, les bases de données et les
    tablespaces, sont définis au niveau de l'instance et stockés dans le
-   tablespace <literal>pg_global</literal>. À l'intérieur de l'instrance
+   tablespace <literal>pg_global</literal>. À l'intérieur de l'instance
    résident plusieurs bases de données, isolées les unes des autres mais
    pouvant accéder aux objets du niveau instance. Dans chaque base se trouvent
    plusieurs schémas contenant des objets comme les tables et les fonctions.
@@ -168,7 +168,7 @@
    <command>CREATE DATABASE</command>, exactement comme ci-dessus. La page de
    référence sur <xref linkend="app-createdb"/> contient les détails de son
    invocation. Notez que <command>createdb</command> sans aucun argument crée
-   une base de donnée portant le nom de l'utilisateur courant.
+   une base de données portant le nom de l'utilisateur courant.
   </para>
 
   <note>
@@ -243,7 +243,7 @@
    de <literal>template1</literal> est que les nouvelles options d'encodage et
    de locale peuvent être indiquées lors de la copie de
    <literal>template0</literal>, alors qu'une copie de
-   <literal>template1</literal> doit utiliser les même options. Ceci est dû au
+   <literal>template1</literal> doit utiliser les mêmes options. Ceci est dû au
    fait que <literal>template1</literal> pourrait contenir des données
    spécifiques à l'encodage ou à la locale alors que
    <literal>template0</literal> n'est pas modifiable.
@@ -329,7 +329,7 @@
 
   <para>
    Par exemple, si pour une raison quelconque vous voulez désactiver
-   l'optimiseur <acronym>GEQO</acronym> pour une base de donnée particulière,
+   l'optimiseur <acronym>GEQO</acronym> pour une base de données particulière,
    vous n'avez pas besoin de le désactiver pour toutes les bases de données ou
    de faire en sorte que tout client se connectant exécute la commande
    <literal>SET geqo TO off;</literal>. Pour appliquer ce réglage par défaut à

--- a/postgresql/nls.xml
+++ b/postgresql/nls.xml
@@ -155,7 +155,7 @@ msgstr "encore une de traduite"
     où <replaceable>region</replaceable> est le code de langue sur deux
     caractères (en majuscules), tel que défini par l'<ulink
     url="https://www.iso.org/iso/country_names_and_code_elements">ISO 3166-1,
-     le code du payes sur deux lettres en majuscule</ulink>,
+     le code du pays sur deux lettres en majuscule</ulink>,
     c'est-à-dire <filename>pt_BR.po</filename> pour le portugais du Brésil. Si vous
     trouvez la langue que vous souhaitez, vous pouvez commencer à travailler
     sur ce fichier.
@@ -238,7 +238,7 @@ msgstr "encore une de traduite"
       <para>
        Si la chaîne originale est une chaîne au format <function>printf</function>, la
        traduction doit l'être aussi. La traduction doit également avoir les
-       même spécificateurs de format et dans le même ordre. Quelques fois, les
+       même spécificateurs de format et dans le même ordre. Quelquefois, les
        règles naturelles de la langue rendent cela impossible ou tout au moins
        difficile. Dans ce cas, il est possible de modifier les spécificateurs de format
        de la façon suivante&nbsp;:
@@ -279,10 +279,10 @@ msgstr "encore une de traduite"
 
      <listitem>
       <para>
-       Lorsque la signification d'un message n'est pas connue ou s'il est ambigü,
+       Lorsque la signification d'un message n'est pas connue ou s'il est ambiguë,
        on pourra demander sa signification sur la liste de diffusion des développeurs.
        Il est possible qu'un anglophone puisse aussi ne pas le comprendre ou le
-       trouver ambigü. Il est alors préférable d'améliorer le message.
+       trouver ambiguë. Il est alors préférable d'améliorer le message.
       </para>
      </listitem>
 
@@ -480,7 +480,7 @@ errmsg_plural("copied %d file",
               n,
               n)
        </programlisting>
-       Le premier argument est le chaîne dans le format approprié pour la forme
+       Le premier argument est la chaîne dans le format approprié pour la forme
        au singulier en anglais, le second est le format de chaîne approprié pour
        la forme plurielle en anglais, et le troisième est la valeur entière
        déterminant la forme à utiliser. Des arguments additionnels sont formatés

--- a/postgresql/oid2name.xml
+++ b/postgresql/oid2name.xml
@@ -29,7 +29,7 @@
   <para>
    <application>oid2name</application> est un outil qui aide les
    administrateurs à examiner la structure des fichiers utilisée par
-   PostgreSQL. Pour l'utiliser, vous devez être connaître la structure de
+   PostgreSQL. Pour l'utiliser, vous devez connaître la structure de
    fichiers utilisée de la base de données. Elle est décrite dans <xref
    linkend="storage"/>.
   </para>
@@ -231,8 +231,8 @@
   </para>
 
   <para>
-   La variable d'environnement variable <envar>PG_COLOR</envar> indique s'il
-   faut utiliser la couleur dans les messages de diagnostique. Les valeurs
+   La variable d'environnement <envar>PG_COLOR</envar> indique s'il
+   faut utiliser la couleur dans les messages de diagnostic. Les valeurs
    possibles sont <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.
   </para>

--- a/postgresql/pageinspect.xml
+++ b/postgresql/pageinspect.xml
@@ -9,7 +9,7 @@
  <para>
   Le module <filename>pageinspect</filename> fournit des fonctions qui vous
   permettent d'inspecter le contenu des pages de la base de données à un bas
-  niveau, ce qui utile pour le débogage. Toutes ces fonctions ne sont
+  niveau, ce qui est utile pour le débogage. Toutes ces fonctions ne sont
   utilisables que par les superutilisateurs.
  </para>
 

--- a/postgresql/perform.xml
+++ b/postgresql/perform.xml
@@ -1850,7 +1850,7 @@ WHERE quelquechosedautre;</programlisting>
     contenant les données nouvellement chargées seront supprimés de toute
     façon. Néanmoins, cette considération ne s'applique que quand <xref
     linkend="guc-wal-level"/> vaut <literal>minimal</literal> car toutes les
-    commandes doivent écrire dans les journaux de transaction dans les autres
+    commandes doivent écrire dans les journaux de transactions dans les autres
     cas.
    </para>
   </sect2>

--- a/postgresql/pgbuffercache.xml
+++ b/postgresql/pgbuffercache.xml
@@ -10,7 +10,7 @@
  <para>
   Le module <filename>pg_buffercache</filename> fournit un moyen pour
   examiner ce qui se passe dans le cache partagé en temps réel.
-  Il offre aussi une façon bas-niveau de supprimer des données du cache,
+  Il offre aussi une façon bas niveau de supprimer des données du cache,
   pour des tests.
  </para>
 
@@ -48,7 +48,7 @@
 
  <para>
   La fonction <function>pg_buffercache_usage_counts()</function> renvoie un
-  ensemble d'enregistrements, chaque ligne décrivant le nombre de tampons²
+  ensemble d'enregistrements, chaque ligne décrivant le nombre de tampons
   pour un décompte d'utilisation donné.
  </para>
 
@@ -62,7 +62,7 @@
  <para>
   La fonction <function>pg_buffercache_evict()</function> permet de supprimer
   un bloc du cache disque d'après son identifiant. L'utilisation de cette
-  fonction est réservée aux superutilisateurs..
+  fonction est réservée aux superutilisateurs.
  </para>
 
  <sect2 id="pgbuffercache-pg-buffercache">
@@ -200,9 +200,9 @@
    Comme des verrous du gestionnaire de tampons ne sont pas acquis pour copier
    les données d'état du tampon que la vue affichera, accéder à la vue
    <structname>pg_buffercache</structname> a moins d'impact sur l'activité
-   normale du tampon mais il ne fournit pas un ensemble cohérent de résultats
+   normale du tampon, mais il ne fournit pas un ensemble cohérent de résultats
    sur tous les tampons. Néanmoins, nous nous assurons que l'information de
-   chaque tampon est cohérent avec lui-même.
+   chaque tampon est cohérente avec lui-même.
   </para>
  </sect2>
 
@@ -366,7 +366,7 @@
 
   <para>
    Tout comme la vue <structname>pg_buffercache</structname>, la fonction
-   <function>pg_buffercache_usage_counts()</function> n'acquiert par de verrous
+   <function>pg_buffercache_usage_counts()</function> n'acquiert pas de verrous
    par le gestionnaire de tampons. De ce fait, l'activité concurrente peut
    amener à des inexactitudes mineures dans le résultat.
   </para>

--- a/postgresql/pgcrypto.xml
+++ b/postgresql/pgcrypto.xml
@@ -124,7 +124,7 @@
     <para>
      Ils incluent une valeur aléatoire appelée sel (<firstterm>salt</firstterm>
      en anglais) avec le résultat, pour que les utilisateurs qui ont le même mot
-     de passer puissent avoir des mots de passe chiffrés différents. C'est
+     de passe puissent avoir des mots de passe chiffrés différents. C'est
      aussi une défense supplémentaire comme l'inversion de l'algorithme.
     </para>
    </listitem>
@@ -1142,7 +1142,7 @@ pgp_armor_headers(data text, key out text, value out text) returns setof record
    <listitem>
     <para>
      <literal>pkcs</literal> &mdash; les données peuvent avoir n'importe quelle
-     longueur (par défault)
+     longueur (par défaut)
     </para>
    </listitem>
    <listitem>
@@ -1207,7 +1207,7 @@ gen_random_uuid() returns uuid
 
    <para>
     <filename>pgcrypto</filename> se configure lui-même suivant les
-    découvertes du scrip <literal>configure</literal> principal de PostgreSQL.
+    découvertes du script <literal>configure</literal> principal de PostgreSQL.
     Les options qui l'affectent sont <literal>--with-zlib</literal> et
     <literal>--with-ssl=openssl</literal>.
    </para>

--- a/postgresql/pgfreespacemap.xml
+++ b/postgresql/pgfreespacemap.xml
@@ -7,7 +7,7 @@
  </indexterm>
 
  <para>
-  Le module <filename>pg_freespacemap</filename> fournit un moyen pour examiner
+  Le module <filename>pg_freespacemap</filename> fournit un moyen d'examiner
   la <link linkend="storage-fsm">carte des espaces libres</link>
   (<acronym>FSM</acronym>).  Il fournit une fonction appelée
   <function>pg_freespace</function>, ou plus précisément deux fonctions qui se
@@ -35,7 +35,7 @@
 
     <listitem>
      <para>
-      Renvoit la quantité d'espace libre dans la page de la relation, spécifiée
+      Renvoie la quantité d'espace libre dans la page de la relation, spécifiée
       par <literal>blkno</literal>, d'après la <acronym>FSM</acronym>.
      </para>
     </listitem>
@@ -60,7 +60,7 @@
 
   <para>
    Les valeurs stockées dans la carte des espaces libres ne sont pas exactes.
-   Elles sont arrondies à une précision de 1/256th du <symbol>BLCKSZ</symbol>
+   Elles sont arrondies à une précision de 1/256e du <symbol>BLCKSZ</symbol>
    (32 octets pour un <symbol>BLCKSZ</symbol> par défaut), et elles ne sont
    pas parfaitement mises à jour quand des lignes sont insérées et mises à jour.
   </para>
@@ -115,7 +115,7 @@ postgres=# SELECT * FROM pg_freespace('foo', 7);
 
   <para>
    Version originale par Mark Kirkwood <email>markir@paradise.net.nz</email>.
-   Ré-écrit en version 8.4 pour s'adapter à la nouvelle implémentation de la
+   Réécrit en version 8.4 pour s'adapter à la nouvelle implémentation de la
    <acronym>FSM</acronym> par Heikki Linnakangas <email>heikki@enterprisedb.com</email>
   </para>
  </sect2>

--- a/postgresql/pgrowlocks.xml
+++ b/postgresql/pgrowlocks.xml
@@ -100,7 +100,7 @@ pgrowlocks(text) returns setof record
   <orderedlist>
    <listitem>
     <para>
-     Si un verrou de type <literal>ACCESS EXCLUSIVE</literal> est posée sur la
+     Si un verrou de type <literal>ACCESS EXCLUSIVE</literal> est posé sur la
      table, <function>pgrowlocks</function> sera bloqué.
     </para>
    </listitem>

--- a/postgresql/pgstatstatements.xml
+++ b/postgresql/pgstatstatements.xml
@@ -820,7 +820,7 @@
       <literal>false</literal>. Le moment où ces statistiques ont été
       réinitialisées est indiqué dans le champ
       <structfield>minmax_stats_since</structfield> de la vue
-      <structname>pg_stat_statements</structname>. Cette fonction renvoit le
+      <structname>pg_stat_statements</structname>. Cette fonction renvoie le
       moment d'une réinitialisation. Ce moment est sauvegardé dans le champ
       <structfield>stats_reset</structfield> de la vue
       <structname>pg_stat_statements_info</structname> ou le champ

--- a/postgresql/pgsurgery.xml
+++ b/postgresql/pgsurgery.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="pgsurgery" xreflabel="pg_surgery">
- <title>pg_surgery &mdash; réaliser des opérations bas niveau sur les données
+ <title>pg_surgery &mdash; réaliser des opérations bas-niveau sur les données
   des relations</title>
 
  <indexterm zone="pgsurgery">
@@ -11,7 +11,7 @@
   Le module <filename>pg_surgery</filename> fournit différentes fonctions pour
   réaliser des opérations sur une relation endommagée. Ces fonctions sont
   dangereuses de par leur concept et les utiliser pourrait corrompre
-  (ou corrompre encore plus) votre bases de données. Par exemple, ces
+  (ou corrompre encore plus) votre base de données. Par exemple, ces
   fonctions peuvent facilement être utilisées pour rendre une table
   incohérente avec ses propres index, causant des violations de contraintes
   <literal>UNIQUE</literal> ou <literal>FOREIGN KEY</literal>, voire même de

--- a/postgresql/pgtrgm.xml
+++ b/postgresql/pgtrgm.xml
@@ -11,7 +11,7 @@
   Le module <filename>pg_trgm</filename> fournit des fonctions et
   opérateurs qui permettent de déterminer des similarités de textes
   alphanumériques en fonction de correspondances de trigrammes. Il
-  fournit également des classes d'opérateur accélérant les recherches de
+  fournit également des classes d'opérateurs accélérant les recherches de
   chaînes similaires.
  </para>
 
@@ -38,7 +38,7 @@
     <filename>pg_trgm</filename> ignore les caractères qui ne forment pas
     de mots (donc non alphanumériques) lors de l'extraction des trigrammes
     d'une chaîne de caractères.
-    Chaque mot est considéré avoir deux espaces en préfixe et une espace en
+    Chaque mot est considéré avoir deux espaces en préfixe et un espace en
     suffixe lors de la détermination de l'ensemble de trigrammes contenu dans
     la chaîne. Par exemple, l'ensemble des trigrammes dans la chaîne
     <quote><literal>cat</literal></quote> est
@@ -566,7 +566,7 @@ SELECT * FROM test_trgm WHERE t LIKE '%foo%bar';
 SELECT * FROM test_trgm WHERE t ~ '(foo|bar)';
    </programlisting>
    La recherche dans l'index fonctionne en extrayant les trigrammes de
-   l'expression rationnelles, puis en les recherchant dans l'index. Plus il est
+   l'expression rationnelle, puis en les recherchant dans l'index. Plus il est
    possible d'extraire de trigrammes de l'expression rationnelle, plus la
    recherche dans l'index sera efficace.
    Contrairement à des recherches basées sur les B-tree, la chaîne

--- a/postgresql/pgvisibility.xml
+++ b/postgresql/pgvisibility.xml
@@ -23,19 +23,19 @@
   ligne n'est pas insérée, mise à jour, supprimée ou verrouillée dans ce bloc.
   Le bit <literal>PD_ALL_VISIBLE</literal> dans l'en-tête de page a la même
   signification que l'octet totalement-visible de la visibility map, mais il
-  est stocké au sein du bloc plutôt que dans une structure de donnée séparée.
+  est stocké au sein du bloc plutôt que dans une structure de données séparée.
   Ces deux bits seront normalement identiques, mais le bit de niveau de
   bloc peut parfois rester défini pendant que la visibility map est purgée
   lors de la récupération suite à un crash&nbsp;; ou ils peuvent être
   différents suite à un changement survenant après que
   <literal>pg_visibility</literal> ait examiné la visibility map et avant
-  qu'il ait examiné le bloc donnée. Tout événement causant une corruption de
+  qu'il ait examiné le bloc donné. Tout événement causant une corruption de
   données peut aussi un désaccord sur ces trois bits.
  </para>
 
  <para>
   Les fonctions qui affichent les informations concernant le bit
-  <literal>PD_ALL_VISIBLE</literal> sont plus beaucoup plus coûteuses que
+  <literal>PD_ALL_VISIBLE</literal> sont beaucoup plus coûteuses que
   celles qui consultent uniquement la visibility map. En effet, elles doivent
   lire les blocs de données des relations plutôt que de ne s'intéresser qu'à
   la visibility map (qui est bien plus petite). Les fonctions qui vérifient
@@ -52,7 +52,7 @@
      </function></term>
     <listitem>
      <para>
-      Renvoie tous les octets complétement visibles et complétement figés de
+      Renvoie tous les octets complètement visibles et complètement figés de
       la visibility map pour un bloc donné pour une relation donnée.
      </para>
     </listitem>
@@ -63,7 +63,7 @@
       boolean, all_frozen OUT boolean, pd_all_visible OUT boolean) returns setof record</function></term>
     <listitem>
      <para>
-      Renvoie tous les octets complétement visibles et complétement figés de
+      Renvoie tous les octets complètement visibles et complètement figés de
       la visibility map pour un bloc donné pour une relation donnée ainsi que
       l'octet <literal>PD_ALL_VISIBLE</literal> pour le bloc.
      </para>
@@ -74,7 +74,7 @@
     <term><function>pg_visibility_map(relation regclass, blkno OUT bigint, all_visible OUT boolean, all_frozen OUT boolean) returns setof record</function></term>
     <listitem>
      <para>
-      Renvoie tous les octets complétement visibles et complétement figés de
+      Renvoie tous les octets complètement visibles et complètement figés de
       la visibility map pour un bloc donné pour une relation donnée.
      </para>
     </listitem>
@@ -85,7 +85,7 @@
 
     <listitem>
      <para>
-      Renvoie tous les octets complétement visibles et complétement figés de
+      Renvoie tous les octets complètement visibles et complètement figés de
       la visibility map pour un bloc donné pour une relation donnée, ainsi que
       l'octet <literal>PD_ALL_VISIBLE</literal> pour le bloc.
      </para>
@@ -98,8 +98,8 @@
 
     <listitem>
      <para>
-      Renvoie le nombre de pages complétement visibles ainsi que le nombre de
-      pages complétement figées de la relation, en concordance avec la
+      Renvoie le nombre de pages complètement visibles ainsi que le nombre de
+      pages complètement figées de la relation, en concordance avec la
       visibility map.
      </para>
     </listitem>
@@ -153,7 +153,7 @@
    superutilisateurs et les rôles disposant des droits du rôle
    <literal>pg_stat_scan_tables</literal>, à l'exception de
    <function>pg_truncate_visibility_map(relation regclass)</function> qui ne
-   peut être executée que par des superutilisateurs.
+   peut être exécutée que par des superutilisateurs.
   </para>
  </sect2>
 

--- a/postgresql/pgwalinspect.xml
+++ b/postgresql/pgwalinspect.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="pgwalinspect" xreflabel="pg_walinspect">
- <title>pg_walinspect &mdash; inspection bas niveau des journaux de
-  transaction</title>
+ <title>pg_walinspect &mdash; inspection bas-niveau des journaux de
+  transactions</title>
 
  <indexterm zone="pgwalinspect">
   <primary>pg_walinspect</primary>
@@ -9,7 +9,7 @@
 
  <para>
   Le module <filename>pg_walinspect</filename> fournit des fonctions SQL qui
-  vous permettent d'inspecter, à un bas niveau, le contenu des journaux de
+  vous permettent d'inspecter à bas-niveau, le contenu des journaux de
   transactions d'une instance <productname>PostgreSQL</productname> en cours
   d'exécution, ce qui est utile pour le débogage, l'analyse, la création de
   rapports ou à des fins pédagogiques. Il est similaire à <xref
@@ -18,7 +18,7 @@
  </para>
 
  <para>
-  Toutes les fonctions de ce module fourniront des informations sur les WAL
+  Toutes les fonctions de ce module fournissent des informations sur les WAL
   utilisant l'identifiant de la timeline actuelle du serveur.
  </para>
 

--- a/postgresql/planstats.xml
+++ b/postgresql/planstats.xml
@@ -30,7 +30,7 @@
   <para>
    Les exemples montrés ci-dessous utilisent les tables de la base de tests de
    régression de <productname>PostgreSQL</productname>. Notez aussi que, comme
-   <command>ANALYZE</command> utilise un échantillonage statistique lors de
+   <command>ANALYZE</command> utilise un échantillonnage statistique lors de
    la réalisation des statistiques, les résultats peuvent changer légèrement
    après toute exécution d'<command>ANALYZE</command>.
   </para>
@@ -293,7 +293,7 @@ rows        = 10000 * 0.307669
    très petit car la distribution de la colonne est réellement assez plat
    (les statistiques affichant ces valeurs particulières comme étant plus
    communes que les autres sont principalement dûes à une erreur
-   d'échantillonage). Dans un cas plus typique où certaines valeurs sont
+   d'échantillonnage). Dans un cas plus typique où certaines valeurs sont
    significativement plus communes que les autres, ce processus compliqué
    donne une amélioration utile dans la précision car la sélectivité pour les
    valeurs les plus communes est trouvée exactement.
@@ -459,7 +459,7 @@ rows = (outer_cardinality * inner_cardinality) * selectivity
 
    <para>
     La corrélation multivariée peut être démontrée avec un jeu de test très
-    simple &mdash; une table avec deux colonnes, chacune contenant les même
+    simple &mdash; une table avec deux colonnes, chacune contenant les mêmes
     valeurs&nbsp;:
 
     <programlisting>
@@ -486,7 +486,7 @@ SELECT relpages, reltuples FROM pg_class WHERE relname = 't';
    </para>
 
    <para>
-    L'exemple suivant montre le résultat de l'estimation d'une conditino
+    L'exemple suivant montre le résultat de l'estimation d'une condition
     <literal>WHERE</literal> sur la colonne <structfield>a</structfield>&nbsp;:
 
     <programlisting>
@@ -603,7 +603,7 @@ EXPLAIN (ANALYZE, TIMING OFF) SELECT COUNT(*) FROM t GROUP BY a, b;
     Cette section introduit la variante des listes <acronym>MCV</acronym>
     (valeurs les plus communes), une extension directe de la statistique par
     colonne décrite dans <xref linkend="row-estimation-examples"/>. Ces
-    statistiques adressent la limitation du sockage de valeurs individuelles
+    statistiques adressent la limitation du stockage de valeurs individuelles
     mais elles sont naturellement plus coûteuses, à la fois pour la
     construction des statistiques lors du <command>ANALYZE</command>, pour le
     stockage et pour le temps de planification.

--- a/postgresql/plhandler.xml
+++ b/postgresql/plhandler.xml
@@ -78,7 +78,7 @@
   s'assurer que <structfield>flinfo-&gt;fn_extra</structfield> pointe sur une
   zone mémoire qui restera allouée au moins jusqu'à la fin de la requête en
   cours, car une structure de données <structname>FmgrInfo</structname> peut
-  être conservée aussi longtemps. Cela peut-être obtenu par l'allocation
+  être conservée aussi longtemps. Cela peut être obtenu par l'allocation
   des données supplémentaires dans le contexte mémoire spécifié par
   <structfield>flinfo-&gt;fn_mcxt</structfield>&nbsp;; de telles données
   ont la même espérance de vie que <structname>FmgrInfo</structname>.
@@ -102,11 +102,11 @@
 
  <para>
   Un modèle de gestionnaire de langage procédural écrit sous la forme d'une
-  extension C est fournie dans <literal>src/test/modules/plsample</literal>.
+  extension C est fourni dans <literal>src/test/modules/plsample</literal>.
   C'est un exemple fonctionnel démontrant une façon de créer un tel
   gestionnaire, de traiter des paramètres et de renvoyer une valeur. Il
   suffit de remplacer les points de suspension par quelques milliers de
-  lignes de codes pour compléter ce modèle.
+  lignes de code pour compléter ce modèle.
  </para>
 
  <para>
@@ -181,7 +181,7 @@ CREATE LANGUAGE plsample
   <varname>check_function_bodies</varname> est activé. Du coup, les vérifications
   dont les résultats pourraient être affectés par les paramètres en question
   doivent être ignorées quand <varname>check_function_bodies</varname> est
-  désactivé pour éviter de échecs erronés lors du chargement d'une sauvegarde.
+  désactivé pour éviter des échecs erronés lors du chargement d'une sauvegarde.
  </para>
 
  <para>
@@ -199,7 +199,7 @@ CREATE LANGUAGE plsample
  </para>
 
  <para>
-  It est recommandé de placer toutes les déclarations de fonctions ainsi que
+  Il est recommandé de placer toutes les déclarations de fonctions ainsi que
   la commande <command>CREATE LANGUAGE</command> dans une
   <firstterm>extension</firstterm> pour qu'une simple commande
   <command>CREATE EXTENSION</command> suffise à installer le langage. Voir

--- a/postgresql/plperl.xml
+++ b/postgresql/plperl.xml
@@ -20,8 +20,8 @@
   Le principal avantage habituellement cité quant à l'utilisation de Perl est que cela
   permet l'utilisation des nombreux opérateurs et fonctions de <quote>gestion
    de chaînes</quote> disponibles grâce à Perl dans des fonctions et procédures stockées.
-  L'analyse de chaînes complexes se trouve facilité par l'utilisation de Perl
-  et des fonctions et structures de contrôles fournies dans PL/pgSQL.
+  L'analyse de chaînes complexes se trouve facilitée par l'utilisation de Perl
+  et des fonctions et structures de contrôle fournies dans PL/pgSQL.
  </para>
 
  <para>
@@ -83,7 +83,7 @@ $$ LANGUAGE plperl;
    </programlisting>
 
    Un bloc de procédure anonyme ne prend pas d'arguments et toute valeur
-   retournée est ignorée. Ceci mis à part, il se comporte comme une fonction
+   retournée est ignorée. Ceci, mis à part, il se comporte comme une fonction
    classique.
   </para>
 
@@ -109,12 +109,12 @@ $$ LANGUAGE plperl;
    linkend="sql-syntax-dollar-quoting"/>) pour cette constante. Si vous
    choisissez d'utiliser la syntaxe d'échappement des chaînes <literal>E''</literal>,
    vous devez doubler les marques de guillemets simples (<literal>'</literal>)
-   et les antislashs (<literal>\</literal>) utilisés dans le corps de la
+   et les antislashes (<literal>\</literal>) utilisés dans le corps de la
    fonction (voir la <xref linkend="sql-syntax-strings"/>).
   </para>
 
   <para>
-   Les arguments et les résultats sont manipulés comme dans n'importe quel
+   Les arguments et les résultats sont manipulés comme dans n'importe quelle
    routine Perl&nbsp;: les arguments sont passés au tableau
    <varname>@_</varname> et une valeur de retour
    est indiquée par <literal>return</literal> ou par la dernière expression
@@ -412,7 +412,7 @@ SELECT * FROM perl_set();</programlisting>
    simplement les arguments d'entrée convertis en tant que texte (comme s'ils
    avaient été affichés par une commande <command>SELECT</command>).
    Inversement, les commandes <function>return</function> et <function>return_next</function>
-   accepterons toute chaîne qui a un format d'entrée acceptable
+   accepteront toute chaîne qui a un format d'entrée acceptable
    pour le type de retour déclaré de la fonction.
   </para>
 
@@ -426,7 +426,7 @@ SELECT * FROM perl_set();</programlisting>
  </sect1>
 
  <sect1 id="plperl-builtins">
-  <title>Fonction incluses</title>
+  <title>Fonctions incluses</title>
 
   <sect2 id="plperl-database">
    <title>Accès à la base de données depuis PL/Perl</title>
@@ -635,7 +635,7 @@ $plan = spi_prepare('SELECT * FROM test WHERE id &gt; $1 AND name = $2', 'INTEGE
        <literal>spi_prepare</literal>, le plan peut être utilisé à la place de la
        requête, soit dans <literal>spi_exec_prepared</literal>, où le résultat est
        identique à celui renvoyé par <literal>spi_exec_query</literal>, soit dans
-       <literal>spi_query_prepared</literal> qui renvoit un curseur exactement comme
+       <literal>spi_query_prepared</literal> qui renvoie un curseur exactement comme
        le fait <literal>spi_query</literal>, qui peut ensuite être passé à
        <literal>spi_fetchrow</literal>. Le deuxième paramètre, optionnel, de
        <literal>spi_exec_prepared</literal> est une référence hachée des
@@ -877,7 +877,7 @@ CALL transaction_test1();
      </term>
      <listitem>
       <para>
-       Retourne les données binaires non échappé représentées par le contenu de
+       Retourne les données binaires non échappées représentées par le contenu de
        la chaîne donnée, qui doit être encodé au format <type>bytea</type>.
       </para>
      </listitem>
@@ -1611,7 +1611,7 @@ DO 'elog(WARNING, join ", ", sort keys %INC)' LANGUAGE plperl;
       <para>
        Lorsqu'une session se termine normalement, et pas à cause d'une erreur fatale,
        tous les blocs <literal>END</literal> qui ont été définis sont exécutés.
-       Actuellement, aucune autre action ne sont réalisées.
+       Actuellement, aucune autre action n'est réalisée.
        Spécifiquement, les descripteurs de fichiers ne sont pas vidés automatiquement
        et les objets ne sont pas détruits automatiquement.
       </para>

--- a/postgresql/plpgsql.xml
+++ b/postgresql/plpgsql.xml
@@ -96,7 +96,7 @@
     Grâce à <application>PL/pgSQL</application> vous pouvez grouper un bloc
     de traitement et une série de requêtes <emphasis>au sein</emphasis> du
     serveur de bases de données, et bénéficier ainsi de la puissance d'un
-    langage de procédures, mais avec de gros gains en terme de communication
+    langage de procédures, mais avec de gros gains en termes de communication
     client/serveur.
    </para>
 
@@ -151,7 +151,7 @@
 
    <para>
     Les fonctions <application>PL/pgSQL</application> peuvent aussi renvoyer
-    un ensemble de lignes (ou une table) de n'importe lequel des type de
+    un ensemble de lignes (ou une table) de n'importe lequel des types de
     données dont les fonctions peuvent renvoyer une instance unique. Ces
     fonctions génèrent leur sortie en exécutant <literal>RETURN NEXT</literal>
     pour chaque élément désiré de l'ensemble résultat ou en utilisant
@@ -240,7 +240,7 @@ END <optional> <replaceable>label</replaceable> </optional>;
   <para>
    Un <replaceable>label</replaceable> est seulement nécessaire si vous voulez
    identifier le bloc à utiliser dans une instruction <literal>EXIT</literal>
-   ou pour qualifier les noms de variable déclarées dans le bloc. Si un label
+   ou pour qualifier les noms de variable déclarée dans le bloc. Si un label
    est écrit après <literal>END</literal>, il doit correspondre au label donné
    au début du bloc.
   </para>
@@ -667,7 +667,7 @@ DECLARE
 
    <para>
     <literal>ALIAS</literal> créant deux manières différentes de nommer
-    le même objet, son utilisation à outrance peut préter à confusion. Il vaut
+    le même objet, son utilisation à outrance peut prêter à confusion. Il vaut
     mieux ne l'utiliser uniquement pour se passer des noms prédéterminés.
    </para>
   </sect2>
@@ -913,7 +913,7 @@ $$ LANGUAGE plpgsql;
     </programlisting>
 
     Ceci surcharge les collationnements associés avec les colonnes de la
-    table, les paramètres ou la variables locales utilisées dans
+    table, les paramètres ou la variable locales utilisées dans
     l'expression, comme cela arriverait dans une commande SQL simple.
    </para>
   </sect2>
@@ -1004,7 +1004,7 @@ PREPARE <replaceable>nom_instruction</replaceable>(integer, integer) AS SELECT $
     une valeur de rangée, si cette variable est une variable de rangée ou
     d'enregistrement). La variable cible peut être une simple variable
     (éventuellement qualifiée avec un nom de bloc), un champ d'une rangée
-    ou variable d'enrengistrement ou un élément ou partie de tableau cible.
+    ou variable d'enregistrement ou un élément ou partie de tableau cible.
     Le signe d'égalité (<literal>=</literal>)
     peut être utilisé à la place de <literal>:=</literal>, qui lui est conforme
     au PL/SQL.
@@ -1081,7 +1081,7 @@ INSERT INTO mytable VALUES (1,'one'), (2,'two');</programlisting>
     <command>EXPLAIN</command> et <command>CREATE TABLE ... AS
     SELECT</command>. Dans ces commandes, tout nom de variable
     <application>PL/pgSQL</application> apparaissant dans le texte de la
-    commande est remplace par un paramètre de la requête, puis la valeur
+    commande est remplacé par un paramètre de la requête, puis la valeur
     actuelle de la variable est fournie comme valeur du paramètre à
     l'exécution. C'est le traitement exact décrit précédemment pour les
     expressions. Pour les détails, voir la <xref
@@ -1173,7 +1173,7 @@ INSERT INTO mytable VALUES (1,'one'), (2,'two');</programlisting>
    </indexterm>
 
    <para>
-    Le résultat d'une commande SQL ne ramenant qu'une seule ligne (mais avec une
+    Le résultat d'une commande SQL ne retourne qu'une seule ligne (mais avec une
     ou plusieurs colonnes) peut être affecté à une variable de type record, row ou
     à une liste de variables scalaires. Ceci se fait en écrivant la commande SQL
     de base et en ajoutant une clause <literal>INTO</literal>. Par exemple,
@@ -1459,7 +1459,7 @@ EXECUTE 'SELECT count(*) FROM '
     <command>SELECT INTO</command> n'est actuellement pas supporté à
     l'intérieur de <command>EXECUTE</command>&nbsp;; à la place, exécutez une
     commande <command>SELECT</command> et spécifiez <literal>INTO</literal>
-    comme faisant parti lui-même d'<command>EXECUTE</command>.
+    comme faisant partie lui-même d'<command>EXECUTE</command>.
    </para>
 
    <note>
@@ -1666,7 +1666,7 @@ EXECUTE format('UPDATE tbl SET %I = $1 WHERE cle = $2', nom_colonne)
    </para>
 
    <table id="plpgsql-current-diagnostics-values">
-    <title>Éléments de diagnostique disponibles</title>
+    <title>Éléments de diagnostics disponibles</title>
     <tgroup cols="3">
      <colspec colname="col1" colwidth="1*"/>
      <colspec colname="col2" colwidth="1*"/>
@@ -2992,7 +2992,7 @@ GET STACKED DIAGNOSTICS <replaceable>variable</replaceable> { = | := } <replacea
     </para>
 
     <table id="plpgsql-exception-diagnostics-values">
-     <title>Diagnostiques et erreurs</title>
+     <title>Diagnostics et erreurs</title>
      <tgroup cols="3">
       <colspec colname="col1" colwidth="2*"/>
       <colspec colname="col2" colwidth="1*"/>
@@ -3552,7 +3552,7 @@ UPDATE foo SET valdonnee = mavaleur WHERE CURRENT OF curs1;
     <para>
      <command>CLOSE</command> ferme le portail sous-tendant un curseur ouvert. Ceci peut
      être utilisé pour libérer des ressources avant la fin de la transaction ou pour
-     libérer la variable curseur pour pouvoir la réouvrir.
+     libérer la variable curseur pour pouvoir la rouvrir.
     </para>
 
     <para>
@@ -3952,7 +3952,7 @@ RAISE EXCEPTION 'Nonexistent ID --> %', user_id
   </para>
 
   <para>
-   Ces deux exemples affichent des façons équivalents pour initialiser
+   Ces deux exemples affichent des façons équivalentes pour initialiser
    SQLSTATE&nbsp;:
    <programlisting>
 RAISE 'Duplicate user ID: %', user_id USING ERRCODE = 'unique_violation';
@@ -3969,7 +3969,7 @@ RAISE division_by_zero;
 RAISE SQLSTATE '22012';
    </programlisting>
    Dans cette syntaxe, <literal>USING</literal> peut être utilisé pour fournir
-   un message d'erreur, un détail ou une astuce personnalisé. Voici une autre
+   un message d'erreur, un détail ou une astuce personnalisée. Voici une autre
    façon de faire l'exemple précédent&nbsp;:
    <programlisting>
 RAISE unique_violation USING MESSAGE = 'Duplicate user ID: ' || user_id;
@@ -4829,7 +4829,7 @@ CREATE EVENT TRIGGER rapporte ON ddl_command_start EXECUTE FUNCTION rapporte();
    remplacée, même si la fonction a une variable nommée
    <literal>foo</literal>. La deuxième occurrence doit être le nom d'une
    colonne de cette table et ne sera donc pas remplacée non plus. De la même
-   façon, la troisième occurence doit être un nom de fonction, donc il ne
+   façon, la troisième occurrence doit être un nom de fonction, donc il ne
    sera pas non plus substitué. Seule la dernière occurrence peut être une
    référence à une variable de la fonction
    <application>PL/pgSQL</application>.

--- a/postgresql/plpython.xml
+++ b/postgresql/plpython.xml
@@ -13,7 +13,7 @@
  </para>
 
  <para>
-  Pour installer PL/Python dans une base de données particulières, utilisez
+  Pour installer PL/Python dans une base de données particulière, utilisez
   <literal>CREATE EXTENSION plpython3u</literal>.
  </para>
 
@@ -254,7 +254,7 @@ $$ LANGUAGE plpython3u;
 
      <listitem>
       <para>
-       Pour les données non scalaires, voire ci dessous.
+       Pour les données non-scalaires, voir ci-dessous.
       </para>
      </listitem>
     </itemizedlist>
@@ -279,7 +279,7 @@ $$ LANGUAGE plpython3u;
     <productname>PostgreSQL</productname> fasse quelque-chose de plus
     raisonnable&nbsp;: si une valeur NULL est passée, la fonction ne sera pas
     appelée du tout mais renverra juste un résultat NULL automatiquement.
-    Sinon, vous pouver vérifier les entrées NULL dans le corps de la
+    Sinon, vous pouvez vérifier les entrées NULL dans le corps de la
     fonction&nbsp;:
 
     <programlisting>CREATE FUNCTION pymax (a integer, b integer)
@@ -321,7 +321,7 @@ SELECT return_arr();
 (1 row)
     </programlisting>
 
-    Les tableaux multi-dimensionnels sont passé dans PL/Python en tant que
+    Les tableaux multi-dimensionnels sont passés dans PL/Python en tant que
     listes Python imbriquées.  Un tableau à 2 dimensions est une liste de
     liste, par exemple.  Quand une fonction PL/Python renvoie un tableau SQL
     multi-dimensionnel, les listes internes doivent avoir la même taille à
@@ -397,7 +397,7 @@ $$ LANGUAGE plpython3u;
    </para>
 
    <para>
-    Il existe plusieurs façon de renvoyer une ligne ou des types composites à
+    Il existe plusieurs façons de renvoyer une ligne ou des types composites à
     partir d'une fonction Python. Les exemples suivants supposent que nous
     avons&nbsp;:
 
@@ -413,7 +413,7 @@ $$ LANGUAGE plpython3u;
 );
     </programlisting>
 
-    Une valeur composite peut être renvoyé comme&nbsp;:
+    Une valeur composite peut être renvoyée comme&nbsp;:
     <variablelist>
      <varlistentry>
       <term>Un type séquence (ligne ou liste), mais pas
@@ -622,7 +622,7 @@ SELECT * FROM multiout_simple_setof(3);
 
   <para>
    Le dictionnaire global <varname>SD</varname> est disponible pour stocker
-   des données privées entre les appels répétées à la même fonction. Cette
+   des données privées entre les appels répétés à la même fonction. Cette
    variable est une donnée statique privée. Le dictionnaire global
    <varname>GD</varname> est une donnée publique disponible pour toutes les
    fonctions Python à l'intérieur d'une session. À utiliser avec

--- a/postgresql/pltcl.xml
+++ b/postgresql/pltcl.xml
@@ -34,7 +34,7 @@
    En plus de l'ensemble sûr de commandes limitées de Tcl, seules quelques
    commandes sont disponibles pour accéder à la base via SPI et pour envoyer
    des messages via <function>elog()</function>. PL/Tcl ne fournit aucun
-   moyen pour accèder aux internes du serveur de bases ou pour gagner un accès
+   moyen pour accéder aux internes du serveur de bases ou pour gagner un accès
    au niveau système d'exploitation avec les droits du processus serveur
    <productname>PostgreSQL</productname> comme le fait une fonction C. Du coup,
    les utilisateurs de la base, sans droits, peuvent utiliser ce langage en
@@ -763,7 +763,7 @@ $$ LANGUAGE pltcl;
 
   <tip>
    <para>
-    La liste de résultats peut être réalisée à partie une représentation en
+    La liste de résultats peut être réalisée à partir une représentation en
     tableau de la ligne modifiée avec la commande Tcl <literal>array
      get</literal>.
    </para>
@@ -899,7 +899,7 @@ CREATE EVENT TRIGGER tcl_a_snitch ON ddl_command_start EXECUTE FUNCTION tclsnitc
    des informations supplémentaires sur une erreur dans un format qui est
    simple à interpréter pour les programmes Tcl. Le contenu est dans le format
    liste Tcl, et le premier mot identifie le sous-système ou la bibliothèque
-   rapportant l'errer&nbsp;; au delà, le contenu est laissé au sous-système
+   rapportant l'erreur&nbsp;; au-delà, le contenu est laissé au sous-système
    individuel ou à la bibliothèque. Pour les erreurs au niveau base rapportées
    par les commandes PL/Tcl commands, le premier mot est
    <literal>POSTGRES</literal>, le second est le numéro de version du serveur,
@@ -1086,11 +1086,11 @@ CALL transaction_test1();
       Ce paramètre, s'il est positionné à autre chose qu'une chaîne vide,
       spécifie le nom (potentiellement qualifié du schéma) d'ue fonction
       PL/Tcl sans paramètre qui doit être exécutée chaque fois qu'un nouvel
-      interpréteur Tcl est crée pour Pl/Tcl.  Une telle fonction peut
+      interpréteur Tcl est créé pour Pl/Tcl.  Une telle fonction peut
       effectuer une initialisation pour la session, comme charger du code Tcl
       additionnel.  Un nouvel interpréteur Tcl est créé wuen une fonction
       PL/Tcl est exécutée pour la première fois dans une session, ou quand un
-      autre interpréteur doit être crée du fait de l'appel à une fonction
+      autre interpréteur doit être créé du fait de l'appel à une fonction
       PL/Tcl par un nouveau rôle SQL.
      </para>
      <para>

--- a/postgresql/postgres-fdw.xml
+++ b/postgresql/postgres-fdw.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="postgres-fdw" xreflabel="postgres_fdw">
  <title>postgres_fdw &mdash;
-   accéder des données enregistrées dans des serveurs <productname>PostgreSQL</productname>
+   accéder à des données enregistrées dans des serveurs <productname>PostgreSQL</productname>
    externes</title>
 
  <indexterm zone="postgres-fdw">
@@ -55,7 +55,7 @@
     <para>
      Créez une table distante avec <xref linkend="sql-createforeigntable"/>
      ou <xref linkend="sql-importforeignschema"/>
-     pour chaque table distante que vous voulez utilisé. Les colonnes de la
+     pour chaque table distante que vous voulez utiliser. Les colonnes de la
      table distante doit correspondre aux colonnes de la table sur le serveur
      distant. Néanmoins, vous pouvez utiliser un nom de table et des noms de
      colonne différents de ceux de la table sur le serveur distant si vous
@@ -87,7 +87,7 @@
   Notez que <filename>postgres_fdw</filename> n'a pour l'instant pas de
   support pour les instructions <command>INSERT</command> avec une clause
   <literal>ON CONFLICT DO UPDATE</literal>. Néanmoins, la clause <literal>ON
-   CONFLICT DO NOTHING</literal> est supporté, si la spécification de l'index
+   CONFLICT DO NOTHING</literal> est supportée, si la spécification de l'index
   unique est omise. Notez aussi que <filename>postgres_fdw</filename> supporte
   le déplacement de ligne demandé par des instructions
   <command>UPDATE</command> exécutées sur des tables partitionnées, mais il ne
@@ -99,8 +99,8 @@
  <para>
   Il est généralement recommandé que les colonnes d'une table distante soient
   déclarées avec exactement les mêmes types de données et le même collationnement
-  que celles utilisées pour les colonnes référencées dans le table du serveur
-  distant. Bien que <filename>postgres_fdw</filename> est actuellement assez
+  que celles utilisées pour les colonnes référencées dans la table du serveur
+  distant. Bien que <filename>postgres_fdw</filename> soit actuellement assez
   lâche sur les conversions de type de données, des anomalies sémantiques
   surprenantes peuvent survenir quand les types ou les collationnements ne
   correspondent pas dans le cas où le serveur distant interprète légèrement

--- a/postgresql/postgres.xml
+++ b/postgresql/postgres.xml
@@ -53,7 +53,7 @@ break is not needed in a wider output rendering.
      relationnelles et au langage SQL. Seules sont nécessaires des
      connaissances générales sur l'utilisation des ordinateurs et aucune
      expérience particulière d'Unix ou en programmation n'est requise. Ce
-     tutorial a pour but de fournir une expérience directe sur les aspects
+     tutoriel a pour but de fournir une expérience directe sur les aspects
      importants du système <productname>PostgreSQL</productname>. Il ne tente
      pas de traiter l'intégralité des thèmes qu'il couvre.
     </para>

--- a/postgresql/problems.xml
+++ b/postgresql/problems.xml
@@ -369,7 +369,7 @@
 
   <note>
    <para>
-    Dû, malheureusement, au grand nombre de pourriels (spam), toutes les
+    Du, malheureusement, au grand nombre de pourriels (spam), toutes les
     adresses de courrier électronique ci-dessus sont modérées sauf si vous
     avez souscrit. Ceci signifie qu'il y aura un certain délai avant que
     l'email ne soit délivré. Si vous souhaitez souscrire aux listes, merci de

--- a/postgresql/protocol.xml
+++ b/postgresql/protocol.xml
@@ -12,7 +12,7 @@
   communication entre le <foreignphrase>frontend</foreignphrase> et le
   <foreignphrase>backend</foreignphrase> (clients et serveurs). Le protocole
   est supporté sur <acronym>TCP/IP</acronym> et aussi sur les sockets de domaine
-  Unix. Le nombre de port 5432 a été enregistré avec l'IANA comme numéro de port
+  Unix. Le numéro de port 5432 a été enregistré auprès de l'IANA comme numéro de port
   TCP attribué pour les serveurs utilisant ce protocole, mais, en pratique, tout
   numéro de port non privilégié peut être utilisé.
  </para>
@@ -764,7 +764,7 @@ SELECT 1/0;
 
     <para>
      Un <command>COMMIT</command> ou un <command>ROLLBACK</command> apparaissant
-     dans un bloc de transaction implicite est exécuté de façon normal, fermant
+     dans un bloc de transaction implicite est exécuté de façon normald, fermant
      le bloc implicite&nbsp;; néanmoins, un message d'avertissement sera renvoyé
      car un <command>COMMIT</command> ou un <command>ROLLBACK</command> sans
      <command>BEGIN</command> pourrait être une erreur. Si des requêtes suivent,
@@ -965,7 +965,7 @@ SELCT 1/0;<!-- this typo is intentional -->
     client doit envoyer un message Sync. Ce message sans paramètre fait que le
     backend ferme la transaction en cours si elle n'est pas à l'intérieur d'un
     bloc de transaction <command>BEGIN</command>/<command>COMMIT</command>
-    (<quote>ferm</quote> signifiant une validation s'il n'y a pas d'erreur et
+    (<quote>fermer</quote> signifiant une validation s'il n'y a pas d'erreur et
     une annulation dans le cas d'une erreur). Une réponse ReadyForQuery est
     ensuite produite. Le but de Sync est de fournir un point de
     resynchronisation pour les erreurs. Quand une erreur est détectée lors du
@@ -1027,14 +1027,14 @@ SELCT 1/0;<!-- this typo is intentional -->
     libère les ressources. Ce n'est pas une erreur d'envoyer Close pour un nom
     inexistant de requête préparée ou de portail. La réponse est habituellement
     CloseComplete, mais pourrait être ErrorResponse si des difficultés sont
-    rencontrés lors de la libération des ressources. Notez que fermer
+    rencontrées lors de la libération des ressources. Notez que fermer
     implicitement une requête préparée ferme tout portail ouvert qui était
     construit par cette requête.
    </para>
 
    <para>
     Le message Flush ne cause pas la génération d'une sortie spécifique mais
-    force le backend à renvoyer toute donnée en attente dans les buffers de
+    force le backend à renvoyer toutes les données en attente dans les buffers de
     sortie. Un Flush doit être envoyé après toute commande de requête étendue
     sauf Sync, si le client souhaite examiner les résultats de cette commande
     avant de lancer d'autres commandes. Sans Flush, les messages renvoyés par le
@@ -1887,7 +1887,7 @@ SELCT 1/0;<!-- this typo is intentional -->
    booléenne à <literal>true</literal> (ou <literal>on</literal>,
    <literal>yes</literal>, <literal>1</literal>) indique au backend d'entrer
    dans le mode walsender de réplication physique, dans lequel un petit ensemble
-   de commandes de réplication, affichées ci-dessous, peut être exécutées à la
+   de commandes de réplication, affichées ci-dessous, peut être exécuté à la
    place de requêtes SQL.
   </para>
 
@@ -3594,7 +3594,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3629,7 +3629,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3664,7 +3664,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3698,7 +3698,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(12)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3740,7 +3740,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3774,7 +3774,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3817,7 +3817,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3851,7 +3851,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3903,7 +3903,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3946,7 +3946,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -3964,7 +3964,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Byte<replaceable>n</replaceable></term>
        <listitem>
         <para>
-         Données supplémentaires SASL, spécifique au mécanisme SASL
+         Données supplémentaires SASL, spécifiques au mécanisme SASL
          utilisé.
         </para>
        </listitem>
@@ -3992,7 +3992,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(12)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4035,7 +4035,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4064,7 +4064,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int16</term>
        <listitem>
         <para>
-         Le nombre de codes format des paramètres
+         Le nombre de codes formats des paramètres
          (dénoté <replaceable>C</replaceable> ci-dessous).
          Il peut valoir zéro pour indiquer qu'il n'y a pas de paramètres ou
          que les paramètres peuvent tous utiliser le format par défaut
@@ -4176,7 +4176,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4193,7 +4193,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(16)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4249,7 +4249,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4294,7 +4294,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4319,7 +4319,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4416,7 +4416,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4455,7 +4455,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4480,7 +4480,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4507,7 +4507,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
         <para>
          Identifie le message comme une réponse Start Copy In. Le client doit
          maintenant envoyer des données <literal>copy-in</literal> (s'il n'est
-         pas préparé à le faire, envoie un message CopyFail).
+         pas préparé à le faire, il envoie un message CopyFail).
         </para>
        </listitem>
       </varlistentry>
@@ -4516,7 +4516,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4577,7 +4577,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4637,7 +4637,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4696,7 +4696,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4757,7 +4757,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4803,7 +4803,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4828,7 +4828,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4884,7 +4884,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4930,7 +4930,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4955,7 +4955,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -4973,7 +4973,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int16</term>
        <listitem>
         <para>
-         Le nombre de codes format des arguments
+         Le nombre de codes formats des arguments
          (dénoté <replaceable>C</replaceable> ci-dessous).
          Ce nombre peut valoir zéro pour indiquer qu'il n'y a pas d'arguments
          ou que tous les arguments utilisent le format par défaut (texte)&nbsp;;
@@ -5066,7 +5066,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5104,7 +5104,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5116,7 +5116,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
          Le code de demande de chiffrement <acronym>GSSAPI</acronym>. La valeur
          est choisie pour contenir <literal>1234</literal> sur les 16 bits les
          plus significatifs, et <literal>5680</literal> sur les 16 bits les
-         moins significatifs.  (Pour éviter de la confusion, ce code ne doit pas
+         moins significatifs.  (Pour éviter la confusion, ce code ne doit pas
          être le même que le numéro de version du protocole.)
         </para>
        </listitem>
@@ -5144,7 +5144,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5179,7 +5179,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5239,7 +5239,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5264,7 +5264,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5321,7 +5321,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5373,7 +5373,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5422,7 +5422,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5465,7 +5465,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5537,7 +5537,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5564,7 +5564,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5600,7 +5600,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5625,7 +5625,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5660,7 +5660,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(5)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5699,7 +5699,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5811,7 +5811,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5866,7 +5866,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5891,7 +5891,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(8)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5903,7 +5903,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
          Le code de demande de chiffrement <acronym>SSL</acronym>. La valeur
          est choisie pour contenir <literal>1234</literal> sur les 16 bits les
          plus significatifs, et <literal>5679</literal> sur les 16 bits les
-         moins significatifs. (Pour éviter de la confusion, ce code ne doit pas
+         moins significatifs. (Pour éviter la confusion, ce code ne doit pas
          être le même que le numéro de version du protocole.)
         </para>
        </listitem>
@@ -5920,7 +5920,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -5992,7 +5992,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
            <term><literal>replication</literal></term>
            <listitem>
             <para>
-             Utilisé pour se connecter mode de réplication en flux, où un petit
+             Utilisé pour se connecter en mode de réplication en flux, où un petit
              ensemble de commandes de réplication peuvent être exécutées au lieu
              de requêtes SQL. Les valeurs peuvent être <literal>true</literal>,
              <literal>false</literal> ou <literal>database</literal>, et la
@@ -6044,7 +6044,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -6069,7 +6069,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32(4)</term>
        <listitem>
         <para>
-         Longueur du contenu du message en octets, longueur inclue.
+         Longueur du contenu du message en octets, longueur incluse.
         </para>
        </listitem>
       </varlistentry>
@@ -6170,7 +6170,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
       Position&nbsp;: la valeur du champ est un entier décimal ASCII, indiquant
       la position du curseur sur l'erreur comme un index sur la chaîne requête
       originale. Le premier caractère est à l'index 1, et les positions sont
-      mesurés en caractères, et non pas en octets.
+      mesurées en caractères, et non pas en octets.
      </para>
     </listitem>
    </varlistentry>
@@ -6215,7 +6215,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
     <term><literal>s</literal></term>
     <listitem>
      <para>
-      Nom du schéma&nbsp;: si l'erreur était associée avec un objet particulier
+      Nom du schéma&nbsp;: si l'erreur était associée à un objet particulier
       de la base, le nom du schéma contenant cet objet, s'il existe.
      </para>
     </listitem>
@@ -6225,7 +6225,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
     <term><literal>t</literal></term>
     <listitem>
      <para>
-      Nom de la table&nbsp;: si l'erreur était associée avec une table
+      Nom de la table&nbsp;: si l'erreur était associée à une table
       particulière, le nom de la table. (Référez-vous au champ du nom de
       schéma pour le nom du schéma de la table.)
      </para>
@@ -6247,7 +6247,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
     <term><literal>d</literal></term>
     <listitem>
      <para>
-      Nom du type de données&nbsp;: si l'erreur était associée avec un type
+      Nom du type de données&nbsp;: si l'erreur était associée à un type
       de données particulier, le nom du type de données. (Référez-vous au champ
       du nom de schéma pour le nom du schéma du type de données.)
      </para>
@@ -6258,8 +6258,8 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
     <term><literal>n</literal></term>
     <listitem>
      <para>
-      Nom de contrainte&nbsp;: si l'erreur était associée avec une contrainte
-      particulière, le nom de la contrainte. Référez-vous aux champs listées
+      Nom de contrainte&nbsp;: si l'erreur était associée à une contrainte
+      particulière, le nom de la contrainte. Référez-vous aux champs listés
       ci-dessus pour la table ou le domaine associé. (Dans ce but, les index
       sont traités comme des contraintes, même si elles n'ont pas été créées
       avec une syntaxe de contrainte.)
@@ -6290,7 +6290,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
     <term><literal>R</literal></term>
     <listitem>
      <para>
-      Routine&nbsp;: le nom de la routine ayant rapportée l'erreur.
+      Routine&nbsp;: le nom de la routine ayant rapporté l'erreur.
      </para>
     </listitem>
    </varlistentry>
@@ -6384,7 +6384,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Byte1('M')</term>
        <listitem>
         <para>
-         Identifie the message comme un message de décodage logique.
+         Identifie le message comme un message de décodage logique.
         </para>
        </listitem>
       </varlistentry>
@@ -6737,7 +6737,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32 (Oid)</term>
        <listitem>
         <para>
-         OID de la relation correspondant ç l'identifiant du message Relation
+         OID de la relation correspondant à l'identifiant du message Relation
          message.
         </para>
        </listitem>
@@ -6865,7 +6865,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Byte1('D')</term>
        <listitem>
         <para>
-         Identifie the message comme un message Delete.
+         Identifie le message comme un message Delete.
         </para>
        </listitem>
       </varlistentry>
@@ -7010,7 +7010,7 @@ psql "dbname=postgres replication=database" -c "IDENTIFY_SYSTEM;"
        <term>Int32 (TransactionId)</term>
        <listitem>
         <para>
-         Xid de la the transaction.
+         Xid de la transaction.
         </para>
        </listitem>
       </varlistentry>

--- a/postgresql/queries.xml
+++ b/postgresql/queries.xml
@@ -11,7 +11,7 @@
  </indexterm>
 
  <para>
-  Les précédents chapitres ont expliqué comme créer des tables, comment
+  Les précédents chapitres ont expliqué comment créer des tables, comment
   les remplir avec des données et comment manipuler ces données.
   Maintenant, nous discutons enfin de la façon de récupérer ces données
   depuis la base de données.

--- a/postgresql/query.xml
+++ b/postgresql/query.xml
@@ -780,7 +780,7 @@ SELECT ville, count(*) FILTER (WHERE t_basse &lt; 45), max(t_basse)
 
 
   <sect1 id="tutorial-update">
-   <title>Mises à jour</title>
+   <title>Mise à jour</title>
 
    <indexterm zone="tutorial-update">
     <primary>UPDATE</primary>

--- a/postgresql/rangetypes.xml
+++ b/postgresql/rangetypes.xml
@@ -36,7 +36,7 @@
  </para>
 
  <para>
-  Chaque type range dispose d'une type multirange correspondant. Un multirange est
+  Chaque type range dispose d'un type multirange correspondant. Un multirange est
   une liste triée de ranges non contigus, non vides et non NULL. La plupart des
   opérateurs ranges fonctionnent aussi sur les multiranges, et ils ont quelques
   fonctions à eux.
@@ -156,10 +156,10 @@ SELECT isempty(numrange(1, 5));
 
   <para>
    La limite basse d'un intervalle peut être omise, signifiant que toutes les
-   valeurs inférieures à la limite haute sont inclues dans l'intervalle, par
+   valeurs inférieures à la limite haute sont incluses dans l'intervalle, par
    exemple <literal>(,3]</literal>. De la même façon, si la limite haute d'un
    intervalle est omise, alors toutes les valeurs supérieures à la limite
-   basse sont inclues dans l'intervalle. Si les limites basse et haute sont
+   basse sont incluses dans l'intervalle. Si les limites basse et haute sont
    omises, toutes les valeurs du type de l'élément sont considérées faire
    partie de l'intervalle. Indiquer une limite manquante comme inclus fait
    qu'elle est automatique convertie en exclus, autrement dit
@@ -409,7 +409,7 @@ SELECT '[1.234, 5.678]'::floatrange;
   </para>
 
   <para>
-   Quand vous définissez votre propre ntervalle, vous obenez automatiquement un
+   Quand vous définissez votre propre intervalle, vous obtenez automatiquement un
    type multirange correspondant.
   </para>
 
@@ -458,7 +458,7 @@ SELECT '[1.234, 5.678]'::floatrange;
    serait nécessaire. Un peu de créativité peut se révéler nécessaire pour
    représenter la différence sous une forme numérique. Dans la mesure du
    possible, la fonction <literal>subtype_diff</literal> devrait être en
-   accord avec l'ordre de tri impliqué par la classe d'opérateur et le
+   accord avec l'ordre de tri impliqué par la classe d'opérateurs et le
    collationnement sélectionnés&nbsp;; autrement dit, son résultat doit être
    positif quand le premier argument est supérieur au second d'après l'ordre
    de tri.

--- a/postgresql/ref/alter_opclass.xml
+++ b/postgresql/ref/alter_opclass.xml
@@ -12,7 +12,7 @@
 
  <refnamediv>
   <refname>ALTER OPERATOR CLASS</refname>
-  <refpurpose>Modifier la définition d'une classe d'opérateur</refpurpose>
+  <refpurpose>Modifier la définition d'une classe d'opérateurs</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -35,7 +35,7 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
   </para>
 
   <para>
-   Seul le propriétaire de la classe d'opérateur peut utiliser <command>ALTER
+   Seul le propriétaire de la classe d'opérateurs peut utiliser <command>ALTER
    OPERATOR CLASS</command>.
    Pour modifier le propriétaire, vous devez être capable d'utiliser
    <literal>SET ROLE</literal> vers le nouveau rôle propriétaire, et ce rôle
@@ -43,8 +43,8 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
    d'opérateur.
    Ces restrictions assurent que la modification du propriétaire
    produise le même effet que celui obtenu par la suppression et la re-création
-   de la classe d'opérateur&nbsp;; néanmoins, un superutilisateur peut modifier
-   le propriétaire de n'importe quelle classe d'opérateur.
+   de la classe d'opérateurs&nbsp;; néanmoins, un superutilisateur peut modifier
+   le propriétaire de n'importe quelle classe d'opérateurs.
   </para>
  </refsect1>
 
@@ -56,7 +56,7 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
     <term><replaceable class="parameter">nom</replaceable></term>
     <listitem>
      <para>
-      Le nom d'une classe d'opérateur.
+      Le nom d'une classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -65,7 +65,7 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
     <term><replaceable class="parameter">méthode_indexage</replaceable></term>
     <listitem>
      <para>
-      Le nom de la méthode d'indexage à laquelle associer la classe d'opérateur.
+      Le nom de la méthode d'indexage à laquelle associer la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -74,7 +74,7 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
     <term><replaceable class="parameter">nouveau_nom</replaceable></term>
     <listitem>
      <para>
-      Le nouveau nom de la classe d'opérateur.
+      Le nouveau nom de la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -83,7 +83,7 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
     <term><replaceable class="parameter">nouveau_propriétaire</replaceable></term>
     <listitem>
      <para>
-      Le nouveau propriétaire de la classe d'opérateur.
+      Le nouveau propriétaire de la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -92,7 +92,7 @@ ALTER OPERATOR CLASS <replaceable>nom</replaceable> USING <replaceable class="pa
     <term><replaceable class="parameter">nouveau_schéma</replaceable></term>
     <listitem>
      <para>
-      Le nouveau schéma de la classe d'opérateur.
+      Le nouveau schéma de la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>

--- a/postgresql/ref/alter_opfamily.xml
+++ b/postgresql/ref/alter_opfamily.xml
@@ -53,15 +53,15 @@ ALTER OPERATOR FAMILY <replaceable>nom</replaceable> USING <replaceable class="p
   <para>
    Quand les opérateurs et fonctions de support sont ajoutés à une famille avec
    la commande <command>ALTER OPERATOR FAMILY</command>, ils ne font partie
-   d'aucune classe d'opérateur spécifique à l'intérieur de la famille. Ils sont
+   d'aucune classe d'opérateurs spécifique à l'intérieur de la famille. Ils sont
    <quote>lâches</quote> dans la famille. Ceci indique que ces opérateurs et
    fonctions sont compatibles avec la sémantique de la famille mais qu'ils ne
    sont pas requis pour un fonctionnement correct d'un index spécifique.  (Les
    opérateurs et fonctions qui sont ainsi nécessaires doivent être déclarés
-   comme faisant partie d'une classe d'opérateur&nbsp;; voir <xref
+   comme faisant partie d'une classe d'opérateurs&nbsp;; voir <xref
    linkend="sql-createopclass"/>.) <productname>PostgreSQL</productname>
    autorise la suppression des membres lâches d'une famille à tout moment, mais
-   les membres d'une classe d'opérateur ne peuvent pas être supprimés sans
+   les membres d'une classe d'opérateurs ne peuvent pas être supprimés sans
    supprimer toute la classe et les index qui en dépendent. Typiquement, les
    opérateurs et fonctions sur un seul type de données font partie des classes
    d'opérateurs car ils ont besoin de supporter un index sur ce type de données
@@ -150,7 +150,7 @@ ALTER OPERATOR FAMILY <replaceable>nom</replaceable> USING <replaceable class="p
       <replaceable class="parameter">type_op</replaceable> car les types de
       données en entrée de la fonction sont toujours les bons à utiliser. Pour
       les fonctions de tri des index B-tree, les fonctions d'égalité d'image
-      B-Tree, ainsi que pour toutes les fonctions des classes d'opérateur GIST,
+      B-Tree, ainsi que pour toutes les fonctions des classes d'opérateurs GIST,
       SP-GiST et GIN, il est nécessaire de spécifier le type de données en
       entrée qui sera utilisé par la fonction.
      </para>
@@ -287,7 +287,7 @@ ALTER OPERATOR FAMILY <replaceable>nom</replaceable> USING <replaceable class="p
   <para>
    La commande exemple suivant ajoute des opérateurs inter-type de données et
    ajoute les fonctions de support pour une famille d'opérateur qui contient
-   déjà les classes d'opérateur Btree pour les types de données
+   déjà les classes d'opérateurs Btree pour les types de données
    <type>int4</type> et <type>int2</type>.
   </para>
 

--- a/postgresql/ref/clusterdb.xml
+++ b/postgresql/ref/clusterdb.xml
@@ -283,7 +283,7 @@
     <listitem>
      <para>
       Spécifie s'il faut utiliser de la couleur dans les messages de
-      diagnostique.  Les valeurs possibles sont <literal>always</literal>,
+      diagnostic.  Les valeurs possibles sont <literal>always</literal>,
       <literal>auto</literal>, <literal>never</literal>.
      </para>
     </listitem>
@@ -301,7 +301,7 @@
 
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de difficulté, voir <xref linkend="sql-cluster"/> et <xref

--- a/postgresql/ref/create_aggregate.xml
+++ b/postgresql/ref/create_aggregate.xml
@@ -264,7 +264,7 @@ CREATE [ OR REPLACE ] AGGREGATE <replaceable class="parameter">nom</replaceable>
    pour <function>MAX</function>. L'optimisation ne prend
    jamais effet sauf si l'opérateur spécifié est membre de la stratégie
    <quote>less than</quote> (NdT&nbsp;: plus petit que) ou <quote>greater
-    than</quote> (NdT&nbsp;: plus grand que) d'une classe d'opérateur pour un
+    than</quote> (NdT&nbsp;: plus grand que) d'une classe d'opérateurs pour un
    index B-tree.
   </para>
 
@@ -356,8 +356,8 @@ CREATE [ OR REPLACE ] AGGREGATE <replaceable class="parameter">nom</replaceable>
       et le reste devant correspondre aux types de données en entrée déclarés
       pour l'agrégat. La fonction doit renvoyer une valeur de type
       <replaceable class="parameter">type_données_état</replaceable>. Cette
-      fonction prend la valeur actuelle de l'état  et les valeurs actuelles des
-      données en entrée. Elle renvoit la prochaine valeur de l'état.
+      fonction prend la valeur actuelle de l'état et les valeurs actuelles des
+      données en entrée. Elle renvoie la prochaine valeur de l'état.
      </para>
 
      <para>

--- a/postgresql/ref/create_cast.xml
+++ b/postgresql/ref/create_cast.xml
@@ -270,7 +270,7 @@ SELECT CAST ( 2 AS numeric ) + 4.0;
   </para>
 
   <para>
-   En général, un transtypage correspond à des type source et destination
+   En général, un transtypage correspond à des types source et destination
    différents. Cependant, il est permis de déclarer un transtypage entre
    types source et destination identiques si la fonction de transtypage a
    plus d'un argument. Cette possibilité est utilisée pour représenter dans le

--- a/postgresql/ref/create_index.xml
+++ b/postgresql/ref/create_index.xml
@@ -179,8 +179,8 @@
 
      <para>
       Les colonnes listées dans la clause <literal>INCLUDE</literal> n'ont pas
-      besoin de classes d'opérateur appropriées. La clause peut contenir les
-      colonnes dont les types de données n'ont pas de classes d'opérateur
+      besoin de classes d'opérateurs appropriées. La clause peut contenir les
+      colonnes dont les types de données n'ont pas de classes d'opérateurs
       définis pour une méthode d'accès donnée.
      </para>
 
@@ -292,7 +292,7 @@
     <term><replaceable class="parameter">classeop</replaceable></term>
     <listitem>
      <para>
-      Le nom d'une classe d'opérateur. Voir plus bas pour les détails.
+      Le nom d'une classe d'opérateurs. Voir plus bas pour les détails.
      </para>
     </listitem>
    </varlistentry>
@@ -445,7 +445,7 @@
        facteur de remplissage à 100 au moment du <command>CREATE
        INDEX</command> comme moyen de maximiser l'utilisation de l'espace.
        Vous devez seulement le considérer quand vous êtes complètement sûr
-       que la table est statique(autrement dit qu'elle ne sera jamais
+       que la table est statique (autrement dit qu'elle ne sera jamais
        affectée par des insertions ou des mises à jour). Une configuration du
        facteur de remplissage à 100 risque autrement de
        <emphasis>baisser</emphasis> les performances&nbsp;: même un petit
@@ -782,15 +782,15 @@
   </para>
 
   <para>
-   Une <firstterm>classe d'opérateur</firstterm> with optional parameters
+   Une <firstterm>classe d'opérateurs</firstterm> with optional parameters
    peut être spécifiée pour
-   chaque colonne d'un index. La classe d'opérateur identifie les opérateurs à
+   chaque colonne d'un index. La classe d'opérateurs identifie les opérateurs à
    utiliser par l'index pour cette colonne. Par exemple, un index B-tree sur des
    entiers codés sur quatre octets utilise la classe
    <literal>int4_ops</literal>, qui contient des
    fonctions de comparaison pour les entiers sur quatre octets. En pratique, la
-   classe d'opérateur par défaut pour le type de données de la colonne est
-   généralement suffisant. Les classes d'opérateur trouvent leur intérêt principal
+   classe d'opérateurs par défaut pour le type de données de la colonne est
+   généralement suffisant. Les classes d'opérateurs trouvent leur intérêt principal
    dans l'existence, pour certains types de données, de plusieurs
    ordonnancements significatifs.
   </para>
@@ -798,7 +798,7 @@
    Soit l'exemple d'un type de données
    <quote>nombre complexe</quote> qui doit être classé par sa valeur absolue
    ou par sa partie réelle. Cela peut être réalisé par la définition de deux
-   classes d'opérateur pour le type de données, puis par la sélection de la
+   classes d'opérateurs pour le type de données, puis par la sélection de la
    classe appropriée lors de la création d'un index.
   </para>
   <para>

--- a/postgresql/ref/create_opclass.xml
+++ b/postgresql/ref/create_opclass.xml
@@ -12,7 +12,7 @@
 
  <refnamediv>
   <refname>CREATE OPERATOR CLASS</refname>
-  <refpurpose>Définir une nouvelle classe d'opérateur</refpurpose>
+  <refpurpose>Définir une nouvelle classe d'opérateurs</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -30,43 +30,43 @@
 
   <para>
    <command>CREATE OPERATOR CLASS</command> crée une nouvelle classe
-   d'opérateur. Une classe d'opérateur définit la façon dont un type de
-   données particulier peut être utilisé avec un index. La classe d'opérateur spécifie
+   d'opérateur. Une classe d'opérateurs définit la façon dont un type de
+   données particulier peut être utilisé avec un index. La classe d'opérateurs spécifie
    le rôle particulier ou la <quote>stratégie</quote> que jouent certains opérateurs
    pour ce type de données et cette méthode d'indexation. La
-   classe d'opérateur spécifie aussi les fonctions de support à
-   utiliser par la méthode d'indexation quand la classe d'opérateur est
+   classe d'opérateurs spécifie aussi les fonctions de support à
+   utiliser par la méthode d'indexation quand la classe d'opérateurs est
    sélectionnée pour une colonne d'index. Tous les opérateurs et fonctions
-   utilisés par une classe d'opérateur doivent être définis avant la création de
-   la classe d'opérateur.
+   utilisés par une classe d'opérateurs doivent être définis avant la création de
+   la classe d'opérateurs.
   </para>
 
   <para>
-   Si un nom de schéma est donné, la classe d'opérateur est créée dans le
+   Si un nom de schéma est donné, la classe d'opérateurs est créée dans le
    schéma spécifié. Sinon, elle est créée dans le schéma courant. Deux classes
    d'opérateur ne peuvent avoir le même nom que s'ils concernent des méthodes
    d'indexation différentes.
   </para>
 
   <para>
-   L'utilisateur qui définit une classe d'opérateur en devient propriétaire.
+   L'utilisateur qui définit une classe d'opérateurs en devient propriétaire.
    Actuellement, le créateur doit être superutilisateur. Cette restriction
-   existe parce qu'une définition erronée d'une classe d'opérateur peut
+   existe parce qu'une définition erronée d'une classe d'opérateurs peut
    gêner le serveur, voire causer un arrêt brutal de celui-ci.
   </para>
 
   <para>
    Actuellement, <command>CREATE OPERATOR CLASS</command> ne vérifie pas si la
-   définition de la classe d'opérateur inclut tous les opérateurs et fonctions
+   définition de la classe d'opérateurs inclut tous les opérateurs et fonctions
    requis par la méthode d'indexation. Il ne vérifie pas non plus si les
    opérateurs et les fonctions forment un ensemble cohérent. Il est de la
-   responsabilité de l'utilisateur de définir une classe d'opérateur valide.
+   responsabilité de l'utilisateur de définir une classe d'opérateurs valide.
   </para>
 
   <para>
-   Les classes d'opérateur en relation peuvent être groupées dans des
+   Les classes d'opérateurs en relation peuvent être groupées dans des
    <firstterm>familles d'opérateurs</firstterm>. Pour ajouter une nouvelle
-   classe d'opérateur à une famille existante, indiquez l'option
+   classe d'opérateurs à une famille existante, indiquez l'option
    <literal>FAMILY</literal> dans <command>CREATE OPERATOR
     CLASS</command>. Sans cette option, la nouvelle classe est placée dans une
    famille de même nom (créant la famille si elle n'existe pas).
@@ -85,7 +85,7 @@
     <term><replaceable class="parameter">nom</replaceable></term>
     <listitem>
      <para>
-      Le nom (éventuellement qualifié du nom du schéma) de la classe d'opérateur à créer.
+      Le nom (éventuellement qualifié du nom du schéma) de la classe d'opérateurs à créer.
      </para>
     </listitem>
    </varlistentry>
@@ -94,8 +94,8 @@
     <term><literal>DEFAULT</literal></term>
     <listitem>
      <para>
-      La classe d'opérateur est celle par défaut pour son type de données.
-      Il ne peut y avoir qu'une classe d'opérateur
+      La classe d'opérateurs est celle par défaut pour son type de données.
+      Il ne peut y avoir qu'une classe d'opérateurs
       par défaut pour un type de données et une méthode d'indexation particuliers.
      </para>
     </listitem>
@@ -105,7 +105,7 @@
     <term><replaceable class="parameter">type_données</replaceable></term>
     <listitem>
      <para>
-      Le type de données de la colonne auquel s'applique cette classe d'opérateur.
+      Le type de données de la colonne auquel s'applique cette classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -114,7 +114,7 @@
     <term><replaceable class="parameter">méthode_index</replaceable></term>
     <listitem>
      <para>
-      Le nom de la méthode d'indexation à laquelle s'applique la classe d'opérateur.
+      Le nom de la méthode d'indexation à laquelle s'applique la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -135,7 +135,7 @@
     <listitem>
      <para>
       Le numéro de stratégie de la méthode d'indexation pour un opérateur associé
-      à la classe d'opérateur.
+      à la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -145,7 +145,7 @@
     <listitem>
      <para>
       Le nom (éventuellement qualifié du nom du schéma) d'un opérateur associé
-      à la classe d'opérateur.
+      à la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -158,7 +158,7 @@
       de l'opérande d'un opérateur ou <literal>NONE</literal> pour
       signifier un opérateur préfixe. Les types de données de l'opérande
       peuvent être omis dans le cas où ils sont identiques au type de
-      données de la classe d'opérateur.
+      données de la classe d'opérateurs.
      </para>
 
      <para>
@@ -200,7 +200,7 @@
     <listitem>
      <para>
       Le numéro de fonction support de la méthode d'indexation pour une fonction
-      associée à la classe d'opérateur.
+      associée à la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -210,7 +210,7 @@
     <listitem>
      <para>
       Le nom (éventuellement qualifié du nom du schéma) d'une fonction
-      support pour la méthode d'indexation de la classe d'opérateur.
+      support pour la méthode d'indexation de la classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -256,9 +256,9 @@
   <para>
    Comme toute la partie d'indexage ne vérifie pas les droits d'accès aux
    fonctions avant de les utiliser, inclure une fonction ou un opérateur dans
-   une classe d'opérateur est équivalent à donner les droits d'exécution à
+   une classe d'opérateurs est équivalent à donner les droits d'exécution à
    PUBLIC sur celle-ci. Ce n'est pas un problème habituellement pour les types
-   de fonctions utiles dans une classe d'opérateur.
+   de fonctions utiles dans une classe d'opérateurs.
   </para>
 
   <para>
@@ -281,7 +281,7 @@
   <title>Exemples</title>
 
   <para>
-   La commande issue de l'exemple suivant définit une classe d'opérateur
+   La commande issue de l'exemple suivant définit une classe d'opérateurs
    d'indexation GiST pour le type de données <literal>_int4</literal> (tableau de
    <type>int4</type>). Voir le module <xref linkend="intarray"/> pour l'exemple
    complet.

--- a/postgresql/ref/create_opfamily.xml
+++ b/postgresql/ref/create_opfamily.xml
@@ -35,7 +35,7 @@ CREATE OPERATOR FAMILY <replaceable class="parameter">nom</replaceable> USING <r
    d'opérateur adéquate, plutôt qu'être des membres <quote>lâches</quote> dans
    la famille d'opérateur. Typiquement, les opérateurs sur un seul type de
    données peuvent être lâches dans une famille d'opérateur contenant des
-   classes d'opérateur pour les deux types de données.)
+   classes d'opérateurs pour les deux types de données.)
   </para>
 
   <para>

--- a/postgresql/ref/create_table.xml
+++ b/postgresql/ref/create_table.xml
@@ -443,12 +443,12 @@ contrainte <literal>EXCLUDE</literal> peut valoir&nbsp;:</phrase>
 
      <para>
       Les partitionnements par intervalle ou par liste nécessitent une
-      classe d'opérateur btree, alors que le partitionnement par hachage
-      exige une classe d'opérateur hash. Si aucune classe d'opérateur n'est
-      précisée explicitement, la classe d'opérateur par défaut du type
-      approprié sera utilisée&nbsp;; si aucune classe d'opérateur n'existe,
+      classe d'opérateurs btree, alors que le partitionnement par hachage
+      exige une classe d'opérateurs hash. Si aucune classe d'opérateurs n'est
+      précisée explicitement, la classe d'opérateurs par défaut du type
+      approprié sera utilisée&nbsp;; si aucune classe d'opérateurs n'existe,
       une erreur sera levée. Si le partitionnement par hachage est utilisé,
-      la classe d'opérateur utilisée doit implémenter la fonction
+      la classe d'opérateurs utilisée doit implémenter la fonction
       de support 2 (voir <xref linkend="xindex-support"/> pour les détails).
      </para>
 

--- a/postgresql/ref/create_type.xml
+++ b/postgresql/ref/create_type.xml
@@ -135,9 +135,9 @@ CREATE TYPE <replaceable class="parameter">nom</replaceable>
 
    <para>
     Le <replaceable class="parameter">sous-type</replaceable> du type intervalle
-    peut être de tout type qui soit associé avec une classe d'opérateur B-tree
+    peut être de tout type qui soit associé avec une classe d'opérateurs B-tree
     (pour déterminer l'ordre des valeurs pour le type intervalle). Habituellement,
-    la classe d'opérateur par défaut du sous-type est utilisée pour déterminer
+    la classe d'opérateurs par défaut du sous-type est utilisée pour déterminer
     l'ordre. Pour utiliser un opérateur de classe autre que celle par défaut,
     indiquez son nom avec <replaceable
     class="parameter">classe_operateur_sous_type</replaceable>. Si le sous-type
@@ -324,7 +324,7 @@ CREATE TYPE <replaceable class="parameter">nom</replaceable>
     calcule des statistiques spécifiques au type de données pour les
     colonnes de ce type. Par défaut, <command>ANALYZE</command> tente de
     récupérer des statistiques à l'aide des opérateurs d'<quote>égalité</quote> et
-    d'<quote>infériorité</quote> du type, s'il existe une classe d'opérateur B-tree
+    d'<quote>infériorité</quote> du type, s'il existe une classe d'opérateurs B-tree
     par défaut pour le type. Ce comportement est inadapté aux types non-scalaires&nbsp;;
     il peut être surchargé à l'aide d'une fonction
     d'analyse personnalisée. La fonction d'analyse doit être déclarée avec
@@ -628,7 +628,7 @@ CREATE TYPE <replaceable class="parameter">nom</replaceable>
     <term><replaceable class="parameter">classe_operateur_sous_type</replaceable></term>
     <listitem>
      <para>
-      Le nom d'une classe d'opérateur B-tree pour le sous-type.
+      Le nom d'une classe d'opérateurs B-tree pour le sous-type.
      </para>
     </listitem>
    </varlistentry>

--- a/postgresql/ref/createdb.xml
+++ b/postgresql/ref/createdb.xml
@@ -398,7 +398,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de difficulté, on peut se référer à <xref

--- a/postgresql/ref/createuser.xml
+++ b/postgresql/ref/createuser.xml
@@ -474,7 +474,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de problèmes, on peut consulter <xref linkend="sql-createrole"/> et

--- a/postgresql/ref/drop_opclass.xml
+++ b/postgresql/ref/drop_opclass.xml
@@ -12,7 +12,7 @@
 
  <refnamediv>
   <refname>DROP OPERATOR CLASS</refname>
-  <refpurpose>Supprimer une classe d'opérateur</refpurpose>
+  <refpurpose>Supprimer une classe d'opérateurs</refpurpose>
  </refnamediv>
 
  <refsynopsisdiv>
@@ -24,14 +24,14 @@
   <title>Description</title>
 
   <para>
-   <command>DROP OPERATOR CLASS</command> supprime une classe d'opérateur.
+   <command>DROP OPERATOR CLASS</command> supprime une classe d'opérateurs.
    Seul le propriétaire de la classe peut la supprimer.
   </para>
 
   <para>
    <command>DROP OPERATOR CLASS</command> ne supprime aucun des opérateurs et
    aucune des fonctions référencés par la classe. Si un index dépend de la
-   classe d'opérateur, vous devez indiquer <literal>CASCADE</literal> pour que
+   classe d'opérateurs, vous devez indiquer <literal>CASCADE</literal> pour que
    la suppression se fasse réellement.
   </para>
  </refsect1>
@@ -54,7 +54,7 @@
     <term><replaceable class="parameter">nom</replaceable></term>
     <listitem>
      <para>
-      Le nom (éventuellement qualifié du nom du schéma) d'une classe d'opérateur.
+      Le nom (éventuellement qualifié du nom du schéma) d'une classe d'opérateurs.
      </para>
     </listitem>
    </varlistentry>
@@ -83,7 +83,7 @@
     <term><literal>RESTRICT</literal></term>
     <listitem>
      <para>
-      La classe d'opérateur n'est pas supprimée si un objet en dépend. Comportement par défaut.
+      La classe d'opérateurs n'est pas supprimée si un objet en dépend. Comportement par défaut.
      </para>
     </listitem>
    </varlistentry>
@@ -108,7 +108,7 @@
   <title>Exemples</title>
 
   <para>
-   Supprimer la classe d'opérateur <literal>widget_ops</literal> des index
+   Supprimer la classe d'opérateurs <literal>widget_ops</literal> des index
    de type arbre-balancé (B-tree)&nbsp;:
 
    <programlisting>DROP OPERATOR CLASS widget_ops USING btree;

--- a/postgresql/ref/drop_opfamily.xml
+++ b/postgresql/ref/drop_opfamily.xml
@@ -33,9 +33,9 @@ DROP OPERATOR FAMILY [ IF EXISTS ] <replaceable class="parameter">nom</replaceab
 
   <para>
    <command>DROP OPERATOR FAMILY</command> inclut la suppression de toutes
-   classes d'opérateur contenues dans la famille, mais elle ne supprime pas les
+   classes d'opérateurs contenues dans la famille, mais elle ne supprime pas les
    opérateurs et fonctions référencées par la famille. Si des index dépendent
-   des classes d'opérateur de la famille, vous devez ajouter
+   des classes d'opérateurs de la famille, vous devez ajouter
    <literal>CASCADE</literal> pour que la suppression réussisse.
   </para>
  </refsect1>

--- a/postgresql/ref/dropdb.xml
+++ b/postgresql/ref/dropdb.xml
@@ -259,7 +259,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de difficultés, il peut être utile de consulter <xref

--- a/postgresql/ref/dropuser.xml
+++ b/postgresql/ref/dropuser.xml
@@ -239,7 +239,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de difficultés, il peut être utile de consulter <xref

--- a/postgresql/ref/insert.xml
+++ b/postgresql/ref/insert.xml
@@ -482,7 +482,7 @@ INSERT INTO <replaceable class="parameter">nom_table</replaceable> [ AS <replace
        Lorsque mentionné, elle indique que la colonne <replaceable
        class="parameter">nom_colonne_index</replaceable> correspondante
        ou <replaceable class="parameter">expression_index</replaceable>
-       utilise une classe d'opérateur en particulier pour être
+       utilise une classe d'opérateurs en particulier pour être
        mis en correspondance durant l'inférence. Typiquement,
        ceci est omis, dans la mesure où les sémantiques
        d'<emphasis>égalité</emphasis> sont souvent équivalentes entre

--- a/postgresql/ref/pg_amcheck.xml
+++ b/postgresql/ref/pg_amcheck.xml
@@ -671,7 +671,7 @@
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut
-   utiliser, ou pas, les couleurs dans les messages de diagnostique. Les
+   utiliser, ou pas, les couleurs dans les messages de diagnostics. Les
    valeurs possibles sont <literal>always</literal>, <literal>auto</literal>
    et <literal>never</literal>.
   </para>

--- a/postgresql/ref/pg_basebackup.xml
+++ b/postgresql/ref/pg_basebackup.xml
@@ -1025,7 +1025,7 @@
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut
-   utiliser les couleurs dans les messages de diagnostique. Les valeurs
+   utiliser les couleurs dans les messages de diagnostics. Les valeurs
    possibles sont <literal>always</literal>, <literal>auto</literal>,
    <literal>never</literal>.
   </para>

--- a/postgresql/ref/pg_combinebackup.xml
+++ b/postgresql/ref/pg_combinebackup.xml
@@ -303,7 +303,7 @@
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut utiliser
-   les couleurs dans les messages de diagnostique. Les valeurs possibles sont
+   les couleurs dans les messages de diagnostics. Les valeurs possibles sont
    <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.
   </para>

--- a/postgresql/ref/pg_dump.xml
+++ b/postgresql/ref/pg_dump.xml
@@ -1608,7 +1608,7 @@
  </refsect1>
 
  <refsect1 id="app-pgdump-diagnostics">
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    <application>pg_dump</application> exécute intrinsèquement des instructions

--- a/postgresql/ref/pg_dumpall.xml
+++ b/postgresql/ref/pg_dumpall.xml
@@ -803,7 +803,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
   <para>
    Comme <application>pg_dumpall</application> appelle
    <application>pg_dump</application> en interne, certains messages de
-   diagnostique se réfèrent en fait à <application>pg_dump</application>.
+   diagnostic se réfèrent en fait à <application>pg_dump</application>.
   </para>
 
   <para>

--- a/postgresql/ref/pg_resetwal.xml
+++ b/postgresql/ref/pg_resetwal.xml
@@ -427,7 +427,7 @@
     <listitem>
      <para>
       Précise s'il faut utiliser des couleurs dans les messages de
-      diagnostique. Les valeurs possibles sont <literal>always</literal>,
+      diagnostic. Les valeurs possibles sont <literal>always</literal>,
       <literal>auto</literal>, <literal>never</literal>.
      </para>
     </listitem>

--- a/postgresql/ref/pg_restore.xml
+++ b/postgresql/ref/pg_restore.xml
@@ -1017,7 +1017,7 @@
 
 
  <refsect1 id="app-pgrestore-diagnostics">
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    Quand une connexion directe à la base de données est spécifiée avec

--- a/postgresql/ref/pg_verifybackup.xml
+++ b/postgresql/ref/pg_verifybackup.xml
@@ -176,7 +176,7 @@
      <term><option>--no-parse-wal</option></term>
      <listitem>
       <para>
-       N'essaie pas d'analyser les journaux de transaction nécessaires à la
+       N'essaie pas d'analyser les journaux de transactions nécessaires à la
        restauration de la sauvegarde.
       </para>
      </listitem>

--- a/postgresql/ref/pg_waldump.xml
+++ b/postgresql/ref/pg_waldump.xml
@@ -392,7 +392,7 @@
     <term><envar>PG_COLOR</envar></term>
     <listitem>
      <para>
-      Indique s'il faut utiliser la couleur dans les messages de diagnostique.
+      Indique s'il faut utiliser la couleur dans les messages de diagnostic.
       Les valeurs possibles sont <literal>always</literal>,
       <literal>auto</literal>, <literal>never</literal>.
      </para>

--- a/postgresql/ref/pg_walsummary.xml
+++ b/postgresql/ref/pg_walsummary.xml
@@ -114,7 +114,7 @@
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut
-   utiliser, ou non, la couleur pour les messages de diagnostique. Les valeurs
+   utiliser, ou non, la couleur pour les messages de diagnostic. Les valeurs
    acceptées sont <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.
   </para>

--- a/postgresql/ref/pgarchivecleanup.xml
+++ b/postgresql/ref/pgarchivecleanup.xml
@@ -175,7 +175,7 @@ pg_archivecleanup:  removing file "archive/00000001000000370000000E"
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut
-   utiliser la couleur dans les messages de diagnostique. Les valeurs
+   utiliser la couleur dans les messages de diagnostic. Les valeurs
    possibles sont <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.
   </para>

--- a/postgresql/ref/pgbench.xml
+++ b/postgresql/ref/pgbench.xml
@@ -1137,7 +1137,7 @@ pgbench <optional> <replaceable>options</replaceable> </optional>
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> précise si l'on
-   doit utiliser la couleur dans les messages de diagnostique.
+   doit utiliser la couleur dans les messages de diagnostic.
    Les valeurs possibles sont
    <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.

--- a/postgresql/ref/pgtestfsync.xml
+++ b/postgresql/ref/pgtestfsync.xml
@@ -30,7 +30,7 @@
    <application>pg_test_fsync</application> a pour but de donner une idée
    raisonnable de la configuration la plus rapide de <xref
    linkend="guc-wal-sync-method"/> sur votre système spécifique, ainsi que de
-   fournir des informations de diagnostiques dans le cas où un problème
+   fournir des informations de diagnostics dans le cas où un problème
    d'entrées/sorties est identifié. Néanmoins, les différences montrées par
    <application>pg_test_fsync</application> pourraient ne pas faire de grosses
    différences sur une utilisation réelle de la base de données, tout
@@ -111,7 +111,7 @@
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut
-   utiliser la couleur dans les messages de diagnostique. Les valeurs
+   utiliser la couleur dans les messages de diagnostic. Les valeurs
    possibles sont <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.
   </para>

--- a/postgresql/ref/postgres-ref.xml
+++ b/postgresql/ref/postgres-ref.xml
@@ -603,7 +603,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    Un message d'erreur mentionnant <literal>semget</literal> ou

--- a/postgresql/ref/psql-ref.xml
+++ b/postgresql/ref/psql-ref.xml
@@ -865,7 +865,7 @@ basetest=&gt;
     <literal>:<replaceable>variable_name</replaceable></literal> où
     <replaceable>variable_name</replaceable> est une
     variable <application>psql</application>, qui sera remplacée par sa valeur.
-    De plus, les occurences de
+    De plus, les occurrences de
     <literal>:'<replaceable>variable_name</replaceable>'</literal>  sont
     remplacées par la valeur de la variable correctement échappée pour devenir
     un unique argument de commande shell (cette dernière forme est presque
@@ -1365,13 +1365,13 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
       </term>
       <listitem>
        <para>
-        Liste les classes d'opérateur (voir
+        Liste les classes d'opérateurs (voir
         <xref linkend="catalog-pg-opclass"/>).
         Si <replaceable class="parameter">access-method-pattern</replaceable>
-        est spécifié, seules les classes d'opérateur associées avec les
+        est spécifié, seules les classes d'opérateurs associées avec les
         méthodes d'accès dont les noms correspondent au motif sont listées.
         Si <replaceable class="parameter">input-type-pattern</replaceable>
-        est spécifié, seules les classes d'opérateur associées avec les types
+        est spécifié, seules les classes d'opérateurs associées avec les types
         en entrée dont les noms correspondent au motif sont listées.
         Si <literal>+</literal> est ajouté au nom de la commande, chaque classe
         d'opérateur est affichée avec sa famille d'opérateur associée et
@@ -1523,7 +1523,7 @@ INSERT INTO tbl1 VALUES ($1, $2) \bind 'first value' 'second value' \g
       <listitem>
        <para>
         Affiche les descriptions des objets du type <literal>contrainte</literal>,
-        <literal>classe d'opérateur</literal>, <literal>famille d'opérateur</literal>,
+        <literal>classe d'opérateurs</literal>, <literal>famille d'opérateur</literal>,
         <literal>règle</literal> et <literal>trigger</literal>. Tous les autres
         commentaires peuvent être visualisés avec les commandes antislash
         respectives pour ces types d'objets.
@@ -2359,7 +2359,7 @@ Tue Oct 26 21:40:57 CEST 1999
         (<foreignphrase>pipe</foreignphrase>) la sortie vers un autre shell
         exécutant <replaceable class="parameter">commande</replaceable> au
         lieu de l'exécuter comme habituellement. Le fichier ou la commande
-        n'est écrit que si la requête renvoit zéro ou plus enregistrements,
+        n'est écrit que si la requête renvoie zéro ou plus enregistrements,
         mais pas si la requête échoue ou s'il s'agit d'une commande SQL ne
         renvoyant pas de données.
        </para>

--- a/postgresql/ref/reindexdb.xml
+++ b/postgresql/ref/reindexdb.xml
@@ -405,7 +405,7 @@
 
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de difficultés, il peut être utile de consulter <xref linkend="sql-reindex"

--- a/postgresql/ref/select.xml
+++ b/postgresql/ref/select.xml
@@ -495,7 +495,7 @@ TABLE [ ONLY ] <replaceable class="parameter">nom_table</replaceable> [ * ]
         <literal>REPEATABLE</literal> n'est pas indiqué, alors un nouvel
         échantillon est choisi au hasard pour chaque requête, basé sur une
         graine générée par le système. Notez que
-        certaines méthodes d'échantillonage supplémentaires pourraient ne pas
+        certaines méthodes d'échantillonnage supplémentaires pourraient ne pas
         accepter la clausse <literal>REPEATABLE</literal>, et toujours
         produire de nouveau échantillon à chaque utilisation.
        </para>
@@ -573,7 +573,7 @@ TABLE [ ONLY ] <replaceable class="parameter">nom_table</replaceable> [ * ]
         chaque fonction, etc. Si certaines fonctions produisent moins de lignes
         que d'autres, des NULL sont ajoutées pour les données manquantes, ce
         qui permet d'avoir comme nombre de lignes celui de la fonction qui en
-        renvoit le plus.
+        renvoie le plus.
        </para>
 
        <para>

--- a/postgresql/ref/set_transaction.xml
+++ b/postgresql/ref/set_transaction.xml
@@ -275,7 +275,7 @@ SET TRANSACTION SNAPSHOT '00000003-0000001B-1';
   <para>
    Dans le standard SQL, il existe une autre caractéristique de transaction
    pouvant être configurée avec ces commandes&nbsp;: la taille de l'aire de
-   diagnostique. Ce concept est spécifique au SQL embarqué et, du coup,
+   diagnostic. Ce concept est spécifique au SQL embarqué et, du coup,
    n'est pas implémenté dans <productname>PostgreSQL</productname>.
   </para>
 

--- a/postgresql/ref/vacuumdb.xml
+++ b/postgresql/ref/vacuumdb.xml
@@ -624,7 +624,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Diagnostiques</title>
+  <title>Diagnostics</title>
 
   <para>
    En cas de difficultés, il peut être utile de consulter <xref

--- a/postgresql/reference.xml
+++ b/postgresql/reference.xml
@@ -230,7 +230,7 @@
     pas toutes destinées à l'ensemble des utilisateurs. Certaines
     nécessitent des privilèges spécifiques. La caractéristique commune à
     toutes ces applications est leur fonctionnement sur toute machine,
-    indépendemment du serveur sur lequel se trouve le serveur de base de données.
+    indépendamment du serveur sur lequel se trouve le serveur de base de données.
    </para>
 
    <para>
@@ -275,7 +275,7 @@
    <para>
     Cette partie contient des informations de référence concernant les applications et
     les outils relatifs au serveur <productname>PostgreSQL</productname>. Ces
-    commandes n'ont d'utilité que lancées sur la machine sur laquelle le serveur
+    commandes n'ont d'utilité que si elles sont lancées sur la machine sur laquelle le serveur
     fonctionne. D'autres programmes utilitaires sont listés
     dans la <xref linkend="reference-client"/>.
    </para>

--- a/postgresql/regress.xml
+++ b/postgresql/regress.xml
@@ -203,7 +203,7 @@ make check-world -j8 >/dev/null
     <listitem>
      <para>
       Les tests pour les méthodes d'authentification supportés
-      nativemement, situés dans <filename>src/test/authentication</filename>.
+      nativement, situés dans <filename>src/test/authentication</filename>.
       (Voir ci-dessous pour des tests supplémentaires relatifs à
       l'authentification.)
      </para>
@@ -304,7 +304,7 @@ make check-world PG_TEST_EXTRA='kerberos ldap ssl load_balance libpq_encryption'
       <listitem>
        <para>
         Lance le test <filename>src/interfaces/libpq/t/004_load_balance_dns.pl</filename>.
-        Ceci nécessite d'éduter le fichier <filename>hosts</filename> et d'ouvrir
+        Ceci nécessite d'éditer le fichier <filename>hosts</filename> et d'ouvrir
         les sockets d'écoute TCP/IP.
        </para>
       </listitem>
@@ -436,7 +436,7 @@ make check PG_TEST_INITDB_EXTRA_OPTS='-k --wal-segsize=4 -c work_mem=50MB'
    </para>
 
    <para>
-    Pour la suite de tests de régression du coeur et pour d'autres tests
+    Pour la suite de tests de régression du cœur et pour d'autres tests
     conduits par <command>pg_regress</command>, des paramètres d'exécution
     peuvent aussi être configurés dans la variable d'environnement
     <varname>PGOPTIONS</varname> (pour les paramètres qui le permettent), par
@@ -492,7 +492,7 @@ make check EXTRA_TESTS=numeric_big
    examiner les différences entre les résultats attendus et ceux obtenus&nbsp;;
    vous pourriez très bien trouver que les différences ne sont pas significatives.
    Néanmoins, nous nous battons toujours pour maintenir des fichiers de
-   références précis et à jour pour toutes les plateformes supportés de façon à
+   références précis et à jour pour toutes les plateformes supportées de façon à
    ce que tous les tests puissent réussir.
   </para>
 

--- a/postgresql/rowtypes.xml
+++ b/postgresql/rowtypes.xml
@@ -331,7 +331,7 @@ SELECT (m).* FROM (SELECT ma_fonction(x) AS m FROM une_table OFFSET 0) ss;
    <link linkend="queries-values">clause <literal>VALUES</literal></link>, ou d'un
    <link linkend="sql-syntax-row-constructors">constructeur de ligne</link>.
    Dans tous les autres contextes (incluant l'imbrication dans une de ces constructions), attacher <literal>.*</literal> à une
-   valeur composite value ne change pas la valeur, car cela signifie <quote>toutes les colonnes</quote> et donc la valeur composite
+   valeur composite ne change pas la valeur, car cela signifie <quote>toutes les colonnes</quote> et donc la valeur composite
    est produite de nouveau. Par exemple, si <function>une_fonction()</function> accepte un argument de valeur composite,
    ces requêtes ont un résultat identique&nbsp;:
 
@@ -513,7 +513,7 @@ SELECT c.une_fonction FROM element_inventaire c;
    La syntaxe du constructeur <literal>ROW</literal> est habituellement plus simple à
    utiliser que la syntaxe du littéral composite lors de l'écriture de valeurs
    composites dans des commandes SQL. Dans <literal>ROW</literal>, les valeurs
-   individuelles d'un champ sont écrites de la même façon qu'elle l'auraient été
+   individuelles d'un champ sont écrites de la même façon qu'elles l'auraient été
    en n'étant pas membres du composite.
   </para>
  </tip>

--- a/postgresql/rules.xml
+++ b/postgresql/rules.xml
@@ -8,7 +8,7 @@
 
  <para>
   Ce chapitre discute du système de règles dans
-  <productname>PostgreSQL</productname>. les systèmes de règles de
+  <productname>PostgreSQL</productname>. Les systèmes de règles de
   production sont simples conceptuellement mais il existe de nombreux points
   subtils impliqués dans leur utilisation.
  </para>
@@ -63,9 +63,9 @@
    affichables dans le journal de traces du serveur si vous avez configuré les
    paramètres <varname>debug_print_parse</varname>,
    <varname>debug_print_rewritten</varname>, ou
-   <varname>debug_print_plan</varname>. les actions de règles sont aussi
+   <varname>debug_print_plan</varname>. Les actions de règles sont aussi
    enregistrées comme arbres de requêtes dans le catalogue système
-   <structname>pg_rewrite</structname>. elles ne sont pas formatées comme la
+   <structname>pg_rewrite</structname>. Elles ne sont pas formatées comme la
    sortie de traces mais elles contiennent exactement la même information.
   </para>
 
@@ -99,20 +99,20 @@
 
     <varlistentry>
      <term>
-      la table d'échelle
-      <indexterm><primary>table d'échelle</primary></indexterm>
+      la table d'échelles
+      <indexterm><primary>table d'échelles</primary></indexterm>
      </term>
      <listitem>
       <para>
-       La table d'échelle est une liste des relations utilisées dans la
+       La table d'échelles est une liste des relations utilisées dans la
        requête. Dans une instruction <command>select</command>, ce sont les
        relations données après le mot clé <literal>from</literal>.
       </para>
 
       <para>
-       Chaque entrée de la table d'échelle identifie une table ou une vue et
+       Chaque entrée de la table d'échelles identifie une table ou une vue et
        indique par quel nom elle est désignée dans les autres parties de la
-       requête. Dans l'arbre de requêtes, les entrées de la table d'échelle
+       requête. Dans l'arbre de requêtes, les entrées de la table d'échelles
        sont référencées par des numéros plutôt que par des noms. Il
        importe donc peu, ici, de savoir s'il y a des noms dupliqués comme cela
        peut être le cas avec une instruction <acronym>SQL</acronym>. Cela peut
@@ -128,7 +128,7 @@
      </term>
      <listitem>
       <para>
-       C'est un index dans la table d'échelle qui identifie la relation où
+       C'est un index dans la table d'échelles qui identifie la relation où
        iront les résultats de la requête.
       </para>
 
@@ -162,7 +162,7 @@
        <command>select</command> et <command>from</command>
        (<literal>*</literal> est seulement une abréviation pour tous les noms
        de colonnes d'une relation. Il est étendu par l'analyseur en colonnes
-       individuelles, pour que le système de règles ne le voit jamais).
+       individuelles, pour que le système de règles ne le voie jamais).
       </para>
 
       <para>
@@ -179,22 +179,22 @@
       </para>
 
       <para>
-       Pour les commandes <command>insert</command>, la liste cible décrit les
+       Pour les commandes <command>insert</command>, la liste cible décrite les
        nouvelles lignes devant aller dans la relation résultat. Elle consiste
        en des expressions de la clause <literal>values</literal> ou en celles de la
        clause <command>select</command> dans <literal>insert ...
-        SELECT</literal>. la première étape du processus de réécriture ajoute
-       les entrées de la liste cible pour les colonnes n'ont affectées par la
+        SELECT</literal>. La première étape du processus de réécriture ajoute
+       les entrées de la liste cible pour les colonnes n'ont affecté par la
        commande originale mais ayant des valeurs par défaut. Toute colonne
        restante (avec soit une valeur donnée soit une valeur par défaut) sera
        remplie par le planificateur avec une expression NULL constante.
       </para>
 
       <para>
-       Pour les commandes <command>update</command>, la liste cible décrit les
+       Pour les commandes <command>update</command>, la liste cible décrite les
        nouvelles lignes remplaçant les anciennes. Dans le système des règles,
        elle contient seulement les expressions de la partie <literal>set
-        colonne = expression</literal> de la commande. le planificateur gèrera
+        colonne = expression</literal> de la commande. Le planificateur gèrera
        les colonnes manquantes en insérant des expressions qui copient les
        valeurs provenant de l'ancienne ligne dans la nouvelle. Comme pour
        <command>DELETE</command>, un <acronym>CTID</acronym> ou une variable
@@ -205,7 +205,7 @@
       <para>
        Chaque entrée de la liste cible contient une expression qui peut être
        une valeur constante, une variable pointant vers une colonne d'une des
-       relations de la table d'échelle, un paramètre ou un arbre d'expressions
+       relations de la table d'échelles, un paramètre ou un arbre d'expressions
        réalisé à partir d'appels de fonctions, de constantes, de variables,
        d'opérateurs, etc.
       </para>
@@ -236,13 +236,13 @@
      <listitem>
       <para>
        L'arbre de jointure de la requête affiche la structure de la clause
-       <literal>from</literal>. pour une simple requête comme <literal>select ... from
+       <literal>from</literal>. Pour une simple requête comme <literal>select ... from
         a, b, c</literal>, l'arbre de jointure est une simple liste d'éléments
        de <literal>from</literal> parce que nous sommes autorisés à les joindre dans
        tout ordre. Mais quand des expressions <literal>join</literal>, et plus
        particulièrement les jointures externes, sont utilisées, nous devons les
        joindre dans l'ordre affiché par les jointures. Dans ce cas, l'arbre de
-       jointure affiche la structure des expressions <literal>join</literal>. les
+       jointure affiche la structure des expressions <literal>join</literal>. Les
        restrictions associées avec ces clauses <literal>join</literal> particulières
        (à partir d'expressions <literal>on</literal> ou <literal>using</literal>) sont
        enregistrées comme des expressions de qualification attachées aux
@@ -263,8 +263,8 @@
      <listitem>
       <para>
        Les autres parties de l'arbre de requête comme la clause <literal>order
-        BY</literal> n'ont pas d'intérêt ici. le système de règles substitue quelques
-       entrées lors de l'application des règles mais ceci n'a pas grand chose à
+        BY</literal> n'ont pas d'intérêt ici. Le système de règles substitue quelques
+       entrées lors de l'application des règles mais ceci n'a pas grand-chose à
        voir avec les fondamentaux du système de règles.
       </para>
      </listitem>
@@ -330,7 +330,7 @@ CREATE RULE "_RETURN" AS ON SELECT TO ma_vue DO INSTEAD
     Les règles <literal>on select</literal> sont appliquées à toutes les requêtes comme
     la dernière étape, même si la commande donnée est un
     <command>insert</command>, <command>update</command> ou
-    <command>delete</command>. et ils ont des sémantiques différentes à partir
+    <command>delete</command>. Et ils ont une sémantique différente à partir
     des règles sur les autres types de commandes dans le fait qu'elles modifient
     l'arbre de requêtes en place au lieu d'en créer un nouveau. Donc, les règles
     <command>select</command> sont décrites avant.
@@ -339,7 +339,7 @@ CREATE RULE "_RETURN" AS ON SELECT TO ma_vue DO INSTEAD
    <para>
     Actuellement, il n'existe qu'une action dans une règle <literal>on
      SELECT</literal> et elle doit être une action <command>select</command>
-    inconditionnelle qui est <literal>instead</literal>. cette restriction était
+    inconditionnelle qui est <literal>instead</literal>. Cette restriction était
     requise pour rendre les règles assez sûres pour les ouvrir aux utilisateurs
     ordinaires et cela restreint les règles <literal>on select</literal> à agir comme
     des vues.
@@ -434,7 +434,7 @@ CREATE VIEW chaussure_prete AS
     <literal>lacet</literal> est référencée dans une table de la requête.
     La règle n'a aucune qualification de règle (discuté plus tard, avec les
     règles autres que <command>select</command> car les règles <command>select</command> ne
-    le sont pas encore) et qu'il s'agit de <literal>instead</literal>. notez que les
+    le sont pas encore) et qu'il s'agit de <literal>instead</literal>. Notez que les
     qualifications de règles ne sont pas identiques aux qualifications de
     requêtes. L'action de notre règle a une qualification de requête. L'action
     de la règle a un arbre de requête qui est une copie de l'instruction
@@ -443,7 +443,7 @@ CREATE VIEW chaussure_prete AS
 
    <note>
     <para>
-     Les deux entrées supplémentaires de la table d'échelle pour <literal>new</literal>
+     Les deux entrées supplémentaires de la table d'échelles pour <literal>new</literal>
      et <literal>old</literal> que vous pouvez voir
      dans l'entrée de <structname>pg_rewrite</structname> ne sont d'aucun intérêt
      pour les règles <command>select</command>.
@@ -503,7 +503,7 @@ SELECT * FROM lacet;
 
     et ceci est transmis au système de règles. Ce système traverse la table
     d'échelle et vérifie s'il existe des règles pour chaque relation. Lors du
-    traitement d'une entrée de la table d'échelle pour
+    traitement d'une entrée de la table d'échelles pour
     <literal>lacet</literal> (la seule jusqu'à maintenant), il trouve la
     règle <literal>_return</literal> avec l'arbre de requête&nbsp;:
 
@@ -536,13 +536,13 @@ SELECT * FROM lacet;
          WHERE s.unite_lacet = u.nom_unite) lacet;
     </programlisting>
 
-    Néanmoins, il y a une différence&nbsp;: la table d'échelle de la
+    Néanmoins, il y a une différence&nbsp;: la table d'échelles de la
     sous-requête a deux entrées supplémentaires, <literal>lacet old</literal> et
-    <literal>lacet new</literal>. ces entrées ne participent pas directement dans
+    <literal>lacet new</literal>. Ces entrées ne participent pas directement dans
     la requête car elles ne sont pas référencées par l'arbre de jointure de la
     sous-requête ou par la liste cible. La réécriture les utilise pour
     enregistrer l'information de vérification des droits d'accès qui étaient
-    présents à l'origine dans l'entrée de table d'échelle référencée par la
+    présents à l'origine dans l'entrée de table d'échelles référencée par la
     vue. De cette façon, l'exécution vérifiera toujours que l'utilisateur a les
     bons droits pour accéder à la vue même s'il n'y a pas d'utilisation directe
     de la vue dans la requête réécrite.
@@ -550,9 +550,9 @@ SELECT * FROM lacet;
 
    <para>
     C'était la première règle appliquée. Le système de règles continuera de
-    vérifier les entrées restantes de la table d'échelle dans la requête
+    vérifier les entrées restantes de la table d'échelles dans la requête
     principale (dans cet exemple, il n'en existe pas plus), et il vérifiera
-    récursivement les entrées de la table d'échelle dans la sous-requête ajoutée
+    récursivement les entrées de la table d'échelles dans la sous-requête ajoutée
     pour voir si une d'elle référence les vues. (Mais il n'étendra ni
     <literal>old</literal> ni <literal>new</literal> &mdash; sinon nous aurions une récursion
     infinie&nbsp;!) Dans cet exemple, il n'existe pas de règles de réécriture
@@ -607,7 +607,7 @@ SELECT * FROM lacet;
     </programlisting>
 
     De façon similaire, les règles pour <literal>chaussure</literal> et
-    <literal>lacet</literal> sont substituées dans la table d'échelle de
+    <literal>lacet</literal> sont substituées dans la table d'échelles de
     la sous-requête, amenant à l'arbre de requête final à trois niveaux&nbsp;:
 
     <programlisting>SELECT chaussure_prete.nom_chaussure, chaussure_prete.dispo,
@@ -657,7 +657,7 @@ SELECT * FROM lacet;
 
    <para>
     Deux détails de l'arbre de requête n'ont pas été abordés dans la
-    description des règles de vue ci-dessus. Ce sont le type de commande et le
+    description des règles de vue ci-dessus. Ce sont le type de commande et la
     relation résultante. En fait, le type de commande n'est pas nécessaire
     pour les règles de la vue mais la relation résultante pourrait affecter
     la façon dont la requête sera réécrite car une attention particulière doit
@@ -669,7 +669,7 @@ SELECT * FROM lacet;
     <command>select</command> et un pour une autre commande. de façon évidente,
     ils ont un type de commande différent et pour une commande autre qu'
     un <command>select</command>, la relation résultante pointe vers l'entrée de
-    table d'échelle où le résultat devrait arriver. Tout le reste est absolument
+    table d'échelles où le résultat devrait arriver. Tout le reste est absolument
     identique. Donc, avec deux tables <literal>t1</literal> et <literal>t2</literal> avec les
     colonnes <literal>a</literal> et <literal>b</literal>, les arbres de requêtes pour les
     deux commandes&nbsp;:
@@ -692,7 +692,7 @@ UPDATE t1 SET b = t2.b FROM t2 WHERE t1.a = t2.a;
      <listitem>
       <para>
        Les listes cibles contiennent une variable pointant vers la colonne
-       <literal>b</literal> de l'entrée de la table d'échelle pour la table
+       <literal>b</literal> de l'entrée de la table d'échelles pour la table
        <literal>t2</literal>.
       </para>
      </listitem>
@@ -700,7 +700,7 @@ UPDATE t1 SET b = t2.b FROM t2 WHERE t1.a = t2.a;
      <listitem>
       <para>
        Les expressions de qualification comparent les colonnes
-       <literal>a</literal> des deux entrées de table d'échelle pour une égalité.
+       <literal>a</literal> des deux entrées de table d'échelles pour une égalité.
       </para>
      </listitem>
 
@@ -747,7 +747,7 @@ UPDATE t1 SET b = t2.b FROM t2 WHERE t1.a = t2.a;
      ID</foreignphrase>).<indexterm><primary>ctid</primary></indexterm> cette colonne système
     contient le numéro de bloc du fichier et la position dans le bloc pour
     cette ligne. Connaissant la table, le <acronym>ctid</acronym> peut être utilisé
-    pour récupérer la ligne originale de <literal>t1</literal> à mettre à jour. après
+    pour récupérer la ligne originale de <literal>t1</literal> à mettre à jour. Après
     avoir ajouté le <acronym>ctid</acronym> dans la liste cible, la requête ressemble à
     ceci&nbsp;:
 
@@ -756,7 +756,7 @@ UPDATE t1 SET b = t2.b FROM t2 WHERE t1.a = t2.a;
 
     Maintenant, un autre détail de <productname>PostgreSQL</productname> entre
     en jeu. Les anciennes lignes de la table ne sont pas surchargées et cela
-    explique pourquoi <command>rollback</command> est rapide. avec un
+    explique pourquoi <command>rollback</command> est rapide. Avec un
     <command>update</command>, la nouvelle ligne résultat est insérée dans la
     table (après avoir enlevé le <acronym>ctid</acronym>) et, dans le nouvel en-tête de
     ligne de l'ancienne ligne, vers où pointe le <acronym>ctid</acronym>, les entrées
@@ -788,7 +788,7 @@ UPDATE t1 SET b = t2.b FROM t2 WHERE t1.a = t2.a;
     le planificateur a toute l'information sur les tables à parcourir et sur
     les relations entre ces tables et les qualifications restrictives à partir
     des vues et les qualifications à partir de la requête originale dans un
-    seule arbre de requête. Et c'est toujours la situation quand la requête
+    seul arbre de requête. Et c'est toujours la situation quand la requête
     originale est déjà une jointure sur des vues. Le planificateur doit décider
     du meilleur chemin pour exécuter la requête et plus le planificateur a
     d'informations, meilleure sera la décision. Le système de règles implémenté
@@ -818,7 +818,7 @@ UPDATE t1 SET b = t2.b FROM t2 WHERE t1.a = t2.a;
    <para>
     Si la sous-requête fait une sélection à partir d'une relation simple et
     qu'elle est suffisamment simple, le processus de réécriture peut
-    automatiquement remplacé la sous-requête avec la relation sous-jacente
+    automatiquement remplacer la sous-requête avec la relation sous-jacente
     pour que l'<command>INSERT</command>, l'<command>UPDATE</command>,
     le <command>DELETE</command> ou le <command>MERGE</command> soit appliqué
     correctement sur la relation
@@ -988,7 +988,7 @@ CREATE UNIQUE INDEX ventes_resume_vendeur
    </programlisting>
 
    Cette vue matérialisée peut être utile pour afficher un graphe dans
-   l'affichage créée pour les vendeurs. Une tâche de fond pourrait être
+   l'affichage créé pour les vendeurs. Une tâche de fond pourrait être
    planifiée pour mettre à jour les statistiques chaque nuit en utilisant
    cette requête SQL&nbsp;:
 
@@ -1222,11 +1222,11 @@ SELECT mot FROM mots ORDER BY mot &lt;-&gt; 'caterpiler' LIMIT 10;
     Les règles de mise à jour sont appliquées par le système de règles lorsque
     la relation résultante et le type de commande d'un arbre de requête sont
     égaux pour l'objet et l'événement donné dans la commande <command>create
-     RULE</command>. pour les règles de mise à jour, le système de règles crée
+     RULE</command>. Pour les règles de mise à jour, le système de règles crée
     une liste d'arbres de requêtes. Initialement, la liste d'arbres de requêtes
     est vide. Il peut y avoir aucune (mot clé <literal>nothing</literal>), une ou
     plusieurs actions. Pour simplifier, nous verrons une règle avec une action.
-    Cette règle peut avoir une  qualification et peut être de type
+    Cette règle peut avoir une qualification et peut être de type
     <literal>instead</literal> ou <literal>also</literal> (valeur par défaut).
    </para>
 
@@ -1308,16 +1308,16 @@ SELECT mot FROM mots ORDER BY mot &lt;-&gt; 'caterpiler' LIMIT 10;
 
    <para>
     Les arbres de requête trouvés dans les actions du catalogue système
-    <structname>pg_rewrite</structname> sont seulement des modèles. comme ils
-    peuvent référencer les entrées de la table d'échelle pour <literal>new</literal> et
+    <structname>pg_rewrite</structname> sont seulement des modèles. Comme ils
+    peuvent référencer les entrées de la table d'échelles pour <literal>new</literal> et
     <literal>old</literal>, quelques substitutions ont dû être faites avant qu'elles ne
     puissent être utilisées. Pour toute référence de <literal>new</literal>, une entrée
     correspondante est recherchée dans la liste cible de la requête originale.
     Si elle est trouvée, cette expression de l'entrée remplace la référence.
     Sinon, <literal>new</literal> signifie la même chose que <literal>old</literal> (pour un
-    <command>update</command>) ou est remplacé par une valeur null (pour un
-    <command>insert</command>). toute référence à <literal>old</literal> est remplacée
-    par une référence à l'entrée de la table d'échelle qui est la relation
+    <command>update</command>) où est remplacé par une valeur null (pour un
+    <command>insert</command>). Toute référence à <literal>old</literal> est remplacée
+    par une référence à l'entrée de la table d'échelles qui est la relation
     résultante.
    </para>
 
@@ -1398,9 +1398,9 @@ CREATE RULE log_lacet AS ON UPDATE TO donnees_lacet
      </programlisting>
 
      (ceci semble un peu étrange car, normalement, vous ne pouvez pas écrire
-     <literal>insert ... values ... from</literal>. ici, la clause <literal>from</literal>
-     indique seulement qu'il existe des entrées de la table d'échelle dans
-     l'arbre de requête pour <literal>new</literal> et <literal>old</literal>. elles sont
+     <literal>insert ... values ... from</literal>. Ici, la clause <literal>from</literal>
+     indique seulement qu'il existe des entrées de la table d'échelles dans
+     l'arbre de requête pour <literal>new</literal> et <literal>old</literal>. Elles sont
      nécessaires pour qu'elles puissent être référencées par des variables dans
      l'arbre de requête de la commande <command>insert</command>).
     </para>
@@ -1409,7 +1409,7 @@ CREATE RULE log_lacet AS ON UPDATE TO donnees_lacet
      La règle est une règle qualifiée <literal>also</literal> de façon à ce que
      le système de règles doit renvoyer deux arbres de requêtes&nbsp;: l'action
      de la règle modifiée et l'arbre de requête original. Dans la première
-     étape, la table d'échelle de la requête originale est incorporée dans l'arbre
+     étape, la table d'échelles de la requête originale est incorporée dans l'arbre
      de requête d'action de la règle. Ceci a pour résultat&nbsp;:
 
      <programlisting>INSERT INTO lacet_log VALUES (
@@ -1536,7 +1536,7 @@ UPDATE donnees_lacet SET dispo_lacet = 6
      </programlisting>
 
      en fait, quatre lignes sont modifiées (<literal>sl1</literal>, <literal>sl2</literal>,
-     <literal>sl3</literal> et <literal>sl4</literal>). mais <literal>sl3</literal> a déjà
+     <literal>sl3</literal> et <literal>sl4</literal>). Mais <literal>sl3</literal> a déjà
      <literal>dispo_lacet = 0</literal>. dans ce cas, la qualification des arbres de
      requêtes originaux sont différents et cela produit un arbre de requête
      supplémentaire&nbsp;:
@@ -1764,7 +1764,7 @@ SELECT lacet_arrive.arr_name, lacet_arrive.arr_quant
     </programlisting>
 
     et jette l'<command>insert</command> actuel sur
-    <literal>lacet_ok</literal>. la requête réécrite est passée de nouveau
+    <literal>lacet_ok</literal>. La requête réécrite est passée de nouveau
     au système de règles et la seconde règle appliquée
     <literal>lacet_upd</literal> produit&nbsp;:
 
@@ -1784,7 +1784,7 @@ SELECT lacet_arrive.arr_name, lacet_arrive.arr_quant
 
     De nouveau, il s'agit d'une règle <literal>instead</literal> et l'arbre de
     requête précédent est jeté. Notez que cette requête utilise toujours la vue
-    <literal>lacet</literal>. mais le système de règles n'a pas fini cette
+    <literal>lacet</literal>. Mais le système de règles n'a pas fini cette
     étape, donc il continue et lui applique la règle <literal>_return</literal>.
     Nous obtenons&nbsp;:
 
@@ -1862,7 +1862,7 @@ UPDATE donnees_lacet
    <para>
     Il y a un petit détail assez horrible. En regardant les deux requêtes, nous
     nous apercevons que la relation <literal>donnees_lacet</literal> apparaît
-    deux fois dans la table d'échelle où cela pourrait être réduit à une seule
+    deux fois dans la table d'échelles où cela pourrait être réduit à une seule
     occurrence. Le planificateur ne gère pas ceci et, du coup, le plan
     d'exécution de la sortie du système de règles pour <command>insert</command>
     sera&nbsp;:
@@ -1878,7 +1878,7 @@ UPDATE donnees_lacet
      -&gt;  Seq Scan on donnees_lacet
     </literallayout>
 
-    alors qu'omettre la table d'échelle supplémentaire résulterait en un&nbsp;:
+    alors qu'omettre la table d'échelles supplémentaire résulterait en un&nbsp;:
 
     <literallayout class="monospaced">Merge Join
      -&gt;  Seq Scan
@@ -1891,9 +1891,9 @@ UPDATE donnees_lacet
 
     qui produit exactement les mêmes entrées dans la table des traces. Du
     coup, le système de règles a causé un parcours supplémentaire dans la table
-    <literal>donnees_lacet</literal> qui n'est absolument pas nécessaire. et le
+    <literal>donnees_lacet</literal> qui n'est absolument pas nécessaire. Et le
     même parcours redondant est fait une fois de plus dans
-    l'<command>update</command>. mais ce fut réellement un travail difficile de
+    l'<command>update</command>. Mais ce fut réellement un travail difficile de
     rendre tout ceci possible.
    </para>
 
@@ -2032,9 +2032,9 @@ GRANT SELECT ON phone_number TO assistant;
 
    Personne en dehors de cet utilisateur (et les superutilisateurs de la base de
    données) ne peut
-   accéder à la table <literal>phone_data</literal>. mais, à cause du
+   accéder à la table <literal>phone_data</literal>. Mais, à cause du
    <command>grant</command>, l'assistant peut lancer un <command>select</command>
-   sur la vue <literal>phone_number</literal>. le système de règles réécrira le
+   sur la vue <literal>phone_number</literal>. Le système de règles réécrira le
    <command>select</command> sur <literal>phone_number</literal> en un
    <command>select</command> sur <literal>phone_data</literal>. Comme l'utilisateur est le
    propriétaire de <literal>phone_number</literal> et du coup le propriétaire de la
@@ -2116,11 +2116,11 @@ SELECT * FROM phone_number WHERE tricky(person, phone);</programlisting>
     données d'exemple pourrait accorder les droits <literal>select</literal>,
     <literal>insert</literal>, <literal>update</literal> et <literal>delete</literal> sur la vue
     <literal>lacet</literal> à quelqu'un d'autre mais seulement <literal>select</literal>
-    sur <literal>lacet_log</literal>. l'action de la règle pourrait écrire des
+    sur <literal>lacet_log</literal>. L'action de la règle pourrait écrire des
     entrées de trace qui seraient toujours exécutées avec succès et que l'autre
-    utilisateur pourrait voir. Mais il ne peut pas créer d'entrées fausses, pas
+    utilisateur pourrait voir. Mais il ne peut pas créer de fausses entrées, pas
     plus qu'il ne peut manipuler ou supprimer celles qui existent. Dans ce cas,
-    il n'existe pas de possibilité de subvertir les règles en convaincant le
+    il n'existe pas de possibilité de subvertir les règles en convainquant le
     planificateur de modifier l'ordre des opérations car la seule règle qui fait
     référence à <literal>shoelace_log</literal> est un <literal>INSERT</literal>
     non qualifié. Ceci pourrait ne plus être vrai dans les scénarios complexes.
@@ -2216,7 +2216,7 @@ CREATE VIEW phone_number WITH (security_barrier) AS
       requête qui a été insérée par une règle <literal>instead</literal>
       (conditionnelle ou non) et est du même type de commande
       (<command>insert</command>, <command>update</command> ou
-      <command>delete</command>) que la requête originale. si aucune requête ne
+      <command>delete</command>) que la requête originale. Si aucune requête ne
       rencontrant ces pré-requis n'est ajoutée à une règle, alors le statut de
       commande renvoyé affiche le type de requête original et annule le
       compteur de ligne et le champ OID.
@@ -2249,7 +2249,7 @@ CREATE VIEW phone_number WITH (security_barrier) AS
   <para>
    Beaucoup de choses pouvant se faire avec des triggers peuvent aussi
    être implémentées en utilisant le système de règles de
-   <productname>PostgreSQL</productname>. un des points qui ne pourra pas être
+   <productname>PostgreSQL</productname>. Un des points qui ne pourra pas être
    implémenté par les règles en certains types de contraintes, notamment les
    clés étrangères. Il est possible de placer une règle qualifiée qui réécrit
    une commande en <literal>nothing</literal> si la valeur d'une colonne n'apparaît
@@ -2344,7 +2344,7 @@ CREATE TABLE logiciel (
 
   <para>
    Avec la prochaine suppression, nous voulons nous débarrasser des 2000
-   ordinateurs où <structfield>nom_hote</structfield> commence avec <literal>old</literal>. il
+   ordinateurs où <structfield>nom_hote</structfield> commence avec <literal>old</literal>. Il
    existe deux commandes possibles pour ce faire. Voici l'une d'elle&nbsp;:
 
    <programlisting>DELETE FROM ordinateur WHERE nom_hote &gt;= 'old'
@@ -2387,7 +2387,7 @@ CREATE TABLE logiciel (
    commande. Le trigger sera appelé une fois pour chacun des 2000 anciens
    ordinateurs qui doivent être supprimées, et ceci résultera en un parcours
    d'index sur <literal>ordinateur</literal> et 2000 parcours d'index sur
-   <literal>logiciel</literal>. l'implémentation de la règle le fera en deux commandes
+   <literal>logiciel</literal>. L'implémentation de la règle le fera en deux commandes
    qui utilisent les index. Et cela dépend de la taille globale de la table
    <literal>logiciel</literal>, si la règle sera toujours aussi rapide dans la
    situation du parcours séquentiel. 2000 exécutions de commandes à partir du
@@ -2402,7 +2402,7 @@ CREATE TABLE logiciel (
    </programlisting>
 
    De nouveau, ceci pourrait résulter en de nombreuses lignes à supprimer dans
-   <literal>ordinateur</literal>. donc, le trigger lancera de nouveau de nombreuses
+   <literal>ordinateur</literal>. Donc, le trigger lancera de nouveau de nombreuses
    commandes via l'exécuteur. La commande générée par la règle sera&nbsp;:
 
    <programlisting>DELETE FROM logiciel WHERE ordinateur.constructeur = 'bim'

--- a/postgresql/runtime.xml
+++ b/postgresql/runtime.xml
@@ -149,7 +149,7 @@
    parent. Il est généralement recommandé que l'utilisateur
    <productname>PostgreSQL</productname> soit propriétaire du répertoire des
    données, mais aussi du répertoire parent pour que ce problème ne se
-   présente pas. Si le répertoire parent souhaité n'existe pas plus, vous
+   présente pas. Si le répertoire parent souhaité n'existe plus, vous
    aurez besoin de le créer, en utilisant les droits de l'utilisateur root si
    nécessaire. Le processus pourrait ressembler à ceci&nbsp;:
    <screen>root# <userinput>mkdir /usr/local/pgsql</userinput>
@@ -613,7 +613,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).</screen>
     <para>
      Bien que les conditions d'erreurs possibles du côté client sont assez
      variées et dépendantes de l'application, certaines pourraient être en
-     relation direct avec la façon dont le serveur a été lancé. Les conditions
+     relation directe avec la façon dont le serveur a été lancé. Les conditions
      autres que celles montrées ici devraient être documentées avec
      l'application client respective.
     </para>
@@ -641,7 +641,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).</screen>
 
     <para>
      Un message d'échec de connexion affiche toujours l'adresse du serveur ou
-     le chemin de la socket, ce qui est utile pour vérifier que le client est
+     le chemin du socket, ce qui est utile pour vérifier que le client est
      en train de se connecter au bon endroit. Si aucun serveur n'est en
      écoute ici, le message d'erreur du noyau sera typiquement soit
      <computeroutput>connection refused</computeroutput> soit
@@ -651,7 +651,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).</screen>
      ne signifie <emphasis>pas</emphasis> que le serveur a obtenu une demande
      de connexion et l'a refusé. Ce cas produira un message différent comme
      indiqué dans la <xref linkend="client-authentication-problems"/>).
-     D'autres messages d'erreurs tel que <computeroutput>connection timed
+     D'autres messages d'erreurs tels que <computeroutput>connection timed
      out</computeroutput> pourraient indiquer des problèmes plus fondamentaux
      comme un manque de connexion réseau, ou un pare-feu bloquant la
      connexion.
@@ -945,7 +945,7 @@ DETAIL:  Failed system call was semget(5440126, 17, 03600).</screen>
  <listitem>
   <indexterm><primary>NetBSD</primary><secondary>configuration IPC</secondary></indexterm>
   <para>
-   La configuration par défaut de la mémoire partagé est en général
+   La configuration par défaut de la mémoire partagée est en général
    suffisante, sauf si vous avez affecté <literal>shared_memory_type</literal>
    à <literal>sysv</literal>. Dans ce cas, vous voudrez habituellement
    augmenter <literal>kern.ipc.semmni</literal> et
@@ -1108,7 +1108,7 @@ projadd -c "PostgreSQL DB User" -K "project.max-shm-memory=(privileged,8GB,deny)
 
   <para>
    Sur un serveur de bases de données ayant beaucoup de connexions,
-   les autres modifications recommandés pour le noyau sont&nbsp;:
+   les autres modifications recommandées pour le noyau sont&nbsp;:
    <programlisting>
 project.max-shm-ids=(priv,32768,deny)
 project.max-sem-ids=(priv,4096,deny)
@@ -1467,7 +1467,7 @@ hugepages-1048576kB  hugepages-2048kB
 
     Dans cet exemple, la valeur par défaut est de 2 Mo, vous pouvez aussi
     demander explicitement soit 2 Mo soit 1 Go avec <xref
-    linkend="guc-huge-page-size"/>.  pour s'adapter au nombre de blocs calculé
+    linkend="guc-huge-page-size"/>.  Pour s'adapter au nombre de blocs calculés
     par <varname>shared_memory_size_in_huge_pages</varname>.  Alors que nous
     avons besoin d'au moins <literal>3170</literal> Huge Pages dans cet exemple,
     une configuration plus importante serait appropriée si les autres programmes
@@ -1481,7 +1481,7 @@ hugepages-1048576kB  hugepages-2048kB
     N'oubliez pas d'ajouter cette configuration à
     <filename>/etc/sysctl.conf</filename> pour qu'elle soit appliquée à
     chaque redémarrage. Pour les tailles personnalisées de Huge Page, nous
-    pouvons utilisez à la place&nbsp;:
+    pouvons utiliser à la place&nbsp;:
 
 <programlisting>
 # <userinput>echo 3170 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages</userinput>
@@ -1636,7 +1636,7 @@ Par exemple, pour exécuter un arrêt rapide&nbsp;:
 
   <important>
    <para>
-    Il vaux mieux de ne pas utiliser <systemitem>SIGKILL</systemitem> pour arrêter
+    Il vaut mieux de ne pas utiliser <systemitem>SIGKILL</systemitem> pour arrêter
     le serveur. Le faire empêchera le serveur de libérer la mémoire partagée et
     les sémaphores. De plus, <systemitem>SIGKILL</systemitem> tue
     le processus <command>postgres</command> sans lui laisser le temps de
@@ -1717,17 +1717,17 @@ Par exemple, pour exécuter un arrêt rapide&nbsp;:
    modifications peuvent être nécessaires sur les applications clientes.
    Tous les changements visibles par les utilisateurs sont listés dans
    les notes de version (<xref linkend="release"/>). Soyez particulièrement
-   attentif à la section Migration. Bien que vous pouvez mettre à jour d'une
+   attentif à la section Migration. Bien que vous puissiez mettre à jour d'une
    version majeure vers une autre sans passer par les versions intermédiaires,
    vous devez lire les notes de version de toutes les versions majeures
    intermédiaires.
   </para>
 
   <para>
-   Les utilisateurs précautionneux testeront leur applications clientes
+   Les utilisateurs précautionneux testeront leurs applications clientes
    sur la nouvelle version avant de basculer complètement. Du coup, il
    est souvent intéressant de mettre en place des installations parallèles
-   des ancienne et nouvelle versions. Lors d'un test d'une mise à jour
+   des anciennes et nouvelles versions. Lors d'un test d'une mise à jour
    majeure de <productname>PostgreSQL</productname>, pensez aux
    différentes catégories suivantes&nbsp;:
   </para>
@@ -1860,7 +1860,7 @@ d'utiliser la commande <application>pg_dumpall</application>
 provenant de la version &version; de
 <productname>PostgreSQL</productname>, car cette version contient
 des corrections de bugs et des améliorations par rapport aux
-anciennes version. Bien que ce conseil peut sembler étonnant, étant
+anciennes versions. Bien que ce conseil puisse sembler étonnant, étant
 donné que vous n'avez pas encore été la nouvelle version, il est
 conseillé de le suivre si vous souhaitez installer la nouvelle
 version en parallèle de l'ancienne. Dans ce cas, vous pouvez
@@ -2110,7 +2110,7 @@ Le client TCP doit se connecter en utilisant <literal>gssencmode=require</litera
 
 <para>
 <productname>PostgreSQL</productname> offre du chiffrement à différents niveaux
-et offre une certaine flexibilité pour éviter que les données soit révélées
+et offre une certaine flexibilité pour éviter que les données soient révélées
 à cause d'un vol du serveur de la base de données, d'administrateurs peu scrupuleux
 et de réseaux non sécurisés. Le chiffrement pourrait aussi être requis pour
 sécuriser des données sensibles, par exemple des informations médicales ou des
@@ -2165,7 +2165,7 @@ serveur de bases de données, tel que l'administrateur du système.
 <listitem>
 <para>
 Le chiffrement du stockage peut se réaliser au niveau du système de
-fichiers ou au niveu du bloc. Les options de chiffrement des systèmes
+fichiers ou au niveau du bloc. Les options de chiffrement des systèmes
 de fichiers sous Linux incluent eCryptfs et EncFS, alors que FreeBSD
 utilise PEFS. Les options de chiffrement au niveau bloc ou au niveau
 disque incluent dm-crypt + LUKS sur Linux et les modules GEOM geli et
@@ -2179,7 +2179,7 @@ lecteurs s'ils sont volés. Ceci ne protège pas contre les attaques quand
 le système de fichiers est monté parce que, une fois monté, le système
 d'exploitation fournit une vue non chiffrée des données. Néanmoins, pour
 monter le système de fichiers, vous avez besoin d'un moyen pour fournir
-la clé de chiffrement au système d'exploitation et, quelque fois, la clé
+la clé de chiffrement au système d'exploitation et, quelquefois, la clé
 est stocké quelque part près de l'hôte qui monte le disque.
 </para>
 </listitem>
@@ -2208,7 +2208,7 @@ d'indiquer quels clients peuvent utiliser des connexions non chiffrées
 (<literal>host</literal>) et lesquels nécessitent des connexions
 chiffrées par GSSAPI (<literal>hostgssenc</literal>).
 Les clients peuvent aussi préciser qu'ils ne se connecteront
-qu'avec des connections chiffrées par GSSAPI
+qu'avec des connexions chiffrées par GSSAPI
 (<literal>gssencmode=require</literal>).
 
 </para>
@@ -2280,7 +2280,7 @@ linkend="installation"/>).
 
   <para>
    Les termes <acronym>SSL</acronym> et <acronym>TLS</acronym> sont souvent
-   utilisés de façon interchangeables pour signifier une connexion chiffrée
+   utilisés de façon interchangeable pour signifier une connexion chiffrée
    sécurisée en utilisant un protocole <acronym>TLS</acronym>. Les protocoles
    <acronym>SSL</acronym> sont les précurseurs des protocoles
    <acronym>TLS</acronym>, et le terme <acronym>SSL</acronym> est encore

--- a/postgresql/seg.xml
+++ b/postgresql/seg.xml
@@ -95,7 +95,7 @@ test=&gt; select '6.25 .. 6.50'::seg as "pH";
    nombres à virgule flottante joint par l'opérateur d'échelle
    (<literal>..</literal> ou <literal>...</literal>). Sinon, il peut être
    spécifié comme un point central plus ou moins une déviation.
-   Des indicateurs optionels (<literal>&lt;</literal>,
+   Des indicateurs optionnels (<literal>&lt;</literal>,
    <literal>&gt;</literal> et <literal>~</literal>) peuvent aussi être stockés.
    (Néanmoins, ces indicateurs sont ignorés par la logique interne.)
    <xref linkend="seg-repr-table"/> donne un aperçu des représentations
@@ -232,7 +232,7 @@ test=&gt; select '6.25 .. 6.50'::seg as "pH";
   <title>Précision</title>
 
   <para>
-   Les valeurs <type>seg</type> sont stockés en interne sous la forme de paires
+   Les valeurs <type>seg</type> sont stockées en interne sous la forme de paires
    de nombres en virgule flottante de 32 bits. Cela signifie que les nombres
    avec plus de sept chiffres significatifs sont tronqués.
   </para>
@@ -242,7 +242,7 @@ test=&gt; select '6.25 .. 6.50'::seg as "pH";
    conservent leur précision originale. C'est-à-dire que, si votre requête
    renvoie 0.00, vous serez sûr que les zéros qui suivent ne sont pas des
    conséquences du formatage&nbsp;: elles reflètent la précision de la donnée
-   originale. Le nombre de zéro au début n'affectent pas la précision&nbsp;:
+   originale. Le nombre de zéro au début n'affecte pas la précision&nbsp;:
    deux chiffres significatifs sont considérés pour la valeur 0.0067.
   </para>
  </sect2>
@@ -251,9 +251,9 @@ test=&gt; select '6.25 .. 6.50'::seg as "pH";
   <title>Utilisation</title>
 
   <para>
-   Le module <filename>seg</filename> inclut une classe d'opérateur pour les
+   Le module <filename>seg</filename> inclut une classe d'opérateurs pour les
    index GiST dans le cas des valeurs <type>seg</type>. Les opérateurs
-   supportés par la classe d'opérateur GiST are shown in <xref linkend="seg-gist-operators"/>.
+   supportés par la classe d'opérateurs GiST sont visibles dans <xref linkend="seg-gist-operators"/>.
   </para>
 
   <table id="seg-gist-operators">
@@ -412,7 +412,7 @@ postgres=&gt; select '10(+-)1'::seg as seg;
    l'idée centrale de GiST (<ulink
    url="http://gist.cs.berkeley.edu/"></ulink>). Mes remerciements aussi aux
    développeurs de PostgreSQL pour m'avoir permis de créer mon propre monde
-   et de pouvoir y vivre sans pertubation. Argonne Lab et le département
+   et de pouvoir y vivre sans perturbation. Argonne Lab et le département
    américain de l'énergie ont aussi toute ma gratitude pour les années de
    support dans ma recherche sur les bases de données.
   </para>

--- a/postgresql/sepgsql.xml
+++ b/postgresql/sepgsql.xml
@@ -27,7 +27,7 @@
   <para>
    Ce module s'intègre avec <productname>SELinux</productname> pour
    fournir une couche de vérification de sécurité supplémentaire qui va
-   au-delà de ce qui est déjà fournit par
+   au-delà de ce qui est déjà fourni par
    <productname>PostgreSQL</productname>. De la perspective de
    <productname>SELinux</productname>, ce module permet à
    <productname>PostgreSQL</productname> de fonctionner comme un
@@ -51,7 +51,7 @@
    sujets au même critère général utilisé pour les objets de tout type
    (par exemple les fichiers). Ce concept a pour but de permettre la mise
    en place d'une politique centralisée pour protéger l'information
-   quelque soit la façon dont l'information est stockée.
+   quelle que soit la façon dont l'information est stockée.
   </para>
 
   <para>
@@ -117,7 +117,7 @@ Policy from config file:        targeted
   <para>
    Voici un exemple montrant comment initialiser un répertoire de données
    avec les fonctions <filename>sepgsql</filename> et les labels de
-   sécurité installés. Ajustez les chemins de façon approprié pour que
+   sécurité installés. Ajustez les chemins de façon appropriée pour que
    cela corresponde à votre installation&nbsp;:
   </para>
 
@@ -152,7 +152,7 @@ $ export PGDATA=/path/to/data/directory
   </para>
 
   <para>
-   Si le processus d'installation se termine sans erreur, vous pouvez
+   Si le processus d'installation se termine sans erreurs, vous pouvez
    commencer à lancer le serveur normalement.
   </para>
  </sect2>
@@ -269,9 +269,9 @@ $ sudo semodule -r sepgsql-regtest
      </indexterm>
      <para>
       Ce paramètre active <productname>sepgsql</productname> pour
-      qu'il fonctionne en mode permissif, quelque soit la configuration
+      qu'il fonctionne en mode permissif, quelle que soit la configuration
       du système. La valeur par défaut est off.
-      Ce paramètre es configurable dans le fichier
+      Ce paramètre est configurable dans le fichier
       <filename>postgresql.conf</filename> et sur la ligne de commande.
      </para>
 
@@ -291,7 +291,7 @@ $ sudo semodule -r sepgsql-regtest
       <primary>paramètre de configuration <varname>sepgsql.debug_audit</varname></primary>
      </indexterm>
      <para>
-      Ce paramètre active l'affichage de messages d'audit quelque soit
+      Ce paramètre active l'affichage de messages d'audit quelle que soit
       la configuration de la politique. La valeur par défaut est
       off, autrement dit les messages seront affichés suivant la
       configuration du système.
@@ -305,7 +305,7 @@ $ sudo semodule -r sepgsql-regtest
      </para>
 
      <para>
-      Ce paramètre force l'activation de toutes les traces, quelque soit
+      Ce paramètre force l'activation de toutes les traces, quelle que soit
       la politique du système.
      </para>
     </listitem>
@@ -450,7 +450,7 @@ UPDATE t1 SET x = 2, y = func1(y) WHERE z = 100;
     <productname>SELinux</productname> définit plusieurs droits pour contrôler
     les opérations standards pour chaque type d'objet&nbsp;: création,
     modification, suppression et changement du label de sécurité. De plus,
-    certains types d'objet ont des droits spéciaux pour contrôler leur
+    certains types d'objet ont des droits spéciaux pour contrôler leurs
     opérations caractéristiques&nbsp;: ajout ou suppression d'entrées dans
     un schéma particulier.
    </para>
@@ -617,7 +617,7 @@ postgres=# SELECT cid, cname, show_credit(cid) FROM customer;
    <para>
     Les transitions de domaine dynamique doivent être considérées avec
     attention car elles permettent aux utilisateurs de basculer leur label, et
-    du coup leur droits, quand ils le souhaitent, plutôt que (dans le cas d'une
+    du coup leurs droits, quand ils le souhaitent, plutôt que (dans le cas d'une
     procédure de confiance) lorsque c'est demandé par le système. Du coup, le
     droit <literal>dyntransition</literal> est seulement considéré sûr quand il
     est utilisé pour basculer vers un domaine avec un plus petit ensemble de
@@ -769,7 +769,7 @@ ERROR:  SELinux: security policy violation
     <term>Droits DDL</term>
     <listitem>
      <para>
-      Dû aux restrictions d'implémentations, certaines opérations DDL
+      Du aux restrictions d'implémentations, certaines opérations DDL
       ne vérifient pas les droits.
      </para>
     </listitem>
@@ -779,7 +779,7 @@ ERROR:  SELinux: security policy violation
     <term>Droits DCL</term>
     <listitem>
      <para>
-      Dû aux restrictions d'implémentations, les droits DCL
+      Du aux restrictions d'implémentations, les droits DCL
       ne vérifient pas les droits.
      </para>
     </listitem>
@@ -804,7 +804,7 @@ ERROR:  SELinux: security policy violation
       l'existence d'un objet particulier, même si l'utilisateur n'est
       pas autorisé à y accéder. Par exemple, nous pouvons inférer
       l'existence d'un objet invisible suite à un conflit de clé primaire,
-      à des violations de clés étrangèes et ainsi de suite, même si nous
+      à des violations de clés étrangères et ainsi de suite, même si nous
       ne pouvons pas accéder au contenu de ces objets. L'existence d'une
       table secrète ne peut pas être caché. Nous ne faisons que
       verrouiller l'accès à son contenu.

--- a/postgresql/sourcerepo.xml
+++ b/postgresql/sourcerepo.xml
@@ -23,7 +23,7 @@
    Avec <productname>Git</productname>, vous devez avoir une copie du dépôt de code sur
    votre machine locale, pour que vous ayez accès à tout l'historique et les
    branches sans avoir besoin d'être en ligne. C'est le moyen le plus rapide
-   et le plus flexible pour développer ou tester des patchs.
+   et le plus flexible pour développer ou tester des correctifs.
   </para>
 
   <procedure>
@@ -35,7 +35,7 @@
      vous pouvez obtenir sur <ulink url="https://git-scm.com"></ulink>. La
      plupart des systèmes ont actuellement une version récente de
      <application>Git</application> installée par défaut ou disponible dans le système
-     de package.
+     de paquets.
     </para>
    </step>
 
@@ -80,7 +80,7 @@ git fetch
 
   <para>
    <productname>Git</productname> peut faire bien plus de choses que de simplement
-   récupérer les sources. Pour plus d'informations, consultez les pages man de
+   récupérer les sources. Pour plus d'informations, consultez les pages de manuel de
    <productname>Git</productname> ou visitez le site <ulink url="https://git-scm.com"></ulink>.
   </para>
  </sect1>

--- a/postgresql/sources.xml
+++ b/postgresql/sources.xml
@@ -14,10 +14,10 @@
   </para>
 
   <para>
-   Les règles de disposition (positionnement des parenthèses, etc) suivent
+   Les règles de disposition (positionnement des parenthèses, etc.) suivent
    les conventions BSD. En particulier, les accolades pour les blocs de
    contrôle <literal>if</literal>, <literal>while</literal>,
-   <literal>switch</literal>, etc ont leur propre ligne.
+   <literal>switch</literal>, etc. ont leur propre ligne.
   </para>
 
   <para>
@@ -102,7 +102,7 @@ less -x4
   </indexterm>
 
   <para>
-   Les messages d'erreurs, d'alertes et de traces produites dans
+   Les messages d'erreur, d'alertes et de traces produites dans
    le code du serveur doivent être créés avec
    <function>ereport</function> ou son ancien cousin <function>elog</function>.
    L'utilisation de cette fonction est suffisamment complexe pour nécessiter
@@ -168,7 +168,7 @@ ereport(ERROR,
    valeurs d'exécution dans un message texte.  Un message
    <quote>conseil</quote>, optionnel, est également fourni. Les appels de
    fonction auxiliaire peuvent être écrits dans tout ordre, bien que la
-   convention est de fait apparaître <function>errcode</function> et
+   convention soit de faire apparaître <function>errcode</function> et
    <function>errmsg</function> en premier.
   </para>
 
@@ -246,7 +246,7 @@ ereport(ERROR,
       <replaceable>fmt_singular</replaceable> est le format singulier de
       l'anglais, <replaceable>fmt_plural</replaceable> est le format pluriel en
       anglais, <replaceable>n</replaceable> est la valeur entière qui détermine
-      la forme utilisée. Les arguments restants sont formatés suivant le chaîne
+      la forme utilisée. Les arguments restants sont formatés suivant la chaîne
       de format sélectionnée. Pour plus d'informations, voir
       <xref linkend="nls-guidelines"/>.
      </para>
@@ -401,7 +401,7 @@ ereport(ERROR,
      <para>
       <function>errcode_for_socket_access()</function> est une fonction commode
       qui sélectionne l'identifiant d'erreur SQLSTATE approprié pour
-      une défaillance dans l'appel système relatif à une socket.
+      une défaillance dans l'appel système relatif à un socket.
      </para>
     </listitem>
     <listitem>
@@ -463,13 +463,13 @@ ereport(ERROR,
    </para>
 
    <para>
-    Des conseils sur l'écriture de bons messages d'erreurs peuvent
+    Des conseils sur l'écriture de bons messages d'erreur peuvent
     être trouvés dans la <xref linkend="error-style-guide"/>.
    </para>
   </sect1>
 
   <sect1 id="error-style-guide">
-   <title>Guide de style des messages d'erreurs</title>
+   <title>Guide de style des messages d'erreur</title>
 
    <para>
     Ce guide de style est fourni dans l'espoir de maintenir une
@@ -526,7 +526,7 @@ Hint:     Le supplément, écrit sous la forme d'une phrase complète.</programl
     N'émettez pas d'hypothèses spécifiques à propos du formatage dans
     les messages textes.  Attendez-vous à ce que les clients et les traces
     du serveur enveloppent les lignes pour correspondre à leurs
-    propres besoins.  Dans les messages longs, les caractères
+    propres besoins.  Dans les longs messages, les caractères
     d'interlignes (\n) peuvent être utilisés pour indiquer les
     coupures suggérées d'un paragraphe.  Ne terminez pas un message
     avec un caractère d'interlignes.  N'utilisez pas des tabulations
@@ -594,7 +594,7 @@ Hint:     Le supplément, écrit sous la forme d'une phrase complète.</programl
    <para>
     Raisonnement&nbsp;: les objets peuvent avoir un nom qui crée une
     ambiguïté une fois incorporé dans un message. Soyez prudent en
-    indiquant où un nom commence et fini.  Mais n'encombrez pas les
+    indiquant où un nom commence et finit.  Mais n'encombrez pas les
     messages avec des guillemets qui ne sont pas nécessaires ou qui
     sont dupliqués.
    </para>
@@ -605,12 +605,12 @@ Hint:     Le supplément, écrit sous la forme d'une phrase complète.</programl
    <title>Grammaire et ponctuation</title>
 
    <para>
-    Les règles sont différentes pour les messages d'erreurs primaires
+    Les règles sont différentes pour les messages d'erreur primaires
     et pour les messages détails/conseils&nbsp;:
    </para>
 
    <para>
-    Messages d'erreurs primaires&nbsp;: ne mettez pas en majuscule la
+    Messages d'erreur primaires&nbsp;: ne mettez pas en majuscule la
     première lettre.  Ne terminez pas un message avec un point.  Ne
     pensez même pas à finir un message avec un point d'exclamation.
    </para>
@@ -625,7 +625,7 @@ Hint:     Le supplément, écrit sous la forme d'une phrase complète.</programl
 
    <para>
     Chaînes de contexte d'erreur: Ne mettez pas en majuscule la première
-    lettre et ne terminer pas la chaîne avec un point. Les chaînes de
+    lettre et ne terminez pas la chaîne avec un point. Les chaînes de
     contexte ne sont normalement pas des phrases complètes.
    </para>
 
@@ -749,7 +749,7 @@ et&nbsp;:
   </simplesect>
 
   <simplesect id="error-style-guide-error-messages">
-   <title>Assembler les messages d'erreurs</title>
+   <title>Assembler les messages d'erreur</title>
 
    <para>
    Quand un message inclut du texte produit ailleurs,
@@ -827,7 +827,7 @@ MEILLEUR : n'a pas pu ouvrir le fichier %s: %m</programlisting>
   <formalpara>
     <title>Mauvais</title>
    <para>
-    Les messages d'erreurs comme <quote>mauvais résultat</quote> sont
+    Les messages d'erreur comme <quote>mauvais résultat</quote> sont
     vraiment difficile à interpréter intelligemment. Cela est mieux
     d'écrire pourquoi le résultat est <quote>mauvais</quote>, par
     exemple, <quote>format invalide</quote>.
@@ -867,7 +867,7 @@ MEILLEUR : type de nœud non reconnu : 42</programlisting>
     l'endroit prévu pour la ressource est connu mais que le programme
     ne peut pas accéder à celle-ci, alors dites que la ressource
     n'<quote>existe</quote> pas. Utilisez <quote>trouvez</quote> dans
-    ce cas là semble faible et embrouille le problème.
+    ce cas-là semble faible et embrouille le problème.
    </para>
   </formalpara>
 
@@ -947,7 +947,7 @@ MEILLEUR : type de nœud non reconnu : 42</programlisting>
    <title>Adaptation linguistique</title>
 
    <para>
-    Gardez à l'esprit que les textes des messages d'erreurs ont besoin
+    Gardez à l'esprit que les textes des messages d'erreur ont besoin
     d'être traduit en d'autres langues.  Suivez les directives dans la
     <xref linkend="nls-guidelines"/> pour éviter de rendre la vie
     difficile aux traducteurs.
@@ -998,8 +998,8 @@ MEILLEUR : type de nœud non reconnu : 42</programlisting>
     <para>
      Les macros avec arguments et les fonctions <literal>static inline</literal>
      peuvent être utilisés. Ces dernières sont préférables s'il y a un risque
-     d'évaluations multiples si elles sont écrites en tant que macro, comme par
-     exemple le cas avec&nbsp;
+     de multiples évaluations si elles sont écrites en tant que macro, comme le
+     cas avec&nbsp;
 <programlisting>
 #define Max(x, y)       ((x) &gt; (y) ? (x) : (y))
    </programlisting>
@@ -1038,7 +1038,7 @@ MemoryContextSwitchTo(MemoryContext context)
   <para>
    Pour pouvoir être exécuté à l'intérieur d'un gestionnaire de signal, le
    code doit être écrit avec beaucoup d'attention. Le problème fondamental
-   est qu'un gestion de signal peut interrompre le code à tout moment, sauf
+   est qu'une gestion de signal peut interrompre le code à tout moment, sauf
    s'il est bloqué. Si le code à l'intérieur d'un gestionnaire de signal
    utilise le même état que le code en dehors, un grand chaos peut survenir.
    Comme exemple, pensez à ce qui arriverait si un gestionnaire de signal
@@ -1073,7 +1073,7 @@ handle_sighup(SIGNAL_ARGS)
   <title>Appeler des pointeurs de fonction</title>
 
   <para>
-   Pour plus de clareté, il est préféré de déréférencer explicitement un
+   Pour plus de claretté, il est préféré de déréférencer explicitement un
    pointeur de fonction lors de l'appel de cette fonction si le pointeur est
    une simple variable, par exemple&nbsp;:
    <programlisting>

--- a/postgresql/spgist.xml
+++ b/postgresql/spgist.xml
@@ -40,7 +40,7 @@
   <para>
    Tout comme <acronym>GiST</acronym>, <acronym>SP-GiST</acronym> est destiné
    à permettre le développement de types de données personnalisées, disposant
-   des méthodes d'accés appropriées, par un expert du domaine plutôt que par
+   des méthodes d'accès appropriées, par un expert du domaine plutôt que par
    un expert en base de données.
   </para>
 
@@ -58,7 +58,7 @@
  </sect2>
 
  <sect2 id="spgist-builtin-opclasses">
-  <title>Classes d'opérateur internes</title>
+  <title>classes d'opérateurs internes</title>
 
   <para>
    La distribution de <productname>PostgreSQL</productname> inclut les classes
@@ -67,7 +67,7 @@
   </para>
 
   <table id="spgist-builtin-opclasses-table">
-   <title>Classes d'opérateur <acronym>SP-GiST</acronym> internes</title>
+   <title>classes d'opérateurs <acronym>SP-GiST</acronym> internes</title>
    <tgroup cols="3">
     <thead>
      <row>
@@ -183,7 +183,7 @@
   </table>
 
   <para>
-   Sur les deux classes d'opérateur pour le type <type>point</type>,
+   Sur les deux classes d'opérateurs pour le type <type>point</type>,
    <literal>quad_point_ops</literal> est celui par défaut.
    <literal>kd_point_ops</literal> gère les mêmes opérateurs mais utilise une
    structure de données différente pour l'index, structure pouvant offrir de
@@ -191,7 +191,7 @@
   </para>
 
   <para>
-   Les classes d'opérateur <literal>quad_point_ops</literal>,
+   Les classes d'opérateurs <literal>quad_point_ops</literal>,
    <literal>kd_point_ops</literal> et <literal>poly_ops</literal> supportent
    l'ordre d'opérateur <literal>&lt;-&gt;</literal>, qui active la recherche de
    type voisin-le-plus-proche (<literal>k-NN</literal>) sur des ensembles de
@@ -215,12 +215,12 @@
   <para>
    Les lignes des feuilles d'un arbre <acronym>SP-GiST</acronym> contiennent
    habituellement des valeurs du même type de données que la colonne indexée,
-   bien qu'il soit possible qu'ils contiennent des repésentations à perte de
+   bien qu'il soit possible qu'ils contiennent des représentations à perte de
    la colonne indexée. Les enregistrements des feuilles stockés à la racine
    représenteront directement la valeur originale de la donnée indexée, mais
    les enregistrements des feuilles à des niveaux plus bas pourraient ne contenir
    qu'une valeur partielle, telle qu'un suffixe. Dans ce cas, les
-   classes d'opérateur des fonctions supportées devront être capables de
+   classes d'opérateurs des fonctions supportées devront être capables de
    reconstruire la valeur originale en utilisant les informations accumulées
    dans les lignes intermédiaires au travers du parcours de l'arbre et vers
    le niveau le plus bas.
@@ -229,8 +229,8 @@
   <para>
    Quand un index <acronym>SP-GiST</acronym> est créé avec des colonnes
    <literal>INCLUDE</literal>, les valeurs de ces colonnes sont aussi
-   stockées dans des enregsitrements feuilles. Les colonnes
-   <literal>INCLUDE</literal> ne concernent pas la classe d'opérateur
+   stockées dans des enregistrements feuilles. Les colonnes
+   <literal>INCLUDE</literal> ne concernent pas la classe d'opérateurs
    <acronym>SP-GiST</acronym>, donc elles ne seront pas discutées avec plus
    de détails ici.
   </para>
@@ -245,14 +245,14 @@
    Chaque nœud a un <firstterm>label</firstterm> qui le décrit. Par exemple,
    dans un arbre <foreignphrase>radix</foreignphrase>, le label du nœud
    peut être le caractère suivant de la chaîne de caractère. (Sinon, une
-   classe d'opérateur peut omettre les labels des nœuds si elle
+   classe d'opérateurs peut omettre les labels des nœuds si elle
    fonctionne avec un ensemble fixe de nœuds pour les enregistrements
    internes&nbsp;; voir <xref linkend ="spgist-null-labels"/>.) En option, une
    ligne intermédiaire peut avoir une valeur
    de <firstterm>préfixe</firstterm> qui décrit tous ses membres. Dans un arbre
    <foreignphrase>radix</foreignphrase>, cela peut être le préfixe commun des chaînes représentant les données.
    La valeur du préfixe n'est pas nécessairement réellement un préfixe, mais peut
-   être toute donnée utilisée par la classe d'opérateur. Par exemple, pour un
+   être toute donnée utilisée par la classe d'opérateurs. Par exemple, pour un
    <foreignphrase>quadtree</foreignphrase>, il peut stocker le barycentre des
    quatre points représenté par chaque feuille. Une ligne intermédiaire d'un
    <foreignphrase>quadtree</foreignphrase> contiendra aussi quatre nœuds correspondants
@@ -262,7 +262,7 @@
   <para>
    Quelques algorithmes de recherche arborescente nécessite la connaissance
    du niveau (ou profondeur) de la ligne en cours, et ainsi le cœur de
-   <acronym>SP-GiST</acronym> fournit aux classes d'opérateur la possibilité
+   <acronym>SP-GiST</acronym> fournit aux classes d'opérateurs la possibilité
    de gérer le décompte des niveaux lors du parcours de l'arbre.
    Il fournit aussi le moyen de reconstruire de façon incrémentale la valeur
    représentée lorsque cela est nécessaire, et pour passer des données
@@ -277,7 +277,7 @@
     stockent des entrées pour les valeurs NULL dans les colonnes indexées,
     cette implémentation reste non apparente au code de l'index de classe
     d'opérateur : aucune valeur NULL d'index ou de condition de recherche ne sera
-    jamais transmis aux méthodes de la classe d'opérateur (il est convenu
+    jamais transmis aux méthodes de la classe d'opérateurs (il est convenu
     que les opérateurs <acronym>SP-GiST</acronym> sont stricts et ainsi
     ne peuvent trouver des valeurs NULL). Le cas des valeurs NULL n'est
     ainsi plus abordé dans les paragraphes qui suivent.
@@ -285,25 +285,25 @@
   </note>
 
   <para>
-   Un index de classe d'opérateur pour <acronym>SP-GiST</acronym> peut
+   Un index de classe d'opérateurs pour <acronym>SP-GiST</acronym> peut
    proposer cinq méthodes personnalisées, et deux optionnelles. Chacune de ces
    cinq méthodes obligatoires doit suivre la convention qui consiste à
    accepter deux arguments de type <type>internal</type>, le premier étant un
    pointeur vers une structure C contenant les valeurs en entrée de cette
    méthode, et le second étant un pointeur vers une structure C où les valeurs
    en sortie seront placées. Quatre de ces méthodes retournent
-   <type>void</type> car leurs résultats sont présent dans la structure en
+   <type>void</type> car leurs résultats sont présents dans la structure en
    sortie. Mais la méthode <function>leaf_consistent</function> retourne
    une valeur de type <type>boolean</type>. Les méthodes ne doivent
    modifier aucun des champs de la structure en entrée. Dans tous les cas, la
    structure en sortie est initialisée avec des zéros avant l'appel à la
    méthode personnalisée. La sixième méthode, optionnelle,
-   <function>compress</function> accepte un <type>datum</type> à iundexer
+   <function>compress</function> accepte un <type>datum</type> à indexer
    comme seul argument et renvoie une valeur convenable pour un enregistrement
    physique dans une ligne feuille. La septième méthode, optionnelle, est
    appelée <function>options</function> et accepte un pointeur
    <type>internal</type> vers une structure C, remplie avec les paramètres
-   spécifiques à la classe d'opérateur, et renvoie <type>void</type>.
+   spécifiques à la classe d'opérateurs, et renvoie <type>void</type>.
   </para>
 
   <para>
@@ -345,7 +345,7 @@ typedef struct spgConfigOut
       </programlisting>
 
       <structfield>attType</structfield> est fourni pour gérer les index polymorphiques
-      de classe d'opérateur. Pour les types de données ordinaires de classe d'opérateur (fixés),
+      de classe d'opérateurs. Pour les types de données ordinaires de classe d'opérateurs (fixés),
       il aura toujours la même valeur et peut ainsi être ignoré.
      </para>
 
@@ -354,7 +354,7 @@ typedef struct spgConfigOut
       <structfield>prefixType</structfield> peut être défini à <literal>VOIDOID</literal>.
       De la même façon, pour les classes d'opérateurs qui n'utilisent pas de label de nœud,
       <structfield>labelType</structfield> peut être défini à <literal>VOIDOID</literal>.
-      <structfield>canReturnData</structfield> peut être défini à true si la classe d'opérateur
+      <structfield>canReturnData</structfield> peut être défini à true si la classe d'opérateurs
       est capable de reconstruire la valeur d'index fournie initialement.
       <structfield>longValuesOK</structfield> doit être défini à true uniquement lorsque
       <structfield>attType</structfield> est de longueur variable et que la classe
@@ -365,10 +365,10 @@ typedef struct spgConfigOut
      <para>
       <structfield>leafType</structfield> doit correspondre au type de
       stockage de l'index défini par l'entrée de catalogue
-      <structfield>opckeytype</structfield> de la classe d'opérateur.
+      <structfield>opckeytype</structfield> de la classe d'opérateurs.
       (Notez que <structfield>opckeytype</structfield> peut valoir zéro,
       impliquant que le type de stockage est le même que le type en entrée de
-      la classe d'opérateur, ce qui est la situation la plus commune.) Pour
+      la classe d'opérateurs, ce qui est la situation la plus commune.) Pour
       des raisons de compatibilité ascendante, la méthode
       <function>config</function> peut configurer
       <structfield>leafType</structfield> à toute autre valeur, et cette
@@ -506,9 +506,9 @@ typedef struct spgChooseOut
       le tableau de nœud.
       Définir <structfield>levelAdd</structfield> à l'incrément de
       <structfield>level</structfield> nécessaire pour descendre au travers de ce nœud,
-      ou le laisser à 0 si la classe d'opérateur n'utilise pas de niveaux.
+      ou le laisser à 0 si la classe d'opérateurs n'utilise pas de niveaux.
       Définir <structfield>restDatum</structfield> à la valeur de <structfield>leafDatum</structfield>
-      si la classe d'opérateur ne modifie pas les valeurs d'un niveau au suivant,
+      si la classe d'opérateurs ne modifie pas les valeurs d'un niveau au suivant,
       ou dans le cas contraire, définir la valeur modifiée pour être utilisée comme
       valeur de <structfield>leafDatum</structfield> au niveau suivant.
      </para>
@@ -519,7 +519,7 @@ typedef struct spgChooseOut
       Définir <structfield>nodeLabel</structfield> au label à utiliser pour le nouveau nœud,
       et définir <structfield>nodeN</structfield> à l'index (de 0) auquel insérer
       le nœud dans le tableau de nœud.
-      Après que ce nœud ait été ajouté, la fonction <function>choose</function>
+      Après que ce nœud a été ajouté, la fonction <function>choose</function>
       sera appelée à nouveau avec la ligne intermédiaire modifiée.
       Cet appel devrait produire un résultat <literal>spgMatchNode</literal>.
      </para>
@@ -613,10 +613,10 @@ typedef struct spgPickSplitOut
       spécifier dans <structfield>nodeLabels</structfield> un tableau de leurs labels,
       ou NULL si les labels ne sont pas nécessaires.
       Attribuer à <structfield>mapTuplesToNodes</structfield> un tableau des index (à partir de zéro)
-      des nœuds auquels seront assignés chaque ligne feuille.
+      des nœuds auxquels seront assignés chaque ligne feuille.
       Attribuer à <structfield>leafTupleDatums</structfield> un tableau des valeurs à
       stocker dans la nouvelle ligne de feuilles (ces valeurs seront les mêmes que celles des données
-      <structfield>datums</structfield> fournies en paramètre si la classe d'opérateur ne modifie
+      <structfield>datums</structfield> fournies en paramètre si la classe d'opérateurs ne modifie
       pas les données d'un niveau à un autre).
       À noter que la fonction <function>picksplit</function> est responsable de l'allocation de mémoire
       des tableaux <structfield>nodeLabels</structfield>, <structfield>mapTuplesToNodes</structfield> et
@@ -688,7 +688,7 @@ typedef struct spgInnerConsistentIn
     Datum       prefixDatum;    /* dans ce cas, la valeur du préfixe */
     int         nNodes;         /* nombre de nœuds dans la ligne intermédiaire */
     Datum      *nodeLabels;     /* labels du nœud (NULL si pas de labels) */
-    void      **traversalValues;        /* valeurs traverses spécifiques de la classe d'opérateur */
+    void      **traversalValues;        /* valeurs traverses spécifiques de la classe d'opérateurs */
     double    **distances;              /* distances associées */
 } spgInnerConsistentIn;
 
@@ -703,7 +703,7 @@ typedef struct spgInnerConsistentOut
 
       Le tableau <structfield>scankeys</structfield>, de longueur <structfield>nkeys</structfield>,
       décrit les conditions de recherche d'index. Ces conditions sont combinées avec un opérateur
-      ET. Seuls les entrées d'index qui correspondent à toutes ces conditions sont conservées
+      et seuls les entrées d'index qui correspondent à toutes ces conditions sont conservées
       (à noter que <structfield>nkeys</structfield> = 0 implique que toutes les entrées d'index sont
       conservées). Généralement, la fonction <function>inner_consistent</function> ne tient compte que
       des champs <structfield>sk_strategy</structfield> et <structfield>sk_argument</structfield>
@@ -739,7 +739,7 @@ typedef struct spgInnerConsistentOut
       <structfield>nNodes</structfield> doit être défini comme le nombre de
       nœuds enfants qui doivent être visités durant la recherche, et
       <structfield>nodeNumbers</structfield> doit être défini comme le
-      tableau de leurs index. Si la classe d'opérateur effectue le suivi des
+      tableau de leurs index. Si la classe d'opérateurs effectue le suivi des
       niveaux, définir <structfield>levelAdds</structfield> comme un tableau
       des incréments à ajouter aux niveaux pour descendre vers chaque nœud à
       visiter (dans la plupart des cas, les incréments seront les mêmes pour
@@ -762,7 +762,7 @@ typedef struct spgInnerConsistentOut
       les informations supplémentaires hors bande
       (<quote>valeurs traverses</quote>) pour diminuer les niveaux de l'arbre
       de recherche, initialiser <structfield>traversalValues</structfield> en
-      un tableau des valeurs traverses appropriées, un pour chaque nœuds
+      un tableau des valeurs traverses appropriées, un pour chaque nœud
       enfants à visiter&nbsp;; sinon laisser
       <structfield>traversalValues</structfield> à NULL. Notez que la
       fonction <function>inner_consistent</function> est responsable de
@@ -807,7 +807,7 @@ typedef struct spgLeafConsistentIn
     int         norderbys;      /* taille du tableau orderbys */
 
     Datum       reconstructedValue;     /* valeur reconstruite au parent */
-    void       *traversalValue; /* valeur traverse spécifique à la classe d'opérateur */
+    void       *traversalValue; /* valeur traverse spécifique à la classe d'opérateurs */
     int         level;          /* niveau actuel (à partir de zéro) */
     bool        returnData;     /* les données originales doivent-elles être reconstruites ? */
 
@@ -906,7 +906,7 @@ typedef struct spgLeafConsistentOut
     <listitem>
      <para>
       Définit un ensemble de paramètres visibles aux utilisateurs qui
-      contrôlent le comportement d'une classe d'opérateur.
+      contrôlent le comportement d'une classe d'opérateurs.
      </para>
 
      <para>
@@ -974,7 +974,7 @@ LANGUAGE C STRICT;
     unique page d'index (8&nbsp;ko par défaut). Cependant, lorsque des données de taille variable
     sont indexées, les longues valeurs ne sont uniquement supportées que par les arbres suffixés,
     dans lesquels chaque niveau de l'arbre contient un préfixe qui est suffisamment petit
-    pour tenir dans une page. La classe d'opérateur doit uniquement définir <structfield>longValuesOK</structfield>
+    pour tenir dans une page. La classe d'opérateurs doit uniquement définir <structfield>longValuesOK</structfield>
     à TRUE si elle supporte ce cas de figure. Dans le cas contraire, le cœur de <acronym>SP-GiST</acronym>
     rejettera l'indexation d'une valeur plus large qu'une page.
    </para>
@@ -995,7 +995,7 @@ LANGUAGE C STRICT;
     et un nœud intermédiaire est inséré. Pour que ce mécanisme résolve le problème,
     le nouveau nœud intermédiaire <emphasis>doit</emphasis> diviser l'ensemble de valeurs
     de feuilles en plus d'un groupe de nœuds. Si la fonction <function>picksplit</function>
-    de la classe d'opérateur n'y parvient pas, le cœur de <acronym>SP-GiST</acronym> met en œuvre
+    de la classe d'opérateurs n'y parvient pas, le cœur de <acronym>SP-GiST</acronym> met en œuvre
     des mesures extraordinaires telles que décrites dans <xref linkend="spgist-all-the-same"/>.
    </para>
 
@@ -1003,9 +1003,9 @@ LANGUAGE C STRICT;
     Quand <structfield>longValuesOK</structfield> vaut true, il est attendu
     que les niveaux successifs de l'arbre <acronym>SP-GiST</acronym>
     absorbera de plus en plus d'informations dans les prefixes et labels de
-    noeuds des enregistrements internes, rendant la donnes feuille de plus en
+    noeuds des enregistrements internes, rendant la donnée feuille de plus en
     plus petite, pour qu'à la fin, elle tienne sur un bloc. Pour empêcher les
-    bugs dans les classes d'opérateur, du style boucle d'insertions infinie,
+    bugs dans les classes d'opérateurs, du style boucle d'insertions infinies,
     le code principal de  <acronym>SP-GiST</acronym> lèvera une erreur si la
     donnée feuille ne devient pas plus petite au bout de dix cycles d'appel à
     la méthode <function>choose</function>.
@@ -1017,7 +1017,7 @@ LANGUAGE C STRICT;
     absorberont de plus en plus d'informations dans les préfixes et labels de
     nœuds des lignes internes, rendant la donnée requise pour la feuille de
     plus en plus petite, jusqu'à ce qu'elle tienne sur un bloc. Pour empêcher
-    que des bugs dans les classes d'opérateur causent des boucles d'insertion
+    que des bugs dans les classes d'opérateurs causent des boucles d'insertion
     infinies, le noyau de <acronym>SP-GiST</acronym> lèvera une erreur si la
     donnée de la feuille ne devient pas plus petite dans les dix cycles
     d'appel à la méthode <function>choose</function>.
@@ -1093,7 +1093,7 @@ LANGUAGE C STRICT;
 
   <para>
    Les sources de <productname>PostgreSQL</productname> incluent plusieurs
-   exemples de classes d'opérateur d'index pour <acronym>SP-GiST</acronym>
+   exemples de classes d'opérateurs d'index pour <acronym>SP-GiST</acronym>
    comme décrit dans <xref linkend="spgist-builtin-opclasses-table"/>. Lire le
    code dans <filename>src/backend/access/spgist/</filename> et
    <filename>src/backend/utils/adt/</filename>.

--- a/postgresql/spi.xml
+++ b/postgresql/spi.xml
@@ -28,13 +28,13 @@
 
  <para>
   Notez que si une commande appelée via SPI échoue, alors le contrôle ne sera
-  pas redonné à votre fonction C. Au contraire, la transaction ou
+  pas rendu à votre fonction C. Au contraire, la transaction ou
   sous-transaction dans laquelle est exécutée votre fonction C sera annulée.
   (Ceci pourrait être surprenant étant donné que les fonctions SPI ont pour
   la plupart des conventions documentées de renvoi d'erreur. Ces conventions
   s'appliquent seulement pour les erreurs détectées à l'intérieur des
   fonctions SPI.) Il est possible de récupérer le contrôle après une erreur
-  en établissant votre propre sous-transaction englobant les appels SPI qui
+  en établissant votre propre sous-transaction englobante les appels SPI qui
   pourraient échouer.
  </para>
 
@@ -506,7 +506,7 @@
       </para>
 
       <para>
-       Sur une erreur, l'une des valeurs négatives suivante est renvoyée&nbsp;:
+       Sur une erreur, l'une des valeurs négatives suivantes est renvoyée&nbsp;:
 
        <variablelist>
         <varlistentry>
@@ -727,7 +727,7 @@ int SPI_execute_extended(const char *<parameter>command</parameter>,
    structure <parameter>options</parameter>, et ensuite remplir les champs
    souhaités. Ceci permet d'assurer la compatibilité ascendante
    du code, car tous les champs ajoutés à la structure dans le futur
-   seront définis comme étant rétro-compatibles s'ils sont mis à zéro.
+   seront définis comme étant rétrocompatibles s'ils sont mis à zéro.
    Les champs de <parameter>options</parameter> actuellement disponibles
    sont&nbsp;:
   </para>
@@ -768,7 +768,7 @@ int SPI_execute_extended(const char *<parameter>command</parameter>,
      <para>
       si <literal>true</literal>, lève une erreur si la requête n'est pas d'un
       type qui renvoie des lignes (ceci n'interdit pas le cas où elle
-      pourrait renvoyer zéro lignes)
+      pourrait renvoyer zéro ligne)
      </para>
     </listitem>
    </varlistentry>
@@ -880,7 +880,7 @@ int SPI_execute_with_args(const char *<parameter>command</parameter>,
          valeurs de paramètres spécifiques fournies. Pour une exécution simple, cette
          fonction doit être préférée. Si la même commande doit être exécutée avec
          plusieurs paramètres différents, chaque méthode peut être la plus rapide,
-         le coût de la planification pouvant contre-balancer les bénéfices des plans
+         le coût de la planification pouvant contrebalancer les bénéfices des plans
          personnalisés.
         </para>
        </refsect1>
@@ -1019,7 +1019,7 @@ int SPI_execute_with_args(const char *<parameter>command</parameter>,
         <para>
          Lorsque la même commande ou une commande semblable doit être lancée à
          plusieurs reprises, il est généralement avantageux de réaliser une
-         analyse du plan d'exécution une fois et de ré-utiliser le plan
+         analyse du plan d'exécution une fois et de réutiliser le plan
          d'exécution pour la commande.
          <function>SPI_prepare</function> convertit une chaîne de commande en une
          requête préparée qui encapsule le résultat de l'analyse du plan. La
@@ -1314,11 +1314,11 @@ SPIPlanPtr SPI_prepare_extended(const char * <parameter>command</parameter>,
   </variablelist>
 
   <para>
-   Les codes appelant doivent toujours mettre à zéro la structure
+   Les codes appelants doivent toujours mettre à zéro la structure
    <parameter>options</parameter> entière, puis remplir les champs souhaités
    avec les valeurs à affecter. Ceci permet d'assurer une compatibilité
    ascendante du code, car tous les champs ajoutés à la structure dans le
-   futur seront définis comme étant rétro-compatibles s'ils sont mis à zéro.
+   futur seront définis comme étant rétrocompatibles s'ils sont mis à zéro.
    Les champs de <parameter>options</parameter>  actuellement disponibles
    sont&nbsp;:
   </para>
@@ -1624,7 +1624,7 @@ SPIPlanPtr SPI_prepare_params(const char * <parameter>command</parameter>,
       passé comme un argument à <function>SPI_cursor_open</function> ou
       <symbol>false</symbol> si ce n'est pas le cas. Les critères sont que le
       <parameter>plan</parameter> représente une seule commande et que cette
-      commande renvoit des lignes à l'appelant&nbsp;; par l'exemple,
+      commande renvoie des lignes à l'appelant&nbsp;; par l'exemple,
       <command>SELECT</command> est autorisé sauf s'il contient une clause
       <literal>INTO</literal> et <command>UPDATE</command> est autorisé seulement
       s'il contient un <literal>RETURNING</literal>
@@ -1896,7 +1896,7 @@ int SPI_execute_plan_extended(SPIPlanPtr <parameter>plan</parameter>,
    <varlistentry>
     <term><literal>bool <parameter>read_only</parameter></literal></term>
     <listitem>
-     <para><literal>true</literal> pour les exécution en lecture seule</para>
+     <para><literal>true</literal> pour les exécutions en lecture seule</para>
     </listitem>
    </varlistentry>
 
@@ -1918,7 +1918,7 @@ int SPI_execute_plan_extended(SPIPlanPtr <parameter>plan</parameter>,
      <para>
       si <literal>true</literal>, lève une erreur si la requête n'est pas d'un
       type qui renvoie des lignes (ceci n'interdit pas le cas où elle
-      pourrait renvoyer zéro lignes)
+      pourrait renvoyer zéro ligne)
      </para>
     </listitem>
    </varlistentry>
@@ -2178,7 +2178,7 @@ int SPI_execute_plan_with_paramlist(SPIPlanPtr <parameter>plan</parameter>,
 
   <para>
     <varname>SPI_processed</varname> et <varname>SPI_tuptable</varname> sont
-    initialisées comme dans <function>SPI_execute</function> en cas de succès.
+    initialisés comme dans <function>SPI_execute</function> en cas de succès.
   </para>
 </refsect1>
 </refentry>
@@ -2216,13 +2216,13 @@ bool <parameter>read_only</parameter>)</synopsis>
   </para>
 
   <para>
-   Utiliser un curseur au lieu de lancer une requête directement a deux
+   Utiliser un curseur au lieu de lancer une requête directement à deux
    avantages. Premièrement, les lignes de résultats peuvent être récupérées un
    certain nombre à la fois, évitant la saturation de mémoire pour les requêtes
    qui retournent trop de lignes. Deuxièmement,
    un portail peut survivre à la fonction C courante (elle peut, en fait, vivre
    jusqu'à la fin de la transaction courante). Renvoyer le nom du portail
-   à l'appelant de la fonction C donne un moyen de retourner une série de ligne
+   à l'appelant de la fonction C donne un moyen de retourner une série de lignes
    en tant que résultat.
   </para>
 
@@ -2346,7 +2346,7 @@ Portal SPI_cursor_open_with_args(const char *<parameter>name</parameter>,
 
                     <para>
                      <function>SPI_cursor_open_with_args</function> initialise un curseur
-                     (en interne, un portail) qui exécutera la requête spécifié. La plupart des
+                     (en interne, un portail) qui exécutera la requête spécifiée. La plupart des
                      paramètres ont la même signification que les paramètres correspondant de
                      <function>SPI_prepare_cursor</function> et <function>SPI_cursor_open</function>.
                     </para>
@@ -2356,7 +2356,7 @@ Portal SPI_cursor_open_with_args(const char *<parameter>name</parameter>,
                      <function>SPI_prepare_cursor</function> suivie de
                      <function>SPI_cursor_open</function>. Si la même commande doit être exécutée
                      avec plusieurs paramètres différents, il n'y a pas de différences sur les
-                     deux méthode, la replanification a un coût mais bénéficie de plans
+                     deux méthodes, la replanification a un coût, mais bénéficie de plans
                      personnalisés.
                     </para>
 
@@ -2626,7 +2626,7 @@ Portal SPI_cursor_parse_open(const char *<parameter>name</parameter>,
   </para>
 
   <para>
-   Le paramètre passée en entrée sera copié dans le portail du curseur, ainsi il
+   Le paramètre passé en entrée sera copié dans le portail du curseur, ainsi il
    peut être libéré alors que le curseur existe toujours.
   </para>
  </refsect1>
@@ -3209,7 +3209,7 @@ int SPI_keepplan(SPIPlanPtr <parameter>plan</parameter>)
                              <function>SPI_keepplan</function> sauvegarde une instruction passée (préparée
                              par <function>SPI_prepare</function>) pour qu'elle ne soit pas libérée par
                              <function>SPI_finish</function> ou par le gestionnaire des transactions.
-                             Cela vous donne la possibilité de ré-utiliser les instructions préparées dans
+                             Cela vous donne la possibilité de réutiliser les instructions préparées dans
                              les prochains appels à votre fonction C dans la session courante.
                             </para>
                            </refsect1>
@@ -4332,7 +4332,7 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
 
                                         <para>
                                          En revanche, si votre fonction C a besoin de renvoyer un objet dans de la
-                                         mémoire allouée (tel que la valeur d'un type de donné passé par référence),
+                                         mémoire allouée (tel que la valeur d'un type de donnée passé par référence),
                                          vous ne pouvez pas allouer cette mémoire en utilisant
                                          <function>palloc</function>, au
                                          moins pas tant que vous êtes connecté à SPI. Si vous essayez, l'objet
@@ -4946,7 +4946,7 @@ const char * SPI_result_code_string(int <parameter>code</parameter>);
    <function>SPI_freetuptable</function> contient la logique de sécurité pour
    protéger contre les demandes dupliquées de suppression à partir du même
    ensemble de lignes. Avec les versions précédentes, les suppressions
-   dupliquées auraient amenées à des crashs.
+   dupliquées auraient amené à des crashs.
   </para>
  </refsect1>
 

--- a/postgresql/sslinfo.xml
+++ b/postgresql/sslinfo.xml
@@ -102,7 +102,7 @@
       du numéro de série de certificat et du créateur du certificat
       garantit une identification unique du certificat (mais pas son propriétaire
       &mdash; le propriétaire doit régulièrement changer ses clés et obtenir de
-      nouveaux certifications à partir du créateur).
+      nouvelles certifications à partir du créateur).
      </para>
 
      <para>
@@ -124,9 +124,9 @@
      <para>
       Renvoie le sujet complet du certificat actuel du client, convertissant
       des données dans l'encodage actuel de la base de données. Nous supposons
-      que si vous utilisez des caractères non ASCII dans le noms des
+      que si vous utilisez des caractères non ASCII dans le nom des
       certificats, votre base de données est capable de représenter ces
-      caractères aussi. Si votre bases de données utilise l'encodage SQL_ASCII,
+      caractères aussi. Si votre base de données utilise l'encodage SQL_ASCII,
       les caractères non ASCII seront représentés par des séquences UTF-8.
      </para>
 

--- a/postgresql/start.xml
+++ b/postgresql/start.xml
@@ -218,7 +218,7 @@
       toujours le droit de créer des bases.  Au lieu de vous connecter au
       système en tant que cet utilisateur, vous pouvez spécifier partout
       l'option <option>-U</option> pour sélectionner un nom d'utilisateur
-      <productname>PostgreSQL</productname> sous lequel vous connecter.
+      <productname>PostgreSQL</productname> sous lequel vous vous connectez.
      </para>
     </footnote>
    </para>

--- a/postgresql/storage.xml
+++ b/postgresql/storage.xml
@@ -134,7 +134,7 @@
      <row>
       <entry><filename>pg_subtrans</filename></entry>
       <entry>Sous-répertoire contenant les données d'états des
-       sous-transaction</entry>
+       sous-transactions</entry>
      </row>
 
      <row>
@@ -252,7 +252,7 @@
    filenode.1, filenode.2, etc. Cette disposition évite des problèmes sur les
    plateformes qui ont des limitations sur les tailles des fichiers.
    (Actuellement, 1&nbsp;Go est la taille du segment par défaut. Cette taille est
-   ajustable en utilisant l'option <option>--with-segsize</option> pour configure
+   ajustable en utilisant l'option <option>--with-segsize</option> pour configurer
    avant de construire <productname>PostgreSQL</productname>.)
    En principe, les fichiers de la carte des espaces libres et de la carte de
    visibilité pourraient aussi nécessiter plusieurs segments, bien qu'il y ait
@@ -343,7 +343,7 @@
    dans les champs. Pour dépasser cette limitation, les valeurs de champ
    volumineuses sont compressées et/ou divisées en plusieurs lignes physiques. Ceci
    survient de façon transparente pour l'utilisateur, avec seulement un petit
-   impact sur le code du serveur. Cette technique est connu sous l'acronyme
+   impact sur le code du serveur. Cette technique est connue sous l'acronyme
    affectueux de <acronym>TOAST</acronym> (ou <quote>the best thing since sliced
     bread</quote>). L'infrastructure <acronym>TOAST</acronym> est aussi utilisé pour
    améliorer la gestion des valeurs de grande taille en mémoire.
@@ -359,7 +359,7 @@
    de la valeur en octets (en incluant ce mot). <acronym>TOAST</acronym> ne
    restreint pas le reste de la représentation de la donnée. Les
    représentations spéciales appelées collectivement <firstterm>valeurs
-    <acronym>TOAST</acronym>ées</firstterm> fonctionnement en modifiant et en
+    <acronym>TOAST</acronym>ées</firstterm> fonctionnent en modifiant et en
    ré-interprétant ce mot de longueur initial. De ce fait, les fonctions C
    supportant un type de données <acronym>TOAST</acronym>-able doivent faire
    attention à la façon dont elles gèrent les valeurs en entrées
@@ -375,15 +375,15 @@
   <para>
    <acronym>TOAST</acronym> récupère deux bits du mot contenant la longueur
    d'un varlena (ceux de poids fort sur les machines big-endian, ceux de poids
-   faible sur les machines little-endian), limitant du coup la taille logique
+   faible sur les machines little endian), limitant du coup la taille logique
    de toute valeur d'un type de données <acronym>TOAST</acronym> à 1&nbsp;Go
    (2<superscript>30</superscript> - 1 octets). Quand les deux bits sont à
    zéro, la valeur est une valeur non <acronym>TOAST</acronym>é du type de
    données et les bits restants dans le mot contenant la longueur indiquent la
-   taille total du datum (incluant ce mot) en octets. Quand le bit de poids
+   taille totale du datum (incluant ce mot) en octets. Quand le bit de poids
    fort (ou de poids faible) est à un, la valeur a un en-tête de seulement un
    octet alors qu'un en-tête normal en fait quatre. Les bits restants donnent
-   la taille total du datum (incluant ce mot) en octets. Cette alternative
+   la taille totale du datum (incluant ce mot) en octets. Cette alternative
    supporte un stockage efficace en espace de valeurs plus petites que 127
    octets, tout en permettant au type de données de grossir jusqu'à 1 Go si
    besoin. Les valeurs avec un en-tête sur un octet ne sont pas alignées par
@@ -402,7 +402,7 @@
    être utilisé. Dans ce cas, les bits restants du mot longueur de quatre
    octets donnent une taille totale du datum compressé, pas celles des données
    au départ. Notez que la compression est aussi possible pour les données de
-   la table TOAST mais l 'en-tête varlena n'indique pas si c'est le cas
+   la table TOAST mais l'en-tête varlena n'indique pas si c'est le cas
    &mdash; le contenu du pointeur <acronym>TOAST</acronym> le précise.
   </para>
 
@@ -471,7 +471,7 @@
     réelle (différente si la compression a été appliquée), et la méthode de
     compression utilisée, si nécessaire. À partir des octets d'en-tête
     varlena, la taille totale d'un pointeur datum <acronym>TOAST</acronym>
-    est par conséquent de 18 octets quelque soit la taille réelle de la
+    est par conséquent de 18 octets quelle que soit la taille réelle de la
     valeur représentée.
    </para>
 
@@ -1037,7 +1037,7 @@
     <firstterm>HEAP_HASNULL</firstterm> est initialisé dans
     <structfield>t_infomask</structfield>. S'il est présent, il commence juste
     après l'en-tête fixe et occupe suffisamment d'octets pour avoir un bit par colonne
-    de données (c'est-à-dire le nombre de bits identique au nombre d'attribut dans
+    de données (c'est-à-dire le nombre de bits identique au nombre d'attributs dans
     <structfield>t_infomask2</structfield>). Dans cette
     liste de bits, un bit 1 indique une valeur non NULL, un bit 0 une valeur
     NULL. Quand le bitmap n'est pas présent, toutes les colonnes sont supposées
@@ -1238,7 +1238,7 @@
   nouveaux blocs et des blocs existants avec suffisamment d'espace ligne pour
   les nouvelles versions de lignes. La vue système <link
   linkend="monitoring-pg-stat-all-tables-view">pg_stat_all_tables</link> permet
-  de superviser l'occurence des mises à jour HOT et non HOT.
+  de superviser l'occurrence des mises à jour HOT et non HOT.
  </para>
 </sect1>
 

--- a/postgresql/syntax.xml
+++ b/postgresql/syntax.xml
@@ -101,7 +101,7 @@ INSERT INTO MA_TABLE VALUES (3, 'salut ici');</programlisting>
     <token>A</token> sont des exemples d'<firstterm>identificateurs</firstterm>.
     Ils identifient des noms de tables, colonnes ou d'autres objets de la base
     de données, suivant la commande qui a été utilisée. Du coup, ils sont
-    quelques fois simplement nommés des <quote>noms</quote>. Les mots-clés et
+    quelques fois simplement nommées des <quote>noms</quote>. Les mots-clés et
     les identificateurs ont la même structure lexicale, signifiant que quelqu'un
     ne peut pas savoir si un jeton est un identificateur ou un mot-clé sans
     connaître le langage. Une liste complète des mots-clés est disponible dans
@@ -191,7 +191,7 @@ INSERT INTO MA_TABLE VALUES (3, 'salut ici');</programlisting>
     majuscule. De ce fait, <literal>foo</literal> devrait être équivalent à
     <literal>"FOO"</literal>, et non pas à <literal>"foo"</literal>, d'après
     le standard. Si vous voulez écrire des applications portables, il est
-    conseillé de soit toujours mettre les noms entre guillemets, soit ne
+    conseillé de, soit toujours mettre les noms entre guillemets, soit ne
     jamais les mettre entre guillemets.)
    </para>
 
@@ -236,7 +236,7 @@ U&amp;"d!0061t!+000061" UESCAPE '!'
    hexadécimal, le signe plus, un guillemet simple ou double, ou un espace
    blanc. Notez que le caractère d'échappement est écrit entre guillemets
    simples, pas entre guillemets doubles,
-   after <literal>UESCAPE</literal>.
+   après <literal>UESCAPE</literal>.
   </para>
 
   <para>
@@ -698,7 +698,7 @@ $fonction$</programlisting>
      est un ou plusieurs chiffres binaires (0 ou 1). Les chiffres hexadécimaux
      et les Hexadecimal digits and the préfixes de base peuvent être en
      minuscule ou en majuscule. Notez que seuls les entiers peuvent avoir des
-     formes non décimales. Ce n'est pas le cas pour nombres à virgule.
+     formes non décimales. Ce n'est pas le cas pour les nombres à virgule.
     </para>
 
     <para>
@@ -1505,7 +1505,7 @@ $1.unecolonne
    </para>
 
    <para>
-    Par exemple, ce qui suit calcule la racine carré de 2&nbsp;:
+    Par exemple, ce qui suit calcule la racine carrée de 2&nbsp;:
 <programlisting>sqrt(2)</programlisting>
    </para>
 
@@ -1703,7 +1703,7 @@ SELECT array_agg(DISTINCT v ORDER BY v DESC) FROM vals;
     d'arguments directs peut être vide&nbsp;; dans ce cas, écrivez simplement
     <literal>()</literal>, et non pas <literal>(*)</literal>.
     (<productname>PostgreSQL</productname> accepte actuellement les deux écritures,
-    mais seule la première est conforme avec le standard SQL.)
+    mais seule la première est conforme au standard SQL.)
    </para>
 
    <para>

--- a/postgresql/system-views.xml
+++ b/postgresql/system-views.xml
@@ -13,7 +13,7 @@
   <para>
    Le schéma d'information (<xref linkend="information-schema"/>) fournit un autre
    ensemble de vues qui recouvrent les fonctionnalités des vues système. Comme
-   le schéma d'information fait parti du standard SQL, alors que les vues décrites ici
+   le schéma d'information fait partie du standard SQL, alors que les vues décrites ici
    sont spécifiques à <productname>PostgreSQL</productname>, il est généralement
    préférable d'utiliser le schéma d'information si celui-ci apporte toutes les
    informations nécessaires.
@@ -766,7 +766,7 @@
   </indexterm>
 
   <para>
-   La vue <structname>pg_file_settings</structname> fournie un
+   La vue <structname>pg_file_settings</structname> fournit un
    résumé du contenu des fichiers de configuration du serveur. Une
    ligne apparaît dans cette vue pour chaque entrée <quote>nom =
     valeur</quote> apparaissant dans les fichiers, avec des annotations
@@ -1051,7 +1051,7 @@
         <structfield>database</structfield> <type>text[]</type>
        </para>
        <para>
-        Liste des noms des base de données pour lesquelles cette règle
+        Liste des noms des bases de données pour lesquelles cette règle
         s'applique
        </para></entry>
      </row>
@@ -1614,7 +1614,7 @@
    réaliser correctement dans le détail. Une telle requête devrait intégrer
    toutes les informations sur les conflits des modes de verrous. Pire, la vue
    <structname>pg_locks</structname> n'expose pas d'informations sur les
-   processus en avance  des autres dans les queues d'attente de verrous, pas
+   processus en avance des autres dans les queues d'attente de verrous, pas
    plus que des informations sur les processus exécutés en parallèle pour
    d'autres sessions clientes. Il est préférable d'utiliser la fonction
    <function>pg_blocking_pids()</function> (voir <xref
@@ -1657,10 +1657,10 @@
    soient pris ou relachés pendant la récupération de l'information.
    Néanmoins, notez que ces verrous sont connus pour ne pas entrer en conflit
    avec les autres verrous déjà détenus. Après que tous les processus serveurs
-   aient été interrogés pour connaître leur verrous fast-path, le reste du
+   a été interrogés pour connaître leurs verrous fast-path, le reste du
    gestionnaire des verrous standards est verrouillé de manière unitaire et une
    image cohérente de tous les verrous restants est collectée en une seule
-   opération atomique. Après avoir déverrouille le gestionnaire de verrous
+   opération atomique. Après avoir déverrouillé le gestionnaire de verrous
    standards, le gestionnaire de verrous de prédicats est verrouillé de la
    même manière et tous les verrous de prédicats sont récupérés en une action
    atomique. Du coup, avec l'exception des verrous fast-path, chaque gestionnaire
@@ -2516,7 +2516,7 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
        pour les slots sur un serveur secondaire, synchronisés à partir du
        serveur primaire (donc dont le champ <structfield>synced</structfield>
        vaut <literal>true</literal>), le champ
-       <structfield>inactive_since</structfield> indique le moment de où la
+       <structfield>inactive_since</structfield> indique le moment d'où la
        synchronisation du slot (voir <xref
        linkend="logicaldecoding-replication-slots-synchronization"/>) s'est
        arrêtée pour la dernière fois. <literal>NULL</literal> si le slot a
@@ -4125,7 +4125,7 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
        </para>
        <para>
         Une liste des fréquences des combinaisons les plus communes, autrement
-        dit le nombre d'occurences de chacune divisé par le nombre total de
+        dit le nombre d'occurrences de chacune divisé par le nombre total de
         lignes. (NULL quand <structfield>most_common_vals</structfield> l'est.)
        </para></entry>
      </row>
@@ -4317,7 +4317,7 @@ SELECT * FROM pg_locks pl LEFT JOIN pg_prepared_xacts ppx
       </para>
       <para>
        Une liste des fréquences des valeurs les plus communes,
-       autrement dit nombre d'occurences de chaque divisé par nombre total de
+       autrement dit nombre d'occurrences de chaque divisé par nombre total de
        lignes.
        (NULL quand <structfield>most_common_vals</structfield> l'est.)
       </para></entry>

--- a/postgresql/tableam.xml
+++ b/postgresql/tableam.xml
@@ -49,10 +49,10 @@
   sont des pointeurs vers des fonctions C et ne sont pas visibles ou
   appelables au niveau du langage SQL. Tous les callbacks et leurs
   comportements sont définis dans la structure
-  <structname>TableAmRoutine</structname> (avec des commentaires dans le
+  <structname>TableAmRoutine</structname> (avec des commentaires dans la
   structure définissant les prérequis des callbacks). La plupart des callbacks
   ont des fonctions wrapper, documentées du point de vue de l'utilisateur
-  (plutôt que de l'implémenteur) de la méthode d'accès aux tables. Pour les
+  (plutôt que de l'implémenter) de la méthode d'accès aux tables. Pour les
   détails, voir le fichier <ulink
   url="https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/access/tableam.h;hb=head">
    <filename>src/include/access/tableam.h</filename></ulink>.
@@ -69,10 +69,10 @@
  </para>
 
  <para>
-  Actuellement, la façon dont un AM enregisrre les données est très peu
+  Actuellement, la façon dont un AM enregistre les données est très peu
   contrainte. Par exemple, il est possible, mais non requis, d'utiliser le
-  cache disque de PostgreSQL. Au cas où il est utilisé, il est sensé
-  d'utiliser la disposition standard d'une page de
+  cache disque de PostgreSQL. Au cas où il est utilisé, il est censé
+  utiliser la disposition standard d'une page de
   <productname>PostgreSQL</productname> comme décrit dans <xref
   linkend="storage-page-layout"/>.
  </para>
@@ -82,7 +82,7 @@
   qu'actuellement, si l'AM veut accepter les modifications et/ou les index, il
   est nécessaire que chaque ligne ait un identifiant de ligne
   (<acronym>TID</acronym>) consistant en un numéro de bloc et un numéro
-  d'enregistrement (voir aussi <xref linkend="storage-page-layout"/>). IL
+  d'enregistrement (voir aussi <xref linkend="storage-page-layout"/>). Il
   n'est pas strictement nécessaire que les sous-parties des
   <acronym>TIDs</acronym> aient cette même signification, avoir un
   <literal>heap</literal>, mais si le support de parcours de bitmap est

--- a/postgresql/tablefunc.xml
+++ b/postgresql/tablefunc.xml
@@ -284,7 +284,7 @@ row_name   category_1   category_2
     En pratique, la requête SQL devrait toujours spécifier <literal>ORDER BY
      1,2</literal> pour s'assurer que les lignes en entrée sont bien ordonnées,
     autrement dit que les valeurs de même <structfield>row_name</structfield>
-    sont placées ensemble et son correctement ordonnées dans la ligne. Notez
+    sont placées ensemble et sont correctement ordonnées dans la ligne. Notez
     que <function>crosstab</function> ne fait pas attention à la deuxième
     colonne du résultat de la requête&nbsp;; elle est là pour permettre le
     tri, pour contrôler l'ordre dans lequel les valeurs de la troisième
@@ -558,7 +558,7 @@ SELECT DISTINCT cat FROM foo ORDER BY 1;
 
    <para>
     La clause <literal>FROM</literal> doit définir le bon nombre de colonnes en
-    sortie avec les bon types de données. S'il y a <replaceable>N</replaceable>
+    sortie avec les bons types de données. S'il y a <replaceable>N</replaceable>
     colonnes dans le résultat de la requête <parameter>source_sql</parameter>,
     les <replaceable>N</replaceable>-2 premiers d'entre eux doivent
     correspondre aux <replaceable>N</replaceable>-2 premières colonnes en
@@ -587,7 +587,7 @@ SELECT DISTINCT cat FROM foo ORDER BY 1;
 
    <para>
     En pratique, la requête <parameter>source_sql</parameter> doit toujours
-    spécifier <literal>ORDER BY 1</literal> pour s'assurer ques les valeurs du
+    spécifier <literal>ORDER BY 1</literal> pour s'assurer que les valeurs du
     même <structfield>row_name</structfield> sont assemblées. Néanmoins,
     l'ordre des catégories dans un groupe n'est pas important. De plus, il est
     essentiel que l'ordre du résultat de la requête
@@ -765,7 +765,7 @@ connectby(text relname, text keyid_fld, text parent_keyid_fld
     Des deux premières colonnes en sortie sont utilisées pour la clé de la
     ligne en cours et la clé de son parent&nbsp;; elles doivent correspondre
     au type du champ clé de la table. La troisième colonne est la
-    profondeur de l'arbre est doit être du type <type>integer</type>. Si un
+    profondeur de l'arbre et doit être du type <type>integer</type>. Si un
     paramètre <parameter>branch_delim</parameter> est renseigné, la prochaine
     colonne en sortie est l'affichage de la branche et doit être de type
     <type>text</type>. Enfin, si le paramètre
@@ -785,7 +785,7 @@ connectby(text relname, text keyid_fld, text parent_keyid_fld
    <para>
     Si l'ordre des relations du même parent est important, incluez le
     paramètre <parameter>orderby_fld</parameter> pour indiquer par quel
-    champ ordonner les relations. Ce champs doit être de tout type de données
+    champ ordonner les relations. Ce champ doit être de tout type de données
     triable. La liste des colonnes en sortie doit inclure une colonne numéro
     de série de type integer si, et seulement si,
     <parameter>orderby_fld</parameter> est spécifiée.

--- a/postgresql/tablesample-method.xml
+++ b/postgresql/tablesample-method.xml
@@ -3,7 +3,7 @@
  <title>Écrire une méthode d'échantillonnage de table</title>
 
  <indexterm zone="tablesample-method">
-  <primary>méthode d'échantillonage de table</primary>
+  <primary>méthode d'échantillonnage de table</primary>
  </indexterm>
 
  <indexterm zone="tablesample-method">
@@ -131,7 +131,7 @@ SampleScanGetSampleSize (PlannerInfo *root,
                          double *tuples);
    </programlisting>
    Cette fonction est appelée durant la planification. Elle doit
-   estimée le nombre de pages de la relation qui seront lues
+   estimer le nombre de pages de la relation qui seront lues
    lors d'un simple parcours, et le nombre de lignes qui seront
    sélectionnées lors du parcours. (Par exemple, cela pourrait
    être déterminé en estimant la fraction échantillonnée,
@@ -149,7 +149,7 @@ SampleScanGetSampleSize (PlannerInfo *root,
    si les valeurs apparaissent invalides (rappelez-vous qu'il s'agit
    uniquement d'une estimation de valeurs futures à l'exécution). Les
    paramètres <literal>pages</literal> et <literal>tuples</literal>
-   sont les valeurs de sorties.
+   sont les valeurs de sortie.
   </para>
 
   <para>

--- a/postgresql/targets-meson.xml
+++ b/postgresql/targets-meson.xml
@@ -169,7 +169,7 @@
     <term><option>install</option></term>
     <listitem>
      <para>
-      Installe postgres, sauf la documentation
+      Installe PostgreSQL, sauf la documentation
      </para>
     </listitem>
   </varlistentry>
@@ -214,7 +214,7 @@
     <term><option>install-world</option></term>
     <listitem>
      <para>
-      Installe postgres, incluant la documentation au format multi-page HTML et page man
+      Installe PostgreSQL, incluant la documentation au format multi-page HTML et page man
      </para>
     </listitem>
   </varlistentry>

--- a/postgresql/tcn.xml
+++ b/postgresql/tcn.xml
@@ -13,7 +13,7 @@
 
  <para>
   Le module <filename>tcn</filename> fournit une fonction trigger qui notifie
-  les processus en écoute de changement sur toutes les tables sur lesquelles
+  les processus à l'écoute de changement sur toutes les tables sur lesquelles
   elle est attachée. Elle doit être utilisée dans un trigger
   <literal>AFTER</literal> et <literal>FOR EACH ROW</literal>.
  </para>
@@ -37,7 +37,7 @@
   indiquer le type d'opération réalisée, et des paires nom de colonne/valeur
   pour les colonnes de la clé primaire. Chaque partie est séparée de la suivante
   par une virgule. Pour faciliter l'analyse en utilisant des expressions
-  rationnelles, les noms de tables et de colonnes sont toujours entourés
+  régulières, les noms de tables et de colonnes sont toujours entourés
   de guillemets doubles et les valeurs sont toujours entourées de guillemets
   simples. Les guillemets à l'intérieur sont doublés.
  </para>

--- a/postgresql/test-decoding.xml
+++ b/postgresql/test-decoding.xml
@@ -10,11 +10,11 @@
  <para>
   <filename>test_decoding</filename> est un exemple de plugin de sortie pour le
   décodage logique.  Il ne fait rien de particulièrement utile, mais peut
-  servir comme point de départ pour créer votre propre plugin de sortie.
+  servir de point de départ pour créer votre propre plugin de sortie.
  </para>
 
  <para>
-  <filename>test_decoding</filename> reçoit les journaux de transaction à
+  <filename>test_decoding</filename> reçoit les journaux de transactions à
   travers les mécanismes de décodage logique, et les décode sous forme de
   représentation au format texte des opérations effectuées.
  </para>
@@ -40,7 +40,7 @@ postgres=# SELECT * FROM pg_logical_slot_get_changes('test_slot', NULL, NULL, 'i
  </para>
 
  <para>
-  Nous pouvons aussi obtenir les changements de transaction en cours. La
+  Nous pouvons aussi obtenir les changements de transactions en cours. La
   sortie ressemblerait typiquement à ceci&nbsp;:
 
  <programlisting>

--- a/postgresql/textsearch.xml
+++ b/postgresql/textsearch.xml
@@ -372,7 +372,7 @@ SELECT to_tsvector('error is not fatal') @@ to_tsquery('fatal &lt;-&gt; error');
     <literal>&lt;1&gt;</literal> est identique à <literal>&lt;-&gt;</literal>,
     tandis que l'opérateur <literal>&lt;2&gt;</literal> n'établit la
     correspondance que si exactement un lexème différent apparaît entre les
-    deux lexèmes en  argument, et ainsi de suite. La fonction
+    deux lexèmes en argument, et ainsi de suite. La fonction
     <literal>phraseto_tsquery</literal> exploite cet opérateur pour construire
     un <literal>tsquery</literal> permettant de reconnaître une phrase quand
     certains des mots sont des termes courants. Par exemple&nbsp;:
@@ -412,7 +412,7 @@ SELECT phraseto_tsquery('the cats ate the rats');
     correspondance qu'avec les documents qui ne contiennent pas
     <literal>x</literal> quelque part. Mais <literal>!x &lt;-&gt; y</literal>
     correspond à <literal>y</literal> s'il n'est pas immédiatement après un
-    <literal>x</literal>&nbsp;; un occurrence de <literal>x</literal> quelque
+    <literal>x</literal>&nbsp;; une occurrence de <literal>x</literal> quelque
     part dans le document n'empêche pas une correspondance. Un autre exemple
     est que <literal>x &amp; y</literal> nécessite seulement que
     <literal>x</literal> et <literal>y</literal> apparaissent quelque part dans
@@ -460,7 +460,7 @@ SELECT phraseto_tsquery('the cats ate the rats');
    </para>
 
    <para>
-    Chaque fonction de recherche plein texte qui dépend d'une configuration a
+    Chaque fonction de recherche plein texte qui dépend d'une configuration à
     un argument <type>regconfig</type> en option, pour que la configuration
     utilisée puisse être précisée explicitement.
     <varname>default_text_search_config</varname> est seulement utilisé quand
@@ -1367,7 +1367,7 @@ LIMIT 10;
 
    <para>
     Si une chaîne <replaceable>options</replaceable> est spécifiée, elle doit
-    consister en une liste de une ou plusieurs paires
+    consister en une liste d'une ou plusieurs paires
     <replaceable>option</replaceable><literal>=</literal><replaceable>valeur</replaceable>
     séparées par des virgules. Les options disponibles sont&nbsp;:
 
@@ -2037,7 +2037,7 @@ SELECT title, body FROM messages WHERE tsv @@ to_tsquery('title &amp; body');
     Après avoir créé ce trigger, toute modification dans
     <structfield>title</structfield> ou <structfield>body</structfield> sera
     automatiquement reflétée dans <structfield>tsv</structfield>, sans que
-    l'application n'ait à s'en soucier.
+    l'application ait à s'en soucier.
    </para>
 
    <para>
@@ -2183,7 +2183,7 @@ LIMIT 10;
 
   <para>
    L'analyseur interne est nommé <literal>pg_catalog.default</literal>.
-   Il reconnait 23 types de jeton, dont la liste est disponible dans
+   Il reconnaît 23 types de jeton, dont la liste est disponible dans
    <xref linkend="textsearch-default-parser"/>.
   </para>
 
@@ -3786,7 +3786,7 @@ SELECT plainto_tsquery('supernovae stars');
  </sect1>
 
  <sect1 id="textsearch-indexes">
-  <title>Types d'index préférées pour la recherche plein texte</title>
+  <title>Types d'index préférés pour la recherche plein texte</title>
 
   <indexterm zone="textsearch-indexes">
    <primary>recherche plein texte</primary>
@@ -3887,7 +3887,7 @@ SELECT plainto_tsquery('supernovae stars');
   <para>
    Un index GiST peut être couvrant, c'est-à-dire utiliser la clause
    <literal>INCLUDE</literal>. Les colonnes incluses peuvent avoir des
-   types de données sans aucune classe d'opérateur GiST.
+   types de données sans aucune classe d'opérateurs GiST.
    Les attributs inclus seront stockés sans compression.
   </para>
 

--- a/postgresql/trigger.xml
+++ b/postgresql/trigger.xml
@@ -89,10 +89,10 @@
    trigger est appelée une fois pour chaque ligne affectée par
    l'instruction qui a lancé le trigger. Au contraire, un trigger en mode
    instruction n'est appelé qu'une seule fois lorsqu'une instruction appropriée
-   est exécutée, quelque soit le nombre de lignes affectées par cette
+   est exécutée, quel que soit le nombre de lignes affectées par cette
    instruction. En particulier, une instruction n'affectant aucune ligne
    résultera toujours en l'exécution de tout trigger en mode instruction
-   applicable. Ces deux types sont quelque fois appelés respectivement des
+   applicable. Ces deux types sont quelques fois appelés respectivement des
    <firstterm>triggers niveau ligne</firstterm> et des
    <firstterm>triggers niveau instruction</firstterm>.
    Les triggers sur <command>TRUNCATE</command> peuvent seulement être définis
@@ -135,11 +135,11 @@
    UPDATE</literal>, il est possible pour les triggers niveau ligne
    <literal>BEFORE</literal> <command>INSERT</command> puis
    <literal>BEFORE</literal> <command>UPDATE</command> d'être exécutés sur
-   les lignes cibles. De telles interactions peuvent être complexs si les
+   les lignes cibles. De telles interactions peuvent être complexes si les
    triggers ne sont pas idempotents parce que les modifications réalisées par
    les triggers <literal>BEFORE</literal> <command>INSERT</command> seront
    vus par les triggers <literal>BEFORE</literal> <command>UPDATE</command>,
-   ceci incluant les modifications sur les colonnes
+   ceci inclut les modifications sur les colonnes
    <varname>EXCLUDED</varname>.
   </para>
 
@@ -161,7 +161,7 @@
   </para>
 
   <para>
-   Une instruction qui cible une table parent dans une hiérarchie d'héritage
+   Une instruction qui cible une table parente dans une hiérarchie d'héritage
    ou de partitionnement ne cause pas le déclenchement des triggers niveau
    instruction des tables enfants affectées&nbsp;; seuls les triggers niveau
    instruction de la table parent sont déclenchés. Néanmoins, les triggers
@@ -188,7 +188,7 @@
    triggers niveau instruction, aucun des triggers <command>DELETE</command>
    et <command>INSERT</command> ne sont déclenchés, y compris en cas de
    déplacement de lignes. Seuls les triggers <command>UPDATE</command>
-   définis sur la table cible utilisés dans une instruction
+   définis sur la table cible utilisée dans une instruction
    <command>UPDATE</command> seront déclenchés.
   </para>
 
@@ -365,7 +365,7 @@
   <para>
    Si une clé étrangère indique des actions référentielles (autrement dit,
    des mises à jour ou des suppressions en cascade), ces actions seront
-   réalisées via des commandes SQL ordinaires de mise jour ou de suppression
+   réalisées via des commandes SQL ordinaires de mis jour ou de suppression
    sur la table référençante. En particulier, tout trigger qui existe sur la
    table référençante sera déclenché pour ces modifications. Si un trigger
    modifie ou bloque l'effet d'une de ces commandes, le résultat final
@@ -391,12 +391,12 @@
    <command>INSERT</command> sur n'importe quelle table ayant des colonnes
    adéquates, pour automatiquement suivre les créations d'enregistrements dans
    une table de transactions par exemple. Elle pourrait aussi être utilisée
-   pour suivre les dernières mises à jours si elle est définie comme un
+   pour suivre les dernières mises à jour si elle est définie comme un
    trigger <command>UPDATE</command>.
   </para>
 
   <para>
-   Chaque langage de programmation supportant les triggers a sa propre
+   Chaque langage de programmation supportant les triggers à sa propre
    méthode pour rendre les données en entrée disponible à la fonction du
    trigger. Cette donnée en entrée inclut le type d'événement du
    trigger (c'est-à-dire <command>INSERT</command> ou

--- a/postgresql/tsm-system-rows.xml
+++ b/postgresql/tsm-system-rows.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="tsm-system-rows" xreflabel="tsm_system_rows">
  <title>tsm_system_rows &mdash;
-  méthode d'échantillonage <literal>SYSTEM_ROWS</literal> pour
+  méthode d'échantillonnage <literal>SYSTEM_ROWS</literal> pour
   <literal>TABLESAMPLE</literal></title>
 
  <indexterm zone="tsm-system-rows">
@@ -10,7 +10,7 @@
 
  <para>
   Le module <filename>tsm_system_rows</filename> fournit la méthode
-  d'échantillonage de table <literal>SYSTEM_ROWS</literal>, qui peut être
+  d'échantillonnage de table <literal>SYSTEM_ROWS</literal>, qui peut être
   utilisé dans la clause <literal>TABLESAMPLE</literal> d'une commande
   <link linkend="sql-select"><command>SELECT</command></link>.
  </para>

--- a/postgresql/tsm-system-time.xml
+++ b/postgresql/tsm-system-time.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sect1 id="tsm-system-time" xreflabel="tsm_system_time">
  <title>tsm_system_time &mdash;
-  méthode d'échantillonage <literal>SYSTEM_TIME</literal> pour
+  méthode d'échantillonnage <literal>SYSTEM_TIME</literal> pour
   <literal>TABLESAMPLE</literal></title>
 
  <indexterm zone="tsm-system-time">
@@ -10,7 +10,7 @@
 
  <para>
   Le module <filename>tsm_system_time</filename> fournit la méthode
-  d'échantillonage de table <literal>SYSTEM_TIME</literal>, qui peut être
+  d'échantillonnage de table <literal>SYSTEM_TIME</literal>, qui peut être
   utilisé par la clause <literal>TABLESAMPLE</literal> d'une commande
   <link linkend="sql-select"><command>SELECT</command></link>.
  </para>

--- a/postgresql/typeconv.xml
+++ b/postgresql/typeconv.xml
@@ -41,7 +41,7 @@
    a un système de types extensible qui est beaucoup plus général et flexible que
    les autres implémentations de <acronym>SQL</acronym>.  Par conséquent, la
    plupart des comportements de conversion de types dans
-   <productname>PostgreSQL</productname> est régie par des règles générales plutôt
+   <productname>PostgreSQL</productname> sont régis par des règles générales plutôt
    que par une heuristique <foreignphrase>ad hoc</foreignphrase>. Cela permet aux
    expressions de types mixtes d'être significatives, même avec des types définis
    par l'utilisateur.
@@ -104,7 +104,7 @@ Les opérateurs
 <para>
 <productname>PostgreSQL</productname> autorise les expressions avec
 des opérateurs de préfixe (un argument) aussi bien
-que infixes (deux arguments). Comme les fonctions, les opérateurs peuvent être
+qu'infixes (deux arguments). Comme les fonctions, les opérateurs peuvent être
 surchargés. Du coup, le même problème existe pour sélectionner le bon opérateur.
 </para>
 </listitem>
@@ -183,7 +183,7 @@ que les expressions ambiguës (celles avec plusieurs solutions candidates) peuve
 </para>
 
 <para>
-Toutes les règles de conversions de types sont écrites en gardant à l'esprit
+Toutes les règles de conversion de types sont écrites en gardant à l'esprit
 plusieurs principes&nbsp;:
 
 <itemizedlist>
@@ -210,7 +210,7 @@ implicites non nécessaires.
 De plus, si une requête nécessite habituellement une conversion
 implicite pour une fonction et si l'utilisateur définit une nouvelle
 fonction avec les types des arguments corrects, l'analyseur devrait
-utiliser cette nouvelle fonction et ne fera plus des conversions
+utiliser cette nouvelle fonction et ne fera plus de conversions
 implicites en utilisant l'ancienne fonction.
 </para>
 </listitem>
@@ -350,7 +350,7 @@ un risque de sécurité lors de l'appel, via un nom qualifié
   </step>
   <step performance="required">
    <para>
-    Si des arguments en entrée sont <type>unkown</type>, vérifier la
+    Si des arguments en entrée sont <type>unknown</type>, vérifier la
     catégorie des types acceptés à la position de ces arguments par les
     candidats restants. À chaque position, sélectionner la catégorie
     <type>chaîne de caractères</type> si un des candidats accepte cette
@@ -370,9 +370,9 @@ un risque de sécurité lors de l'appel, via un nom qualifié
   </step>
   <step id="op-resol-last-unknown" performance="required">
    <para>
-    S'il y a des arguments à la fois <type>unkown</type> et connus, et que tous
+    S'il y a des arguments à la fois <type>unknown</type> et connus, et que tous
     les arguments de type connu ont le même type, supposer que les arguments
-    <type>unkown</type> sont de ce même type, et vérifier les candidats
+    <type>unknown</type> sont de ce même type, et vérifier les candidats
     qui acceptent ce type aux positions des arguments de type <type>unknown</type>.
     Si un seul candidat réussit ce test, l'utiliser. Sinon, échec.
    </para>
@@ -784,9 +784,9 @@ est déterminée selon les étapes suivantes.
   </step>
   <step performance="required">
    <para>
-    S'il y a des arguments à fois <type>unkown</type> et connus, et que tous
+    S'il y a des arguments à la fois <type>unknown</type> et connus, et que tous
     les arguments de type connu ont le même type, supposer que les arguments
-    <type>unkown</type> sont de ce même type, et vérifier les candidats
+    <type>unknown</type> sont de ce même type, et vérifier les candidats
     qui acceptent ce type aux positions des arguments de type <type>unknown</type>.
     Si un seul candidat réussit ce test, l'utiliser. Sinon, échec.
    </para>
@@ -854,7 +854,7 @@ SELECT public.variadic_example(0),
 (1 row)
  </screen>
 
- Néanmoins, le premier et le deuxième appels préféreront des fonctions plus
+ Néanmoins, le premier et le deuxième appel préféreront des fonctions plus
  spécifiques si elles sont disponibles&nbsp;:
 
  <screen>
@@ -876,7 +876,7 @@ SELECT public.variadic_example(0),
  </screen>
 
  Étant donné la configuration par défaut et si seule la première fonction existe,
- le premier et le deuxième appels ne sont pas sécurisés. Tout utilisateur
+ le premier et le deuxième appel ne sont pas sécurisés. Tout utilisateur
  peut les intercepter en créant la deuxième et la troisième fonction. En utilisant
  une correspondance exacte du type d'argument et en utilisant le mot-clé
  <literal>VARIADIC</literal>, le troisième appel est sécurisé.

--- a/postgresql/unaccent.xml
+++ b/postgresql/unaccent.xml
@@ -10,7 +10,7 @@
  <para>
   <filename>unaccent</filename> est un dictionnaire de recherche plein texte
   qui supprime les
-  accents d'un lexeme. C'est un dictionnaire de filtre, ce qui signifie que sa
+  accents d'un lexème. C'est un dictionnaire de filtre, ce qui signifie que sa
   sortie est passée au prochain dictionnaire (s'il y en a un), contrairement
   au comportement normal des dictionnaires. Cela permet le traitement des
   accents pour la recherche plein texte.
@@ -72,7 +72,7 @@
 
    <listitem>
     <para>
-     Sinon, si seulement un caractère est donnée sur une ligne, les occurences
+     Sinon, si seulement un caractère est donné sur une ligne, les occurrences
      de ce caractère sont supprimées. Ceci est utile dans les langues où les
      accents sont représentés par des caractères séparés.
     </para>
@@ -147,7 +147,7 @@
 ma_base=# ALTER TEXT SEARCH DICTIONARY unaccent (RULES='mes_regles');
      </programlisting>
 
-     Vous pouvez aussi créer des nouveaux dictionnaires basés sur le modèle.
+     Vous pouvez aussi créer de nouveaux dictionnaires basés sur le modèle.
     </para>
 
     <para>
@@ -197,8 +197,8 @@ ma_base=# select ts_headline('fr','Hôtel de la Mer',to_tsquery('fr','Hotels'));
 
     <para>
      La fonction <function>unaccent()</function> supprime les accents d'une
-     chaîne de caractères donnée. Il utilise un dictionnaire de type
-     <filename>unaccent</filename> mais il peut être utilisé en dehors du
+     chaîne de caractères donnée. Elle utilise un dictionnaire de type
+     <filename>unaccent</filename> mais elle peut être utilisé en dehors du
      contexte normal de la recherche plein texte.
     </para>
 

--- a/postgresql/user-manag.xml
+++ b/postgresql/user-manag.xml
@@ -15,7 +15,7 @@
  </para>
 
  <para>
-  Le concept des rôles comprends les concepts des <quote>utilisateurs</quote> et des
+  Le concept des rôles comprend les concepts des <quote>utilisateurs</quote> et des
   <quote>groupes</quote>. Dans les versions de <productname>PostgreSQL</productname>
   antérieures à la 8.1, les utilisateurs et les groupes étaient des types
   d'entité distincts mais, maintenant, ce ne sont que des rôles. Tout rôle peut
@@ -55,7 +55,7 @@
    <synopsis>CREATE ROLE <replaceable>nom_utilisateur</replaceable>;</synopsis>
    <replaceable>nom_utilisateur</replaceable> suit les règles des
    identifiants SQL&nbsp;: soit sans guillemets et sans caractères spéciaux,
-   soit entre double-guillemets (en pratique, vous voudrez surtout ajouter
+   soit entre double guillemets (en pratique, vous voudrez surtout ajouter
    des options supplémentaires, comme <literal>LOGIN</literal>, à cette commande.
    Vous trouverez plus de détails ci-dessous). Pour supprimer un rôle existant,
    utilisez la commande analogue <link linkend="sql-droprole"><command>DROP
@@ -108,7 +108,7 @@ dropuser <replaceable>nom_utilisateur</replaceable></synopsis>
    certain rôle et ce rôle détermine les droits d'accès initiaux pour les
    commandes lancées sur cette connexion. Le nom du rôle
    à employer pour une connexion à une base particulière est indiqué
-   par le client initialisant la demande de connexion et ce, de la
+   par le client initialisant la demande de connexion, et ce, de la
    manière qui lui est propre.  Par exemple, le programme
    <command>psql</command> utilise l'option de ligne de commandes
    <option>-U</option> pour préciser sous quel rôle il se
@@ -261,7 +261,7 @@ CREATE USER <replaceable>nom</replaceable>;</programlisting>
         <option>md5</option> utilisent des mots de
         passe.  Les mots de passe de la base de données ne sont pas
         les mêmes que ceux du système d'exploitation.  Indiquez un
-        mots de passe lors de la création d'un rôle avec
+        mot de passe lors de la création d'un rôle avec
         <literal>CREATE ROLE
         <replaceable>nom_utilisateur</replaceable> PASSWORD
         '<replaceable>le_mot_de_passe</replaceable>'</literal>.
@@ -302,7 +302,7 @@ CREATE USER <replaceable>nom</replaceable>;</programlisting>
       <listitem>
        <para>
         La limite de connexions peut indiquer combien de connexions concurrentes
-        un rôle peut faire.  -1 (la valeur par défaut) signifie aucune limite.
+        un rôle peut faire.  -1 (la valeur par défaut) ne signifie aucune limite.
         Précisez une limite de connexion lors de la création d'un rôle avec
         <literal>CREATE ROLE <replaceable>nom</replaceable> CONNECTION LIMIT
         '<replaceable>integer</replaceable>'</literal>.
@@ -340,7 +340,7 @@ CREATE USER <replaceable>nom</replaceable>;</programlisting>
       <listitem>
        <para>
         La limite de connexions peut indiquer combien de connexions concurrentes
-        un même rôle peut réaliser. La valeur par défaut, -1, signifie aucune
+        un même rôle peut réaliser. La valeur par défaut, -1, ne signifie aucune
         limite.  Indiquez une limite de connexion lors de la création d'un rôle
         avec
         <literal>CREATE ROLE <replaceable>nom</replaceable> CONNECTION LIMIT '<replaceable>integer</replaceable>'</literal>.
@@ -443,7 +443,7 @@ REVOKE <replaceable>role_groupe</replaceable> FROM <replaceable>role1</replaceab
 
   <para>
    Les membres d'un rôle groupe peuvent utiliser les droits du rôle de deux façons.
-   Tout d'abord, les rôles membres qui se sont vu attribués l'appartenance avec l'option
+   Tout d'abord, les rôles membres qui se sont vus attribués l'appartenance avec l'option
    <literal>SET</literal> peuvent exécuter
    <link linkend="sql-set-role"><command>SET ROLE</command></link> pour
    <quote>devenir</quote> temporairement le rôle groupe. Dans cet état, la session
@@ -693,7 +693,7 @@ DROP ROLE role_a_supprimer;
      <row>
       <entry>pg_stat_scan_tables</entry>
       <entry>Exécute des fonctions de monitoring pouvant prendre des verrous
-       verrous <literal>ACCESS SHARE</literal> sur les tables, potentiellement
+       <literal>ACCESS SHARE</literal> sur les tables, potentiellement
        pour une longue durée.</entry>
      </row>
      <row>
@@ -765,7 +765,7 @@ DROP ROLE role_a_supprimer;
    <literal>pg_read_all_settings</literal>,
    <literal>pg_read_all_stats</literal> et
    <literal>pg_stat_scan_tables</literal> ont pour but de permettre aux
-   administrateurs de configurer aisément un rôle en vu de superviser le
+   administrateurs de configurer aisément un rôle en vue de superviser le
    serveur de base de données. Ils accordent un ensemble de privilèges
    permettant au rôle de lire plusieurs paramètres de configuration,
    statistiques et information système normalement réservés aux
@@ -774,7 +774,7 @@ DROP ROLE role_a_supprimer;
 
   <para>
    Le rôle <literal>pg_database_owner</literal> a un membre implicite, à savoir
-   le propriétaire de la base de données en cours. Comme tout tôlen il peut être
+   le propriétaire de la base de données en cours. Comme tout rôle, il peut être
    propriétaire des objets et recevoir des autorisations d'accès.  En
    conséquence, une fois que <literal>pg_database_owner</literal> a des droits
    dans une base modèle, chaque propriétaire d'une base créée à partir de ce

--- a/postgresql/vacuumlo.xml
+++ b/postgresql/vacuumlo.xml
@@ -179,7 +179,7 @@
  </refsect1>
 
  <refsect1>
-  <title>Environment</title>
+  <title>Environnement</title>
 
   <variablelist>
    <varlistentry>
@@ -204,7 +204,7 @@
 
   <para>
    La variable d'environnement <envar>PG_COLOR</envar> indique s'il faut, ou
-   non, utiliser de la couleur dans les messages de diagnostique. Les valeurs
+   non, utiliser de la couleur dans les messages de diagnostic. Les valeurs
    possibles sont <literal>always</literal>, <literal>auto</literal> et
    <literal>never</literal>.
   </para>
@@ -218,11 +218,11 @@
    Tout d'abord, <application>vacuumlo</application> construit une table
    temporaire contenant tous les OID des Large Objects se trouvant dans la base
    sélectionnée. Puis, il parcourt toutes les colonnes de la base qui sont du
-   type <type>oid</type> ou <type>lo</type>, et supprime toutes entrées
-   correspondant de la table temporaire. (Note&nbsp;: seuls sont pris en compte
+   type <type>oid</type> ou <type>lo</type>, et supprime toutes les entrées
+   correspondantes de la table temporaire. (Note&nbsp;: seuls sont pris en compte
    les types de ces noms&nbsp;; en particulier, les domaines utilisant ces
    types ne sont pas pris en compte.)  Les enregistrements restants dans la
-   table temporaires sont identifiés comme les Large Objects orphelins. Ils sont
+   table temporaire sont identifiés comme les Large Objects orphelins. Ils sont
    supprimés.
   </para>
  </refsect1>

--- a/postgresql/wait_event_types.xml
+++ b/postgresql/wait_event_types.xml
@@ -151,7 +151,7 @@
      <row>
       <entry><literal>GssOpenServer</literal></entry>
       <entry>En attente de lecture de données depuis le client
-        lors de l'établissement une session GSSAPI.</entry>
+        lors de l'établissement d'une session GSSAPI.</entry>
      </row>
      <row>
       <entry><literal>LibpqwalreceiverConnect</literal></entry>
@@ -1177,7 +1177,7 @@
       <entry>En attente de lecture ou mise à jour d'un fichier
         <filename>pg_filenode.map</filename>
         (utilisé pour suivre les attributions des numéros de fichier
-        de certains catalogue système).</entry>
+        de certain catalogue système).</entry>
      </row>
      <row>
       <entry><literal>RelCacheInit</literal></entry>

--- a/postgresql/wal-for-extensions.xml
+++ b/postgresql/wal-for-extensions.xml
@@ -20,7 +20,7 @@
    façon générique. Cette méthode est simple à implémenter et ne nécessite pas
    qu'une bibliothèque partagée de l'extension soit chargée pour appliquer les
    enregistrements. Néanmoins, les enregistrements WAL génériques seront
-   ignorés lors du traiteùment du décodage logique.
+   ignorés lors du traitement du décodage logique.
   </para>
 
   <para>

--- a/postgresql/wal.xml
+++ b/postgresql/wal.xml
@@ -3,9 +3,9 @@
  <title>Fiabilité et journaux de transaction</title>
 
  <para>
-  This chapter explains how to control the reliability of
-  <productname>PostgreSQL</productname>, including details about the
-  Write-Ahead Log.
+  Ce chapitre explique comment contrôler la fiabilité de
+  <productname>PostgreSQL</productname>, y compris les détails sur
+  le journal de transactions (Write-Ahead Log, ou <acronym>WAL</acronym>).
  </para>
 
  <sect1 id="wal-reliability">
@@ -16,7 +16,7 @@
    données sérieux. <productname>PostgreSQL</productname> fait tout
    son possible pour garantir un fonctionnement fiable. Un des aspects
    de la fiabilité est de stocker toutes les données validées par une
-   transaction dans un espace non volatile,
+   transaction dans un espace non volatil,
    insensible aux coupures de courant, aux bogues du système d'exploitation
    et aux problèmes matériels (sauf en cas de problème sur l'espace non
    volatile, bien sûr).
@@ -174,8 +174,8 @@
   <para>
    Quand le système d'exploitation envoie une demande d'écriture au système de
    stockage,
-   il ne peut pas faire grand chose pour s'assurer que les données sont
-   arrivées dans un espace de stockage réellement non volatile.
+   il ne peut pas faire grand-chose pour s'assurer que les données sont
+   arrivées dans un espace de stockage réellement non volatil.
    C'est plutôt la responsabilité de l'administrateur de
    s'assurer que tous les composants de
    stockage garantissent l'intégrité des données et des métadonnées du système de
@@ -370,7 +370,7 @@
 
   <tip>
    <para>
-    Comme les journaux de transaction permettent de restaurer le contenu des
+    Comme les journaux de transactions permettent de restaurer le contenu des
     fichiers de base de données après un arrêt brutal, un système de
     fichiers journalisé n'est pas nécessaire pour stocker avec fiabilité
     les fichiers de données ou les journaux de transactions.
@@ -387,7 +387,7 @@
   </tip>
 
   <para>
-   Utiliser les journaux de transaction permet de réduire de façon
+   Utiliser les journaux de transactions permet de réduire de façon
    significative le nombre d'écritures sur le disque&nbsp;: seul le journal
    a besoin d'être écrit sur le disque pour garantir qu'une
    transaction a été validée, il n'y a pas besoin d'écrire dans chaque fichier de
@@ -403,17 +403,17 @@
   </para>
 
   <para>
-   Les journaux de transaction rendent possible le support de sauvegarde
+   Les journaux de transactions rendent possible le support de sauvegarde
    en ligne et de récupération à un moment donné dans le temps,
    comme décrit dans la <xref linkend="continuous-archiving"/>.
    En archivant les journaux de transaction,
    nous permettons un retour à tout instant couvert par les données
    disponibles dans les journaux de transaction&nbsp;: nous installons
    simplement une ancienne sauvegarde physique de la base de données et nous
-   rejouons les journaux de transaction jusqu'au moment désiré. Qui plus est,
+   rejouons les journaux de transactions jusqu'au moment désiré. Qui plus est,
    la sauvegarde physique n'a pas besoin d'être une image instantanée de
    l'état de la base de données &mdash; si elle a été faite pendant une
-   longue période de temps, alors rejouer les journaux de transaction pour
+   longue période de temps, alors rejouer les journaux de transactions pour
    cette période corrigera toute incohérence interne.
   </para>
  </sect1>
@@ -582,7 +582,7 @@
    <foreignphrase>checkpoints</foreignphrase>
    (ou <firstterm>points de contrôle</firstterm>)
    sont des points qui garantissent que les fichiers de données
-   des table et des index ont été mis à
+   des tables et des index ont été mis à
    jour avec toutes les informations enregistrées dans le journal avant le
    checkpoint. Au moment du checkpoint, toutes les
    pages de données modifiées (<foreignphrase>dirty</foreignphrase>)
@@ -592,7 +592,7 @@
    transactions.)
    En cas de défaillance, la procédure de récupération recherche le
    dernier enregistrement d'un checkpoint
-   (enregistrement connus sous le nom de <quote>redo log</quote>)
+   (enregistrement connu sous le nom de <quote>redo log</quote>)
    pour déterminer le point des journaux
    à partir duquel il devra lancer l'opération de REDO.
    Toute modification effectuée sur les fichiers de données avant ce point
@@ -710,7 +710,7 @@
    Sur les plateformes Linux et POSIX, <xref
    linkend="guc-checkpoint-flush-after"/> vous permet de forcer le système
    d'exploitation à vider sur disque les pages écrites par un checkpoint
-   après qu'un nombre configurable d'octets soit écrit. Sinon ces pages
+   après qu'un nombre configurable d'octets a été écrit. Sinon ces pages
    pourraient rester dans le cache disque du système d'exploitation,
    provoquant un blocage quand <literal>fsync</literal> est exécuté à la fin
    d'un checkpoint. Cette configuration aide souvent à réduire la latence des
@@ -763,7 +763,7 @@
    En mode de restauration d'archive et en mode standby, le serveur
    réalise périodiquement des <firstterm>restartpoints</firstterm>
    <indexterm><primary>restartpoint</primary></indexterm> (points de
-   redémarrage), qui sont similaire aux checkpoints lors du fonctionnement
+   redémarrage), qui sont similaires aux checkpoints lors du fonctionnement
    normal&nbsp;: le serveur force l'écriture de son état sur disque, met à
    jour le fichier <filename>pg_control</filename> pour indiquer que les
    données déjà traitées des journaux de transactions n'ont plus besoin d'être
@@ -781,7 +781,7 @@
    restartpoint est déclenché suite à un dépassement de délai si un
    enregistrement de checkpoint record est atteint alors qu'au moins <xref
    linkend="guc-checkpoint-timeout"/> secondes sont passées depuis le dernier
-   restartpoint ou quand ma tentative précédent de restartpoint a échoué.
+   restartpoint ou quand ma tentative précédente de restartpoint a échoué.
    Dans ce dernier cas, le prochain restartpoint sera prévu dans 15 secondes.
    Un restartpoint est déclenché suite à une demande pour des raisons
    similaires au checkpoint mais principalement si la volumétrie des fichiers
@@ -856,7 +856,7 @@
    pas activé, ou si moins de <xref linkend="guc-commit-siblings"/> autres
    sessions sont actuellement dans une transaction active&nbsp;; ce
    mécanisme évite l'endormissement quand il est improbable que d'autres sessions
-   valident bientôt leur transactions. Il est à noter que, sur
+   valident bientôt leurs transactions. Il est à noter que, sur
    certaines plateformes, la résolution d'une requête d'endormissement est de dix
    millisecondes, ce qui implique que toute valeur comprise entre 1 et 10000 pour
    le paramètre <varname>commit_delay</varname> aura le même effet. Notez aussi
@@ -962,7 +962,7 @@
    soit <literal>fsync</literal>, soit <literal>fsync_writethrough</literal>,
    les opérations en écriture déplacent le cache WAL dans le cache du noyau
    et <function>issue_xlog_fsync</function> les synchronise sur disque.
-   Quelque soit la configuration de <varname>track_wal_io_timing</varname>,
+   Quelle que soit la configuration de <varname>track_wal_io_timing</varname>,
    le nombre de fois où <function>XLogWrite</function> écrit et que
    <function>issue_xlog_fsync</function> synchronise les données WAL sur
    disque sont aussi comptées dans, respectivement,
@@ -1016,7 +1016,7 @@
   </para>
 
   <para>
-   Les journaux de transaction sont un ensemble de fichiers stockés dans le répertoire
+   Les journaux de transactions sont un ensemble de fichiers stockés dans le répertoire
    <filename>pg_wal</filename> sous celui des données,
    chacun d'une taille de 16&nbsp;Mo normalement (cette
    taille pouvant être modifiée en modifiant l'option

--- a/postgresql/xact.xml
+++ b/postgresql/xact.xml
@@ -16,7 +16,7 @@
    Les transactions peuvent être créées explicitement en utilisant
    <command>BEGIN</command> ou <command>START TRANSACTION</command>
    et elles sont terminées en utilisant
-   <command>COMMIT</command> oyu <command>ROLLBACK</command>. Les requêtes SQL
+   <command>COMMIT</command> ou <command>ROLLBACK</command>. Les requêtes SQL
    en dehors de transactions explicites utilisent automatiquement des
    transactions à une requête.
   </para>
@@ -49,7 +49,7 @@
 
   <para>
    Le type interne d'un identifiant de transaction, <type>xid</type>, est
-   sur bits et boucle après 4 milliards de transaction. Un epoch sur 32 bit
+   sur 32 bits et boucle après 4 milliards de transactions. Un epoch sur 32 bit
    est incrémenté à chaque boucle. Il existe aussi un type <type>xid8</type>
    sur 64 bits qui inclut cet epoch et, de ce fait, ne boucle pas pendant toute
    la vie d'une installation&nbsp;; il peut être converti en xid. Les fonctions
@@ -109,8 +109,8 @@
    Les sous-transactions sont commencées dans des transactions, permettant à
    de grosses transactions d'être séparées en plusieurs unités plus petites.
    Les sous-transactions peuvent être validées ou annulées sans affecter leurs
-   transactions parents, permettant ainsi aux transactions parents de continuer.
-   Cela permet une gestion plus facile des erreurs, qui est un problèm fréquent
+   transactions parentes, permettant ainsi aux transactions parentes de continuer.
+   Cela permet une gestion plus facile des erreurs, qui est un problème fréquent
    lors du développement d'applications. Le mot sous-transaction est souvent
    abrégé en <firstterm>subxact</firstterm>.
   </para>
@@ -154,7 +154,7 @@
   </para>
 
   <para>
-   Quand une transaction deniveau haut avec un xid st validé, toutes les
+   Quand une transaction de niveau haut avec un xid est validée, toutes les
    sous-transactions enfants sous-validées sont aussi enregistrées de façon
    permanente dans le répertoire <filename>pg_xact</filename> comme étant
    validées. Si la transaction de niveau haut annule, toutes ses
@@ -184,14 +184,14 @@
    pour but d'être utilisées par des systèmes de gestion externe des
    transactions. <productname>PostgreSQL</productname> suit les fonctionnalités
    et le modèle proposés par le standard X/Open XA, mais n'implémente pas certains
-   aspects mois fréquemment utilisés.
+   aspects moins fréquemment utilisés.
   </para>
 
   <para>
    Quand l'utilisateur exécute <command>PREPARE TRANSACTION</command>, les
    seules commandes possibles après sont <command>COMMIT PREPARED</command>
    ou <command>ROLLBACK PREPARED</command>. En général, cet état préparé est
-   sensé avoir une durée de vie très courte, mais des problèmes externes de
+   censé avoir une durée de vie très courte, mais des problèmes externes de
    disponibilité pourraient forcer les transactions à rester dans cet état
    pour un long moment. Les transactions préparées rapides sont stockées
    uniquement en mémoire partagée et dans les WAL. Les transactions qui durent

--- a/postgresql/xaggr.xml
+++ b/postgresql/xaggr.xml
@@ -39,8 +39,8 @@
   <function>sum</function> en est un exemple.
   <function>sum</function> débute à zéro et ajoute la valeur de la ligne
   courante à son total en cours. Par exemple, pour obtenir un agrégat
-  <function>sum</function> qui opère sur un type de données nombres
-  complexes, il suffira décrire la fonction d'addition pour ce type de donnée.
+  <function>sum</function> qui opère sur un type de données de nombres
+  complexes, il suffira de décrire la fonction d'addition pour ce type de donnée.
   La définition de l'agrégat sera&nbsp;:
   <programlisting>CREATE AGGREGATE somme (complex)
 (
@@ -68,7 +68,7 @@ SELECT somme(a) FROM test_complexe;
  <para>
   La définition précédente de <function>sum</function> retournera zéro (la
   condition d'état initial) s'il n'y a que des valeurs d'entrée NULL.
-  Dans ce cas, on peut souhaiter qu' elle retourne NULL &mdash; le
+  Dans ce cas, on peut souhaiter qu'elle retourne NULL &mdash; le
   standard SQL prévoit que la fonction <function>sum</function> se comporte
   ainsi. Cela peut être obtenu par l'omission de l'instruction
   <literal>initcond</literal>, de sorte que la condition d'état initial soit
@@ -123,7 +123,7 @@ SELECT somme(a) FROM test_complexe;
   Les appels de fonctions d'agrégat en SQL autorisent les options
   <literal>DISTINCT</literal> et <literal>ORDER BY</literal> qui contrôlent
   les lignes envoyées à la fonction de transition de l'agrégat et leur ordre.
-  Ces options sont implémentées en arrière plan et ne concernent pas les
+  Ces options sont implémentées en arrière-plan et ne concernent pas les
   fonctions de support de l'agrégat.
  </para>
 
@@ -146,13 +146,13 @@ SELECT somme(a) FROM test_complexe;
   <para>
    Les fonctions d'agrégat peuvent accepter en option un <firstterm>mode
     d'agrégat en déplacement</firstterm>, qui autorise une exécution bien plus
-   rapide des fonctions d'agrégats pour les fenêtre dont le point de démarrage
+   rapide des fonctions d'agrégats pour les fenêtres dont le point de démarrage
    se déplace.
    (Voir <xref linkend="tutorial-window"/> et
    <xref linkend="syntax-window-functions"/> pour des informations sur
    l'utilisation des fonctions d'agrégats en tant que fonctions de fenêtrage.)
    L'idée de base est qu'en plus d'une fonction de transition <quote>en
-    avant</quote>, l'agrégat fournir une <firstterm>fonction de transition
+    avant</quote>, l'agrégat doit fournir une <firstterm>fonction de transition
     inverse</firstterm>, qui permet aux lignes d'être supprimées de la valeur
    d'état de l'agrégat quand elles quittent l'étendue de la fenêtre. Par
    exemple, un agrégat <function>sum</function> qui utilise l'addition comme
@@ -161,13 +161,13 @@ SELECT somme(a) FROM test_complexe;
    mécanisme de fonction de fenêtrage doit recalculer l'agrégat à partir du
    début à chaque fois que le point de départ de la fenêtre est déplacé, ce
    qui a pour effet d'augmenter la durée d'exécution proportionnellement au
-   nombre de lignes en entrée multiplé à la longueur moyenne de la fenêtre.
+   nombre de lignes en entrée multiplié à la longueur moyenne de la fenêtre.
    Avec une fonction de transition inverse, la durée d'exécution est uniquement
    proportionnelle au nombre de lignes en entrée.
   </para>
 
   <para>
-   La fonction de transition inverse se voit fourni la valeur de l'état courant
+   La fonction de transition inverse se voit fournie la valeur de l'état courant
    et les valeurs en entrée de l'agrégat pour la première ligne inclus dans
    l'état courant. Il doit reconstruire la valeur d'état telle qu'elle aurait
    été si la ligne en entrée n'avait pas été agrégé, mais seulement les lignes
@@ -333,7 +333,7 @@ SELECT attrelid::regclass, array_accum(atttypid::regtype)
    Elle devrait avoir un type de résultat polymorphique mais pas d'argument
    polymorphique, ce que <command>CREATE FUNCTION</command> rejetera sur la base
    que le type en résultat ne peut pas être déduit de cet appel. Cependant,
-   quelque fois, il est inconfortable d'utiliser un type d'état polymorphique.
+   quelques fois, il est inconfortable d'utiliser un type d'état polymorphique.
    Le cas le plus fréquent arrive quand les fonctions de support de l'agrégat
    sont à écrire en C et que le type d'état doit être déclaré comme
    <type>internal</type> parce qu'il n'existe pas d'équivalent SQL pour lui.

--- a/postgresql/xfunc.xml
+++ b/postgresql/xfunc.xml
@@ -61,7 +61,7 @@
  </para>
 
  <para>
-  Lors de  la lecture de ce chapitre, il peut être utile de consulter la page
+  Lors de la lecture de ce chapitre, il peut être utile de consulter la page
   de référence de la commande <link linkend="sql-createfunction"><command>CREATE
   FUNCTION</command></link> pour mieux
   comprendre les exemples. Quelques exemples extraits de ce chapitre peuvent
@@ -118,7 +118,7 @@
    </listitem>
    <listitem>
     <para>
-     Certains attributs de fonction, tel que la volatilité, ne s'appliquent pas
+     Certains attributs de fonction, tels que la volatilité, ne s'appliquent pas
      aux procédures. Ces attributs contrôlent l'utilisation de la fonction dans
      une requête, et ne sont pas pertinents dans le cas de procédures.
     </para>
@@ -128,7 +128,7 @@
  
  <para>
   Les explications présentes dans les sections suivantes concernant comment
-  définir des fonctions utilisateurs s'appliquent également aux procédure, à
+  définir des fonctions utilisateurs s'appliquent également aux procédures, à
   la différence des points ci-dessus.
  </para>
 
@@ -256,7 +256,7 @@ CALL clean_emp();
   Si vous choisissez d'utiliser la syntaxe habituelle avec des guillemets
   simples, vous devez doubler les marques de guillemet simple
   (<literal>'</literal>) et les antislashs (<literal>\</literal>), en supposant
-  que vous utilisez la syntaxe d'échappement de chaînes, utilisés dans le corps
+  que vous utilisiez la syntaxe d'échappement de chaînes, utilisés dans le corps
   de la fonction (voir la <xref linkend="sql-syntax-strings"/>).
  </para>
 
@@ -570,7 +570,7 @@ $$ LANGUAGE SQL;
       erreur telle que&nbsp;:
       <screen><computeroutput>+ERROR:  return type mismatch in function declared to return emp
 DETAIL:  Final statement returns text instead of point at column 4.</computeroutput></screen>
-      sera renvoyée. Comme c'est le cas ppour les types de base, le système ne fera
+      sera renvoyée. Comme c'est le cas pour les types de base, le système ne fera
       pas de conversion explicite automatiquement, mais seulement des conversions
       implicites ou d'affectation.
      </para>
@@ -773,7 +773,7 @@ CREATE PROCEDURE tp1 (accountno integer, debit numeric, OUT new_balance numeric)
 $$ LANGUAGE SQL;
 </programlisting>
      Pour appeler cette procédure, an argument matching the <literal>OUT</literal>
-     parameter must be included. Il est habituel d'écriture <literal>NULL</literal>.
+     parameter must be included. Il est habituel d'écrire <literal>NULL</literal>.
 <programlisting>
 CALL tp1(17, 100.0, NULL);
 </programlisting>
@@ -908,15 +908,15 @@ SELECT mleast(arr =&gt; ARRAY[10, -1, 5, 4.4]);
      <para>
       Les fonctions peuvent être déclarées avec des valeurs par défaut pour
       certains des paramètres en entrée ou pour tous. Les valeurs par défaut
-      sont insérées quand la fonction est appelée avec moins d'arguments que
-      à priori nécessaires. Comme les arguments peuvent seulement être omis
+      sont insérées quand la fonction est appelée avec moins d'arguments qu'à
+      priori nécessaires. Comme les arguments peuvent seulement être omis
       à partir de la fin de la liste des arguments, tous les paramètres après
-      un paramètres disposant d'une valeur par défaut disposeront eux-aussi
+      un paramètre disposant d'une valeur par défaut disposeront eux-aussi
       d'une valeur par défaut. (Bien que l'utilisation de la notation avec des
       arguments nommés pourrait autoriser une relâche de cette restriction,
       elle est toujours forcée pour que la notation des arguments de position
       fonctionne correctement.) Que vous l'utilisez ou non, cette possibilité
-      implique la nécessite de prendre des précautions lors de l'appel de
+      implique la nécessité de prendre des précautions lors de l'appel de
       fonctions dans les bases de données où certains utilisateurs ne font pas
       confiance à d'autres utilisateurs&nbsp;;  voir <xref linkend="typeconv-func"/>.
      </para>
@@ -963,10 +963,10 @@ ERROR:  function foo() does not exist
      <para>
       Toutes les fonctions SQL peuvent être utilisées dans la clause
       <literal>FROM</literal> d'une requête mais ceci est particulièrement utile pour les
-      fonctions renvoyant des types composite. Si la fonction est définie pour
+      fonctions renvoyant des types composites. Si la fonction est définie pour
       renvoyer un type de base, la fonction table produit une table d'une seule
       colonne. Si la fonction est définie pour renvoyer un type composite, la
-      fonction  table produit une colonne pour chaque attribut du type composite.
+      fonction table produit une colonne pour chaque attribut du type composite.
      </para>
 
      <para>
@@ -1121,7 +1121,7 @@ SELECT nom, enfant FROM noeuds, LATERAL listeenfant(nom) AS enfant;
      <para>
       Les fonctions retournant des ensembles peuvent aussi être
       appelées dans la clause select d'une requête. Pour chaque ligne que cette
-      requête génère par elle-même, la fonction retournant un ensemble est
+      requête génère elle-même, la fonction retournant un ensemble est
       appelée, et une ligne résultat est générée pour chaque élément de l'ensemble
       retourné par la fonction.
       L'exemple précédent peut aussi être implémenté avec des requêtes telles
@@ -1218,7 +1218,7 @@ SELECT srf1(srf2(x), srf3(y)), srf4(srf5(z)) FROM tab;
       constructions d'évaluations conditionnelles, telles que
       <literal>CASE</literal> ou <literal>COALESCE</literal>. Ce comportement
       signifie aussi que des fonctions SETOF seront évaluées même quand il
-      pourrait apparaître qu'elles devraient être ignorées grâce à une
+      pourra apparaître qu'elles devraient être ignorées grâce à une
       construction d'évaluation conditionnelle, telle que
       <literal>CASE</literal> ou <literal>COALESCE</literal>. Par exemple,
       considérez&nbsp;:
@@ -1656,7 +1656,7 @@ LANGUAGE C;
         la base de données. Elle peut renvoyer différents
         résultats sur des appels successifs avec les mêmes arguments.
         L'optimiseur ne fait aucune supposition sur le comportement de telles
-        fonctions. Une requête utilisant une fonction volatile ré-évaluera la
+        fonctions. Une requête utilisant une fonction volatile réévaluera la
         fonction à chaque ligne où sa valeur est nécessaire.
        </para>
       </listitem>
@@ -1735,7 +1735,7 @@ LANGUAGE C;
      effectuées par la commande SQL qui a appelé la fonction. Une fonction
      <literal>VOLATILE</literal> verra les changements, une fonction
      <literal>STABLE</literal> ou <literal>IMMUTABLE</literal> ne les verra pas.
-     Ce comportement est implantée en utilisant le comportement par images de
+     Ce comportement est implanté en utilisant le comportement par images de
      MVCC (voir <xref linkend="mvcc"/>)&nbsp;: les fonctions
      <literal>STABLE</literal> et <literal>IMMUTABLE</literal> utilisent une
      image établie au lancement de la requête appelante alors que les fonctions
@@ -1957,7 +1957,7 @@ LANGUAGE internal    STRICT;
       </orderedlist>
 
       Si cette séquence ne fonctionne pas, l'extension pour les noms de fichier
-      des bibliothèques partagées spécifique à la plateforme (souvent
+      des bibliothèques partagées spécifiques à la plateforme (souvent
       <filename>.so</filename>) est ajoutée au nom attribué et la séquence est à
       nouveau tentée. En cas de nouvel échec, le chargement échoue.
      </para>
@@ -2144,7 +2144,7 @@ typedef struct
       Un autre point important est d'éviter de laisser des bits non initialisés
       dans les structures de types de données&nbsp;;; par exemple, prenez bien soin
       de remplir avec des zéros tous les octets de remplissage qui sont présents
-      dans les structures de données à des fins d'alignement. A défaut, des
+      dans les structures de données à des fins d'alignement. À défaut, des
       constantes logiquement équivalentes de vos types de données pourraient
       être considérées comme inégales par l'optimiseur, impliquant une
       planification inefficace (bien que les résultats puissent malgré tout
@@ -2206,7 +2206,7 @@ memcpy(destination->data, buffer, 40);
      <productname>PostgreSQL</productname>. La colonne <quote>Défini
      dans</quote> donne le fichier d'en-tête devant être inclus pour accéder à
      la définition du type (la définition effective peut se trouver dans un
-     fichier différent inclus dans le fichier indiqué. Il est recommandé que les
+     fichier différent inclus dans le fichier indiqué). Il est recommandé que les
      utilisateurs s'en tiennent à l'interface définie).  Notez que vous devriez
      toujours inclure <filename>postgres.h</filename> en premier dans tout
      fichier source du code serveur car il déclare un grand nombre d'éléments
@@ -2610,7 +2610,7 @@ CREATE FUNCTION concat_text(text, text) RETURNS text
       garantit le renvoi d'une copie de l'argument spécifié où nous pouvons
       écrire en toute sécurité (les macros normales peuvent parfois renvoyer
       un pointeur vers une valeur physiquement mise en mémoire dans une table qui
-      ne doit pas être modifiée. En utilisant les macros
+      ne doit pas être modifiée). En utilisant les macros
       <function>PG_GETARG_<replaceable>xxx</replaceable>_COPY()</function>, on
       garantit l'écriture du résultat). La seconde variante se compose des macros
       <function>PG_GETARG_<replaceable>xxx</replaceable>_SLICE()</function>
@@ -2649,7 +2649,7 @@ CREATE FUNCTION concat_text(text, text) RETURNS text
       Avant de nous intéresser à des sujets plus avancés, nous devons discuter de
       quelques règles de codage des fonctions en langage C de
       <productname>PostgreSQL</productname>.  Bien qu'il soit possible de charger
-      des fonctions écrites dans des langages autre que le C dans
+      des fonctions écrites dans des langages autres que le C dans
       <productname>PostgreSQL</productname>, c'est habituellement difficile
       (quand c'est possible) parce que les autres langages comme C++, FORTRAN ou
       Pascal ne suivent pas fréquemment les mêmes conventions de nommage que le
@@ -2706,7 +2706,7 @@ CREATE FUNCTION concat_text(text, text) RETURNS text
         <para>
          Remettez toujours à zéro les octets de vos structures en utilisant
          <function>memset</function>
-         (ou allouez les avec la fonction <function>palloc0</function>).
+         (ou allouez-les avec la fonction <function>palloc0</function>).
          Même si vous assignez chacun des champs de votre structure, il
          pourrait rester des espaces de remplissage (trous dans la structure)
          afin de respecter l'alignement des données qui contiennent des
@@ -2817,7 +2817,7 @@ c_surpaye(PG_FUNCTION_ARGS)
 
     <para>
      Il y a aussi <function>GetAttributeByNum</function>, qui sélectionne
-     l'attribut cible par le numéro de colonne au lieu de son nom.
+     l'attribut ciblé par le numéro de colonne au lieu de son nom.
     </para>
 
     <para>
@@ -2851,7 +2851,7 @@ c_surpaye(PG_FUNCTION_ARGS)
    (autrement dit un <quote>tuple</quote>)&nbsp;: vous pouvez le construire à
    partir d'un tableau de valeurs Datum ou à partir d'un tableau de
    chaînes C qui peuvent passer dans les fonctions de conversion des types
-   de données du tuple. Quelque soit le cas, vous avez d'abord besoin
+   de données du tuple. Quel que soit le cas, vous avez d'abord besoin
    d'obtenir et de construire un descripteur <structname>TupleDesc</structname> pour
    la structure du tuple. En travaillant avec des Datums, vous passez le
      <structname>TupleDesc</structname> à <function>BlessTupleDesc</function>, puis vous appelez
@@ -2992,13 +2992,13 @@ c_surpaye(PG_FUNCTION_ARGS)
       (plusieurs lignes). Dans la première méthode, appelée mode
       <firstterm>ValuePerCall</firstterm>,  une fonction renvoyant un ensemble
       de lignes est appelée de façon répétée (en passant les mêmes arguments à
-      chaque fois) et elle renvoit une nouvelle ligne pour chaque appel,
+      chaque fois) et elle renvoie une nouvelle ligne pour chaque appel,
       jusqu'à ce qu'il n'y ait plus de lignes à renvoyer et qu'elle le signale
       en renvoyant NULL. La fonction <acronym>SRF</acronym> doit de ce fait
       sauvegarder l'état entre appels pour se rappeler ce qu'elle faisait et
       renvoyer le bon prochain élément à chaque appel. Dans l'autre méthode,
       appelée mode <firstterm>Materialize</firstterm>, une SRF remplit et
-      renvoit un objet <foreignphrase>tuplestore</foreignphrase> contenant le
+      renvoie un objet <foreignphrase>tuplestore</foreignphrase> contenant le
       résultat entier. Un seul appel survient pour le résultat complet, et il
       n'est pas nécessaire de conserver l'état entre appels.
      </para>
@@ -3741,7 +3741,7 @@ extern bool InjectionPointDetach(const char *name);
 
 
     <sect2 id="extend-Cpp">
-     <title>Coder des extensions en  C++</title>
+     <title>Coder des extensions en C++</title>
 
      <indexterm zone="extend-Cpp">
       <primary>C++</primary>
@@ -3791,7 +3791,7 @@ extern bool InjectionPointDetach(const char *name);
        </listitem>
        <listitem>
         <para>
-         Si vous appelez des fonctions du serveur depuis du code C++, assurez vous que
+         Si vous appelez des fonctions du serveur depuis du code C++, assurez-vous que
          la pile d'appels ne contienne que des structures C (<acronym>POD</acronym>).
          Ceci est nécessaire dans la mesure où les erreurs au niveau du serveur génèrent un
          saut via l'instruction <function>longjmp()</function> qui ne peut dépiler proprement
@@ -3802,8 +3802,8 @@ extern bool InjectionPointDetach(const char *name);
      </para>
 
      <para>
-      Pour résumer, le code C++ doit donc être placé derrière un rempart  de fonctions
-      <literal>extern C</literal> qui fourniront l'interface avec le serveur, et devra éviter
+      Pour résumer, le code C++ doit donc être placé derrière un rempart de fonctions
+      <literal>extern C</literal> qui fourniront l'interface avec le serveur, et devront éviter
       toute fuite de mécanismes propres au C++ (exceptions, allocation/libération de mémoire
       et objets non-POD dans la pile).
      </para>
@@ -3897,7 +3897,7 @@ supportfn(internal) returns internal
      également &mdash; dans l'exemple juste ci-dessus, <literal>n * 1</literal>
      serait aussi simplifié en <literal>n</literal>.
      (Mais notez que c'est juste un exemple&nbsp;; cette optimisation particulière
-     n'est pas réellement mise en oeuvre par <productname>PostgreSQL</productname>.)
+     n'est pas réellement mise en œuvre par <productname>PostgreSQL</productname>.)
      Nous ne garantissons pas que <productname>PostgreSQL</productname> n'appelera
      jamais la fonction cible dans les cas que la fonction de support pourrait
      simplifier. Assurez-vous d'une équivalence rigoureuse entre l'expression
@@ -3932,7 +3932,7 @@ supportfn(internal) returns internal
      Pour les fonctions cibles qui renvoient un booléen, il est envisageable
      de convertir un appel de fonction au niveau d'un <literal>WHERE</literal> vers une ou
      plusieurs clauses d'un opérateur indexable. Ces clauses peuvent être
-     exactement équivalentes à la condition de la fonction, ou bien elle peuvent
+     exactement équivalentes à la condition de la fonction, ou bien elles peuvent
      être plus faibles (c'est-à-dire qu'elles peuvent accepter certaines
      valeurs que la condition via la fonction n'accepte pas).
      Dans ce dernier cas, la condition d'index est dite

--- a/postgresql/xindex.xml
+++ b/postgresql/xindex.xml
@@ -6,7 +6,7 @@
   Les procédures décrites jusqu'à maintenant permettent de définir de nouveaux
   types, de nouvelles fonctions et de nouveaux opérateurs. Néanmoins, nous ne
   pouvons pas encore définir un index sur une colonne d'un nouveau type de
-  données. Pour cela, nous devons définir une <firstterm>classe d'opérateur</firstterm>
+  données. Pour cela, nous devons définir une <firstterm>classe d'opérateurs</firstterm>
   pour le nouveau type de données. Plus loin dans cette section, nous
   illustrerons ce concept avec un exemple&nbsp;: une nouvelle classe
   d'opérateur pour la méthode d'indexation B-tree qui enregistre et trie des
@@ -14,10 +14,10 @@
  </para>
 
  <para>
-  Les classes d'opérateur peuvent être groupées en <firstterm>familles
+  Les classes d'opérateurs peuvent être groupées en <firstterm>familles
    d'opérateur</firstterm> pour afficher les relations entre classes
   compatibles sémantiquement.  Quand un seul type de données est impliqué,
-  une classe d'opérateur est suffisant, donc nous allons nous fixer sur ce
+  une classe d'opérateurs est suffisante, donc nous allons nous fixer sur ce
   cas en premier puis retourner aux familles d'opérateur.
  </para>
 
@@ -25,7 +25,7 @@
   <title>Méthodes d'indexation et classes d'opérateurs</title>
 
   <para>
-   Les classes d'opérateur sont associées à une méthode d'accès d'index,
+   Les classes d'opérateurs sont associées à une méthode d'accès d'index,
    telle que <link linkend="btree">B-Tree</link> ou
    <link linkend="gin">GIN</link>. Les méthodes d'accès personnalisées
    aux index peuvent être définies avec
@@ -36,12 +36,12 @@
   <para>
    Les routines pour une méthode d'indexation n'ont pas à connaître directement
    les types de données sur lesquels opère la méthode d'indexation. Au lieu de
-   cela, une <firstterm>classe d'opérateur</firstterm> identifie l'ensemble d'opérations
+   cela, une <firstterm>classe d'opérateurs</firstterm> identifie l'ensemble d'opérations
    que la méthode d'indexation doit utiliser pour fonctionner avec un type
    particulier de données. Les classes d'opérateurs sont ainsi dénommées parce
    qu'une de leur tâche est de spécifier l'ensemble des opérateurs de la clause
    <literal>WHERE</literal> utilisables avec un index (c'est-à-dire, qui peuvent être
-   requalifiés en balayage d'index). Une classe d'opérateur peut également
+   requalifiés en balayage d'index). Une classe d'opérateurs peut également
    spécifier des <firstterm>fonctions de support</firstterm>, nécessaires pour les
    opérations internes de la méthode d'indexation mais sans correspondance
    directe avec un quelconque opérateur de clause <literal>WHERE</literal> pouvant être
@@ -56,27 +56,27 @@
    pour chaque type de données auquel il peut s'appliquer. Il peut être utile
    pour un type de donnée de nombre complexe de disposer d'une classe
    d'opérateur B-tree qui trie les données selon la valeur absolue complexe, une
-   autre selon la partie réelle, etc. Typiquement, une des classes d'opérateur
+   autre selon la partie réelle, etc. Typiquement, une des classes d'opérateurs
    sera considérée comme plus utile et sera marquée comme l'opérateur par défaut
    pour ce type de données et cette méthode d'indexation.
   </para>
 
   <para>
-   Le même nom de classe d'opérateur peut être utilisé pour plusieurs méthodes
+   Le même nom de classe d'opérateurs peut être utilisé pour plusieurs méthodes
    d'indexation différentes (par exemple, les méthodes d'index B-tree et hash ont
-   toutes les deux des classes d'opérateur nommées <literal>int4_ops</literal>)
+   toutes les deux des classes d'opérateurs nommées <literal>int4_ops</literal>)
    mais chacune de ces classes est une entité indépendante et doit être définie
    séparément.
   </para>
  </sect2>
 
  <sect2 id="xindex-strategies">
-  <title>Stratégies des méthode d'indexation</title>
+  <title>Stratégies des méthodes d'indexation</title>
 
   <para>
-   Les opérateurs associés à une classe d'opérateur sont identifiés par des
+   Les opérateurs associés à une classe d'opérateurs sont identifiés par des
    <quote>numéros de stratégie</quote>, servant à identifier la sémantique de
-   chaque opérateur dans le contexte de sa classe d'opérateur. Par exemple, les
+   chaque opérateur dans le contexte de sa classe d'opérateurs. Par exemple, les
    B-trees imposent un classement strict selon les clés, du plus petit au plus
    grand. Ainsi, des opérateurs comme <quote>plus petit que</quote> et <quote>plus
     grand que</quote> sont intéressants pour un B-tree. Comme
@@ -85,7 +85,7 @@
    nom d'un opérateur (par exemple, <literal>&lt;</literal> ou <literal>&gt;=</literal>) et
    rapporter de quelle comparaison il s'agit. Au lieu de cela, la méthode
    d'indexation définit un ensemble de <quote>stratégies</quote>, qui peuvent être
-   comprises comme des opérateurs généralisés. Chaque classe d'opérateur
+   comprises comme des opérateurs généralisés. Chaque classe d'opérateurs
    spécifie l'opérateur effectif correspondant à chaque stratégie pour un type
    de donnée particulier et pour une interprétation de la sémantique d'index.
   </para>
@@ -156,9 +156,9 @@
   <para>
    Les index GiST sont plus flexibles&nbsp;: ils n'ont pas du tout un
    ensemble fixe de stratégies. À la place, la routine de support de
-   <quote>cohérence</quote> de chaque classe d'opérateur GiST interprète les
+   <quote>cohérence</quote> de chaque classe d'opérateurs GiST interprète les
    numéros de stratégie comme elle l'entend. Comme exemple, plusieurs des classes
-   d'opérateurs  GiST indexe les objets géométriques à deux dimensions
+   d'opérateurs GiST indexent les objets géométriques à deux dimensions
    fournissant les stratégies <quote>R-tree</quote> affichées dans
    <xref linkend="xindex-rtree-strat-table"/>. Quatre d'entre elles sont des vrais
    tests à deux dimensions (surcharge, identique, contient, contenu par)&nbsp;;
@@ -231,9 +231,9 @@
   <para>
    Les index SP-GiST sont similaires aux index GiST en flexibilité&nbsp;: ils n'ont
    pas un ensemble fixe de stratégie. À la place, les routines de support de
-   chaque classe d'opérateur interprètent les numéros de stratégie suivant la
-   définition du classe d'opérateur. Comme exemple, les numéros des stratégies
-   utilisés par les classes d'opérateur sur des points sont affichés dans
+   chaque classe d'opérateurs interprètent les numéros de stratégie suivant la
+   définition de la classe d'opérateurs. Comme exemple, les numéros des stratégies
+   utilisés par les classes d'opérateurs sur des points sont affichés dans
    <xref linkend="xindex-spgist-point-strat-table"/>.
   </para>
 
@@ -279,8 +279,8 @@
    Les index GIN sont similaires aux index GiST et SP-GiST, dans le fait qu'ils
    n'ont pas d'ensemble fixé de stratégies. À la place, les routines support de
    chaque opérateur de classe interprètent les numéros de stratégie suivant la
-   définition de la classe d'opérateur. Comme exemple, les numéros de stratégie
-   utilisés par la classe d'opérateur interne pour les tableaux sont affichés
+   définition de la classe d'opérateurs. Comme exemple, les numéros de stratégie
+   utilisés par la classe d'opérateurs internes pour les tableaux sont affichés
    dans <xref linkend="xindex-gin-array-strat-table"/>.
   </para>
 
@@ -317,9 +317,9 @@
   <para>
    Les index BRIN sont similaires aux index GiST, SP-GiST et GIN dans le fait
    qu'ils n'ont pas un ensemble fixe de stratégies. À la place, les routines de
-   support de chaque classe d'opérateur interprètent les numéros de stratégie
-   suivant la définition de la classe d'opérateur. Par exemple, les numéros de
-   stratégie utilisés par les classes d'opérateur <literal>Minmax</literal>
+   support de chaque classe d'opérateurs interprètent les numéros de stratégie
+   suivant la définition de la classe d'opérateurs. Par exemple, les numéros de
+   stratégie utilisés par les classes d'opérateurs <literal>Minmax</literal>
    sont indiqués dans <xref linkend="xindex-brin-minmax-strat-table"/>.
   </para>
 
@@ -374,7 +374,7 @@
   <title>Routines d'appui des méthodes d'indexation</title>
 
   <para>
-   Généralement, les stratégies n'apportent pas  assez d'informations au système
+   Généralement, les stratégies n'apportent pas assez d'informations au système
    pour indiquer comment utiliser un index. Dans la pratique, les méthodes
    d'indexation demandent des routines d'appui additionnelles pour fonctionner. Par
    exemple, les méthodes d'index B-tree doivent être capables de comparer deux
@@ -387,26 +387,26 @@
   </para>
 
   <para>
-   Comme pour les stratégies, la classe d'opérateur énumère les fonctions
+   Comme pour les stratégies, la classe d'opérateurs énumère les fonctions
    spécifiques et le rôle qu'elles doivent jouer pour un
    type de donnée donné et une interprétation sémantique donnée. La méthode d'indexation
-   définit l'ensemble des fonctions dont elle a besoin et la classe d'opérateur
+   définit l'ensemble des fonctions dont elle a besoin et la classe d'opérateurs
    identifie les fonctions exactes à utiliser en les assignant aux
    <quote>numéros de fonction d'appui</quote> spécifiés par la méthode d'indexage.
   </para>
 
   <para>
-   De plus, certaines classes d'opérateur autorisent les utilisateurs à
+   De plus, certaines classes d'opérateurs autorisent les utilisateurs à
    indiquer des paramètres pour contrôler leur comportement. Chaque méthode
    native d'accès aux index a une fonction de support optionnelle appelée
    <function>options</function>, qui définit un ensemble de paramètres
-   spécifiques à la classe d'opérateur.
+   spécifiques à la classe d'opérateurs.
   </para>
 
   <para>
    Les B-trees requièrent une fonction support de comparaison et permettent
    quatre fonctions support supplémentaires à fournir comme option de la
-   classe d'opérateur, comme indiqué dans <xref
+   classe d'opérateurs, comme indiqué dans <xref
    linkend="xindex-btree-support-table"/>. Les prérequis pour ces fonctions
    support sont expliqués en détails dans <xref
    linkend="btree-support-funcs"/>.
@@ -449,14 +449,14 @@
      </row>
      <row>
       <entry>
-       Détermine s'il est sûr que les index utilisant la classe d'opérateur
+       Détermine s'il est sûr que les index utilisant la classe d'opérateurs
        s'appliquent à l'optimisation de déduplication des Btree (optionnel)
       </entry>
       <entry>4</entry>
      </row>
      <row>
       <entry>
-       Définit des options spécifiques à cette classe d'opérateur
+       Définit des options spécifiques à cette classe d'opérateurs
        (optionnel)
       </entry>
       <entry>5</entry>
@@ -467,7 +467,7 @@
 
   <para>
    Les index hash requièrent une fonction d'appui, et permettent deux
-   fonctions supplémentaires à fournir à la classe d'opérateur, comme indiqué
+   fonctions supplémentaires à fournir à la classe d'opérateurs, comme indiqué
    dans <xref linkend="xindex-hash-support-table"/>.
   </para>
 
@@ -498,7 +498,7 @@
      </row>
      <row>
       <entry>
-       Définit des options spécifiques à cette classe d'opérateur
+       Définit des options spécifiques à cette classe d'opérateurs
        (optionnel)
       </entry>
       <entry>3</entry>
@@ -586,7 +586,7 @@
      <row>
       <entry><function>options</function></entry>
       <entry>
-       Définit des options spécifiques à cette classe d'opérateur
+       Définit des options spécifiques à cette classe d'opérateurs
        (optionnel)
       </entry>
       <entry>10</entry>
@@ -624,7 +624,7 @@
     <tbody>
      <row>
       <entry><function>config</function></entry>
-      <entry>fournit des informations basiques sur la classe d'opérateur</entry>
+      <entry>fournit des informations basiques sur la classe d'opérateurs</entry>
       <entry>1</entry>
      </row>
      <row>
@@ -728,7 +728,7 @@
      <row>
       <entry><function>options</function></entry>
       <entry>
-       Définit des options spécifiques à cette classe d'opérateur
+       Définit des options spécifiques à cette classe d'opérateurs
        (optionnel)
       </entry>
       <entry>7</entry>
@@ -787,7 +787,7 @@
      <row>
       <entry><function>options</function></entry>
       <entry>
-       Définit des options spécifiques à cette classe d'opérateur
+       Définit des options spécifiques à cette classe d'opérateurs
        (optionnel)
       </entry>
       <entry>5</entry>
@@ -798,13 +798,13 @@
 
   <para>
    Contrairement aux opérateurs de recherche, les fonctions d'appui renvoient le
-   type de donnée, quelqu'il soit, que la méthode d'indexation particulière
+   type de donnée, quel qu'il soit, que la méthode d'indexation particulière
    attend, par exemple, dans le cas de la fonction de comparaison des B-trees,
    un entier signé. Le nombre et le type des arguments pour chaque fonction de
    support peuvent dépendre de la méthode d'indexage. Pour les index B-tree et
    de hachage, les fonctions de support pour la comparaison et le hachage
    prennent les mêmes types de données en entrée que les opérateurs inclus
-   dans la classe d'opérateur, mais ce n'est pas le cas pour la plupart des
+   dans la classe d'opérateurs, mais ce n'est pas le cas pour la plupart des
    fonctions de support GiST, SP-GiST, GIN et BRIN.
   </para>
  </sect2>
@@ -814,17 +814,17 @@
 
   <para>
    Maintenant que nous avons vu les idées, voici l'exemple promis de création
-   d'une nouvelle classe d'opérateur. Cette classe d'opérateur encapsule les
+   d'une nouvelle classe d'opérateurs. Cette classe d'opérateurs encapsule les
    opérateurs qui trient les nombres complexes selon l'ordre de la valeur
    absolue, aussi avons-nous choisi le nom de
    <literal>complex_abs_ops</literal>. En premier lieu, nous avons besoin d'un
    ensemble d'opérateurs. La procédure pour définir des opérateurs a été
-   discutée dans la <xref linkend="xoper"/>.  Pour une classe d'opérateur sur les
+   discutée dans la <xref linkend="xoper"/>.  Pour une classe d'opérateurs sur les
    B-trees, nous avons besoin des opérateurs&nbsp;:
 
    <itemizedlist spacing="compact">
     <listitem><simpara>valeur absolue inférieure à (stratégie 1)&nbsp;;</simpara></listitem>
-    <listitem><simpara>valeur absolue inférieure-ou-égale à (stratégie
+    <listitem><simpara>valeur absolue inférieure ou égale à (stratégie
       2)&nbsp;;</simpara></listitem>
     <listitem><simpara>valeur absolue égale à (stratégie 3)&nbsp;;</simpara></listitem>
     <listitem><simpara>valeur absolue supérieure-ou-égale à (stratégie
@@ -834,7 +834,7 @@
   </para>
 
   <para>
-   Le plus simple moyen de définie un ensemble d'opérateurs de comparaison est
+   Le plus simple moyen de définir un ensemble d'opérateurs de comparaison est
    d'écrire en premier la fonction de comparaison B-tree, puis d'écrire les
    autres fonctions en tant que wrapper de la fonction de support. Ceci réduit
    les risques de résultats incohérents pour les cas spécifiques. En suivant
@@ -872,7 +872,7 @@ complex_abs_lt(PG_FUNCTION_ARGS)
 }
 ]]></programlisting>
 
-   Les quatre autres fonctions diffèrent seulement sur la façon dont ils
+   Les quatre autres fonctions diffèrent seulement sur la façon dont elles
    comparent le résultat de la fonction interne au zéro.
   </para>
 
@@ -938,7 +938,7 @@ CREATE OPERATOR &lt; (
 
   <para>
    La prochaine étape est l'enregistrement de la routine d'appui nécessaire pour
-   les  B-trees. Le code exemple C qui implémente ceci est dans le même fichier
+   les B-trees. Le code exemple C qui implémente ceci est dans le même fichier
    qui contient les fonctions d'opérateur. Voici comment déclarer la
    fonction&nbsp;:
 
@@ -951,7 +951,7 @@ CREATE OPERATOR &lt; (
 
   <para>
    Maintenant que nous avons les opérateurs requis et la routine d'appui, nous
-   pouvons enfin créer la classe d'opérateur.
+   pouvons enfin créer la classe d'opérateurs.
 
    <programlisting><![CDATA[
 CREATE OPERATOR CLASS complex_abs_ops
@@ -977,12 +977,12 @@ CREATE OPERATOR CLASS complex_abs_ops
    <programlisting>        OPERATOR        1       &lt; (complex, complex) ,
    </programlisting>
    mais il n'y a pas besoin de faire ainsi quand les opérateurs prennent le même
-   type de donnée que celui pour lequel la classe d'opérateur a été définie.
+   type de donnée que celui pour lequel la classe d'opérateurs a été définie.
   </para>
 
   <para>
    Les exemples ci-dessus supposent que vous voulez que cette nouvelle classe
-   d'opérateur soit la classe d'opérateur B-tree par défaut pour le type de
+   d'opérateur soit la classe d'opérateurs B-tree par défaut pour le type de
    donnée <type>complex</type>. Si vous ne voulez pas, supprimez simplement le
    mot <literal>DEFAULT</literal>.
   </para>
@@ -992,16 +992,16 @@ CREATE OPERATOR CLASS complex_abs_ops
   <title>Classes et familles d'opérateur</title>
 
   <para>
-   Jusqu'à maintenant, nous avons supposé implicitement qu'une classe d'opérateur
-   s'occupe d'un seul type de données. Bien qu'il ne peut y avoir qu'un seul
+   Jusqu'à maintenant, nous avons supposé implicitement qu'une classe d'opérateurs
+   s'occupe d'un seul type de données. Bien qu'il ne puisse y avoir qu'un seul
    type de données dans une colonne d'index particulière, il est souvent utile
    d'indexer les opérations qui comparent une colonne indexée à une valeur d'un
    type de données différent. De plus, s'il est intéressant d'utiliser un
-   opérateur inter-type en connexion avec une classe d'opérateur, souvent cet
-   autre type de donnée a sa propre classe d'opérateur. Rendre explicite les
+   opérateur inter-type en connexion avec une classe d'opérateurs, fréquemment cet
+   autre type de donnée à sa propre classe d'opérateurs. Rendre explicite les
    connexions entre classes en relation est d'une grande aide pour que le
    planificateur optimise les requêtes SQL (tout particulièrement pour les
-   classes d'opérateur B-tree car le planificateur sait bien comme les
+   classes d'opérateurs B-tree car le planificateur sait bien comme les
    utiliser).
   </para>
 
@@ -1009,12 +1009,12 @@ CREATE OPERATOR CLASS complex_abs_ops
    Pour gérer ces besoins, <productname>PostgreSQL</productname> utilise le
    concept d'une <firstterm>famille d'opérateur</firstterm>
    <indexterm><primary>famille d'opérateur</primary></indexterm>.
-   Une famille d'opérateur contient une ou plusieurs classes d'opérateur et
+   Une famille d'opérateur contient une ou plusieurs classes d'opérateurs et
    peut aussi contenir des opérateurs indexables et les fonctions de support
    correspondantes appartenant à la famille entière mais pas à une classe
    particulière de la famille. Nous disons que ces opérateurs et fonctions
    sont <quote>lâches</quote> à l'intérieur de la famille, en opposition à
-   être lié à une classe spécifique. Typiquement, chaque classe d'opérateur
+   être lié à une classe spécifique. Typiquement, chaque classe d'opérateurs
    contient des opérateurs de types de données simples alors que les
    opérateurs inter-type sont lâches dans la famille.
   </para>
@@ -1024,11 +1024,11 @@ CREATE OPERATOR CLASS complex_abs_ops
    une sémantique compatible où les pré-requis de la compatibilité sont
    dictés par la méthode indexage. Du coup, vous pouvez vous demander la raison
    pour s'embarrasser de distinguer les sous-ensembles de la famille en tant
-   que classes d'opérateur. En fait, dans beaucoup de cas, les divisions en
+   que classes d'opérateurs. En fait, dans beaucoup de cas, les divisions en
    classe sont inutiles et la famille est le seul groupe intéressant. La
    raison de la définition de classes d'opérateurs est qu'ils spécifient à
    quel point la famille est nécessaire pour supporter un index particulier.
-   S'il existe un index utilisant une classe d'opérateur, alors cette classe
+   S'il existe un index utilisant une classe d'opérateurs, alors cette classe
    d'opérateur ne peut pas être supprimée sans supprimer l'index &mdash; mais
    les autres parties de la famille d'opérateurs, donc les autres classes et
    les opérateurs lâches, peuvent être supprimées. Du coup, une classe
@@ -1049,7 +1049,7 @@ CREATE OPERATOR CLASS complex_abs_ops
    contient aussi des opérateurs de comparaison inter-type permettant la
    comparaison de deux de ces types, pour qu'un index parmi ces types puisse
    être parcouru en utilisant une valeur de comparaison d'un autre type. La
-   famille peut être dupliqué par ces définitions&nbsp;:
+   famille peut être dupliquée par ces définitions&nbsp;:
 
    <programlisting><![CDATA[
 CREATE OPERATOR FAMILY integer_ops USING btree;
@@ -1154,9 +1154,9 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
    plusieurs fois dans la famille. Ceci est autorisé aussi longtemps que chaque
    instance d'un numéro particulier a des types de données distincts en entrée.
    Les instances qui ont les deux types en entrée égalent au type en entrée de
-   la classe d'opérateur sont les opérateurs primaires et les fonctions de
-   support pour cette classe d'opérateur et, dans la plupart des cas, doivent
-   être déclarées comme membre de la classe d'opérateur plutôt qu'en tant que
+   la classe d'opérateurs sont les opérateurs primaires et les fonctions de
+   support pour cette classe d'opérateurs et, dans la plupart des cas, doivent
+   être déclarées comme membre de la classe d'opérateurs plutôt qu'en tant que
    membres lâches de la famille.
   </para>
 
@@ -1167,7 +1167,7 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
    doit y avoir une fonction de support pour les deux mêmes types de données
    en entrée que celui de l'opérateur. Il est recommandé qu'une famille soit
    complète, c'est-à-dire que pour chaque combinaison de types de données,
-   tous les opérateurs sont inclus. Chaque classe d'opérateur doit juste
+   tous les opérateurs sont inclus. Chaque classe d'opérateurs doit juste
    inclure les opérateurs non inter-types et les fonctions de support pour ce
    type de données.
   </para>
@@ -1188,8 +1188,8 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
    Notez qu'il y a seulement une fonction de support par type de
    données, pas une par opérateur d'égalité. Il est recommandé qu'une famille
    soit terminée, c'est-à-dire fournit un opérateur d'égalité pour chaque
-   combinaison de types de données. Chaque classe d'opérateur doit inclure
-   l'opérateur d'égalité non inter-type et la fonction de support pour ce type
+   combinaison de types de données. Chaque classe d'opérateurs doit inclure
+   l'opérateur d'égalité non-inter-type et la fonction de support pour ce type
    de données.
   </para>
 
@@ -1201,7 +1201,7 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
 
   <para>
    Dans BRIN, les pré-requis dépendent de l'ensemble de travail fourni par les
-   classes d'opérateur. Pour les classes basées sur <literal>minmax</literal>,
+   classes d'opérateurs. Pour les classes basées sur <literal>minmax</literal>,
    le comportement requis est le même que pour les familles d'opérateur
    B-tree&nbsp;: tous les opérateurs d'une famille doivent avoir un tri
    compatible, et les conversions ne doivent pas changer l'ordre de tri
@@ -1213,7 +1213,7 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
     Avant <productname>PostgreSQL</productname> 8.3, le concept des familles
     d'opérateurs n'existait pas. Donc, tous les opérateurs inter-type dont le
     but était d'être utilisés avec un index étaient liés directement à la
-    classe d'opérateur de l'index. Bien que cette approche fonctionne toujours,
+    classe d'opérateurs de l'index. Bien que cette approche fonctionne toujours,
     elle est obsolète car elle rend trop importantes les dépendances de l'index
     et parce que le planificateur peut gérer des comparaisons inter-type avec
     plus d'efficacité que quand les typdes de données ont des opérateurs dans la
@@ -1224,14 +1224,14 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
   </sect2>
 
  <sect2 id="xindex-opclass-dependencies">
-  <title>Dépendances du système pour les classes d'opérateur</title>
+  <title>Dépendances du système pour les classes d'opérateurs</title>
 
    <indexterm>
     <primary>Opérateur d'ordonnancement</primary>
    </indexterm>
 
   <para>
-   <productname>PostgreSQL</productname> utilise les classe d'opérateur pour
+   <productname>PostgreSQL</productname> utilise les classes d'opérateurs pour
    inférer les propriétés des opérateurs de plusieurs autres façons que le seul
    usage avec les index. Donc, vous pouvez créer des classes
    d'opérateur même si vous n'avez pas l'intention d'indexer une quelconque
@@ -1243,22 +1243,22 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
    <literal>ORDER BY</literal> et <literal>DISTINCT</literal> qui requièrent la comparaison et
    le tri des valeurs. Pour implémenter ces caractéristiques sur un type de
    donnée défini par l'utilisateur, <productname>PostgreSQL</productname>
-   recherche la classe d'opérateur B-tree par défaut pour le type de donnée. Le
-   membre <quote>equals</quote> de cette classe d'opérateur définit pour le système
+   recherche la classe d'opérateurs B-tree par défaut pour le type de donnée. Le
+   membre <quote>equals</quote> de cette classe d'opérateurs définit pour le système
    la notion d'égalité des valeurs pour <literal>GROUP BY</literal> et
-   <literal>DISTINCT</literal>, et le tri ordonné imposé par la classe d'opérateur
+   <literal>DISTINCT</literal>, et le tri ordonné imposé par la classe d'opérateurs
    définit le <literal>ORDER BY</literal> par défaut.
   </para>
 
   <para>
-   S'il n'y a pas de classe d'opérateur B-tree par défaut pour le type de
-   donnée, le système cherchera une classe d'opérateur de découpage. Mais
-   puisque cette classe d'opérateur ne fournit que l'égalité, il est seulement
+   S'il n'y a pas de classe d'opérateurs B-tree par défaut pour le type de
+   donnée, le système cherchera une classe d'opérateurs de découpage. Mais
+   puisque cette classe d'opérateurs ne fournit que l'égalité, il est seulement
    capable de supporter le regroupement mais pas le tri.
   </para>
 
   <para>
-   Quand il n'y a pas de classe d'opérateur par défaut pour un type de donnée,
+   Quand il n'y a pas de classe d'opérateurs par défaut pour un type de donnée,
    vous obtenez des erreurs telles que <quote>could not identify an ordering
    operator</quote> si vous essayez d'utiliser ces caractéristiques SQL avec le type
    de donnée.
@@ -1276,7 +1276,7 @@ ALTER OPERATOR FAMILY integer_ops USING btree ADD
    </note>
 
   <para>
-   Trier par une classe d'opérateur B-tree qui n'est pas celle par défaut est
+   Trier par une classe d'opérateurs B-tree qui n'est pas celle par défaut est
    possible en précisant l'opérateur inférieur-à de la classe dans une option
    <literal>USING</literal>, par exemple
 <programlisting>
@@ -1288,9 +1288,9 @@ SELECT * FROM mytable ORDER BY somecol USING ~&lt;~;
 
   <para>
    La comparaison de tableaux d'un type de données utilisateur repose également
-   sur la sémantique définie par la classe d'opérateur B-tree par défaut du
-   type.  S'il n'y a pas de classe d'opérateur B-tree par défaut, mais qu'il y
-   a une classe d'opérateur de type hash, alors l'égalité de tableau est
+   sur la sémantique définie par la classe d'opérateurs B-tree par défaut du
+   type.  S'il n'y a pas de classe d'opérateurs B-tree par défaut, mais qu'il y
+   a une classe d'opérateurs de type hash, alors l'égalité de tableau est
    supportée, mais pas la comparaison pour les tris.
   </para>
 
@@ -1311,19 +1311,19 @@ SELECT sum(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 10 FOLLOWING)
    <literal>x</literal> de la ligne courante pour identifier les limites de la
    fenêtre courante.  Comparer les limites résultantes aux valeurs de
    <literal>x</literal> des autres lignes est possible en utilisant les
-   opérateurs de comparaison fournis par la classe d'opérateur B-tree qui
+   opérateurs de comparaison fournis par la classe d'opérateurs B-tree qui
    définit le tri de l'<literal>ORDER BY</literal> &mdash; mais les opérateurs
-   d'addition et de soustraction ne font pas partie de la classe d'opérateur,
+   d'addition et de soustraction ne font pas partie de la classe d'opérateurs,
    alors lesquels devraient être utilisés&nbsp;?  Inscrire en dur ce choix ne serait
-   pas désirable, car différents ordres de tris (différentes classes d'opérateur
+   pas désirable, car différents ordres de tris (différentes classes d'opérateurs
    B-tree) pourraient nécessiter des comportements différents.  Ainsi, une
-   classe d'opérateur B-tree peut préciser une fonction de support
+   classe d'opérateurs B-tree peut préciser une fonction de support
    <firstterm>in_range</firstterm> qui encapsule les comportements d'addition
    et de soustraction faisant sens pour son ordre de tri.  Elle peut même
    fournir plus d'une fonction de support in_range, s'il fait sens d'utiliser
    plus d'un type de données comme offset dans la clause
    <literal>RANGE</literal>.
-   Si la classe d'opérateur B-tree associée à la clause <literal>ORDER
+   Si la classe d'opérateurs B-tree associée à la clause <literal>ORDER
     BY</literal> de la fenêtre n'a pas de fonction de support in_range
    correspondante, l'option
    <literal>RANGE</literal> <replaceable>offset</replaceable>
@@ -1382,7 +1382,7 @@ SELECT * FROM places ORDER BY location <-> point '(101,456)' LIMIT 10;
    notion de tri de <productname>PostgreSQL</productname>, donc c'est une
    représentation naturelle. Comme l'opérateur <literal>&lt;-&gt;</literal>
    renvoie <type>float8</type>, il peut être indiqué dans la commande de
-   création d'une classe d'opérateur&nbsp;:
+   création d'une classe d'opérateurs&nbsp;:
    <programlisting><![CDATA[
 OPERATOR 15    <-> (point, point) FOR ORDER BY float_ops
 ]]>
@@ -1395,11 +1395,11 @@ OPERATOR 15    <-> (point, point) FOR ORDER BY float_ops
  </sect2>
 
  <sect2 id="xindex-opclass-features">
-  <title>Caractéristiques spéciales des classes d'opérateur</title>
+  <title>Caractéristiques spéciales des classes d'opérateurs</title>
 
   <para>
-   Il y a deux caractéristiques spéciales des classes d'opérateur dont nous
-   n'avons pas encore parlées, essentiellement parce qu'elles ne sont pas utiles
+   Il y a deux caractéristiques spéciales des classes d'opérateurs dont nous
+   n'avons pas encore parlé, essentiellement parce qu'elles ne sont pas utiles
    avec les méthodes d'index les plus communément utilisées.
   </para>
 
@@ -1430,14 +1430,14 @@ OPERATOR 15    <-> (point, point) FOR ORDER BY float_ops
    les recherches à perte (actuellement GiST, SP-GiST et GIN) permettent aux fonctions
    de support des classes individuelles d'opérateurs de lever le drapeau
    recheck, et donc c'est essentiellement une fonctionnalité pour les
-   classes d'opérateur.
+   classes d'opérateurs.
   </para>
 
   <para>
    Considérons à nouveau la situation où nous gardons seulement dans l'index le
    rectangle délimitant un objet complexe comme un polygone. Dans ce cas, il
    n'est pas très intéressant de conserver le polygone entier dans l'index -
-   nous pouvons aussi bien conserver seulement un objet simple du type
+   nous pouvons aussi bien conserver uniquement un objet simple du type
    <type>box</type>. Cette situation est exprimée par l'option <literal>STORAGE</literal>
    dans la commande <command>CREATE OPERATOR CLASS</command>&nbsp;: nous aurons à
    écrire quelque chose comme&nbsp;:
@@ -1456,18 +1456,18 @@ OPERATOR 15    <-> (point, point) FOR ORDER BY float_ops
    type de donnée quand <literal>STORAGE</literal> est utilisé. De la même
    manière, SP-GiST nécessite une fonction d'appui
    <function>compress</function> pour convertir le type de stockage quand il
-   est différent&nbsp;; si une classe d'opérateur SP-GiST supporte aussi la
+   est différent&nbsp;; si une classe d'opérateurs SP-GiST supporte aussi la
    récupération des données, la conversion inverse doit être gérée par la
    fonction <function>consistent</function>. Avec GIN, le type
    <literal>STORAGE</literal> identifie le type des valeurs
    <quote>key</quote>, qui est normalement différent du type de la colonne
-   indexée &mdash; par exemple, une classe d'opérateur pour des colonnes de
+   indexée &mdash; par exemple, une classe d'opérateurs pour des colonnes de
    tableaux d'entiers pourrait avoir des clés qui sont seulement des entiers.
    Les routines de support GIN <function>extractValue</function> et
    <function>extractQuery</function> sont responsables de l'extraction des
    clés à partir des valeurs indexées. BRIN est similaire à GIN&nbsp;: le
    type <literal>STORAGE</literal> identifie le type de valeurs résumées
-   stockées, et les procédures de support des classes d'opérateur sont
+   stockées, et les procédures de support des classes d'opérateurs sont
    responsables de l'interprétation correcte des valeurs résumées.
   </para>
  </sect2>

--- a/postgresql/xml2.xml
+++ b/postgresql/xml2.xml
@@ -345,7 +345,7 @@ WHERE t.author_id = p.person_id;
     renvoyées par la fonction pourrait ne pas être le même que le nombre de
     documents en entrée. La première ligne renvoyée contient le premier
     résultat de chaque requête, la deuxième le second résultat de chaque
-    requête. Si une res requêtes a moins de valeur que les autres, des valeurs
+    requête. Si une des requêtes a moins de valeurs que les autres, des valeurs
     NULL seront renvoyées.
    </para>
 

--- a/slony/failover.xml
+++ b/slony/failover.xml
@@ -306,7 +306,7 @@ wait for event (origin = 1, confirmed = 2);</programlisting>
 
 <para>
   La bascule est assez <quote>simple</quote> s'il n'y a que deux
-  n&oelig;uds&nbsp;; si un cluster &slony1; comprends de nombreux n&oelig;uds,
+  n&oelig;uds&nbsp;; si un cluster &slony1; comprend de nombreux n&oelig;uds,
   exécuter une bascule propre demande une planification et une exécution très
   attentives aux détails.
 </para>

--- a/slony/faq.xml
+++ b/slony/faq.xml
@@ -1550,7 +1550,7 @@ could not open file '$libdir/xxid': No such file or directory</command>
             Slony crée des conversions pour la conversion xid vers xxid et
             vice versa -- mais la 7.2 ne peut pas créer de nouvelles conversions
             et dans ce cas vous êtes obligé de le modifier à la main. Je me
-            rappelle avoir créé une classe d'opérateur et modifié certaines
+            rappelle avoir créé une classe d'opérateurs et modifié certaines
             fonctions.
           </para>
         </listitem>
@@ -2223,7 +2223,7 @@ CONTEXT:  PL/pgSQL function "setaddtable_int" line 71 at SQL statement</screen>
       </para>
 
       <para>
-        Diagnostiques&nbsp;: Exécuter les requêtes suivantes pour voir s'il y a
+        Diagnostics&nbsp;: Exécuter les requêtes suivantes pour voir s'il y a
         un résidus d'entrées en état <quote>fantôme/obsolète/bloqué</quote> dans
         la table <xref linkend="table.sl-confirm"/>:
 

--- a/slony/firstdb.xml
+++ b/slony/firstdb.xml
@@ -324,7 +324,7 @@ _EOF_
 <para>
   Même si nous avons désormais le démon <xref linkend="slon"/> exécuté à la fois
   sur le maître et l'esclave, et qu'ils sont tous les deux en train de cracher
-  des diagnostiques et d'autres messages, les données ne sont toujours pas
+  des diagnostics et d'autres messages, les données ne sont toujours pas
   répliquées. L'activité que vous constatez est la synchronisation de la
   configuration du cluster entre les deux processus <xref linkend="slon"/>.
 </para>
@@ -443,7 +443,7 @@ fi
 <para>
   Si ce script renvoie <command>FAILED</command>, merci de contacter les
   développeurs sur <ulink url="http://slony.info/">http://slony.info/</ulink>.
-  Préparez-vous aussi à fournir des informations de diagnostique, comme les
+  Préparez-vous aussi à fournir des informations de diagnostic, comme les
   journaux applicatifs créés par les processus &lslon; et les résultats de la
   commande &lteststate;.
 </para>

--- a/slony/monitoring.xml
+++ b/slony/monitoring.xml
@@ -19,7 +19,7 @@
 
 <para>
   Voici une liste des tables contenant une information particulièrement
-  intéressante d'un point de vue surveillance et diagnostique.
+  intéressante d'un point de vue surveillance et diagnostic.
 </para>
 
 <glosslist>
@@ -282,7 +282,7 @@
 </itemizedlist>
 
 <para>
-  Le script réalise un travail de diagnostique se basant sur les paramètres
+  Le script réalise un travail de diagnostic se basant sur les paramètres
   du script&nbsp;; si vous n'aimez pas les valeurs par défaut, n'hésitez pas
   à les modifier&nbsp;!
 </para>


### PR DESCRIPTION
Ce commit n'a pas vocation à corriger l'intégralité des fautes de la documentation : une relecture bien plus approfondie et de nombreuses reformulations seraient nécessaires. L'objectif est principalement de corriger les fautes les plus grossières qui se remarquent au premier coup d'oeil.

Si c'est nécessaire, je peux sans problème faire un commit par fichier : mais je me suis dit que ça allait réellement spam les pull requests. Dans tous les cas les modifications ne seront pas agréables à vérifier de toutes façons.



