### PR TITLE
Relecture et traduction v18 de pg_dump

### DIFF
--- a/postgresql/ref/pg_dump.xml
+++ b/postgresql/ref/pg_dump.xml
@@ -14,8 +14,8 @@
   <refname>pg_dump</refname>
 
   <refpurpose>
-   sauvegarder une base de données <productname>PostgreSQL</productname> dans
-   un script ou tout autre fichier d'archive
+   exporter une base de données <productname>PostgreSQL</productname> sous forme
+   de script SQL ou dans d'autres formats
   </refpurpose>
  </refnamediv>
 
@@ -36,20 +36,21 @@
 
   <para>
    <application>pg_dump</application> est un outil d'export d'une base de
-   données <productname>PostgreSQL</productname>. Les exports réalisée
+   données <productname>PostgreSQL</productname>. Les exports réalisés
    sont cohérents, même lors d'accès concurrents à la base de données.
    <application>pg_dump</application> ne bloque pas l'accès des autres
    utilisateurs (ni en lecture ni en écriture).
-   <application>pg_dump</application> is generally not the right choice for
-   taking regular backups of production databases.  See <xref
-   linkend="backup"/> for further discussion.
+   Notez toutefois que, sauf dans des cas simples,
+   <application>pg_dump</application> n'est généralement pas le choix le plus adapté
+   pour effectuer des sauvegardes régulières de bases de données en production.
+   Consultez <xref linkend="backup"/> pour plus d'informations à ce sujet.
   </para>
 
   <para>
-   <application>pg_dump</application> sauvegarde seulement une base de
-   données. Pour exporter une instance complète ou pour exporter les
-   objets globaux communs à toutes les bases de données d'une même instance,
-   tels que les rôles et les tablespaces, utilisez <xref
+   <application>pg_dump</application> n'exporte qu'une seule base de
+   données. Pour exporter une instance complète, ou pour exporter les
+   objets globaux communs à toutes les bases de données d'une même instance
+   (tels que les rôles et les tablespaces), utilisez <xref
    linkend="app-pg-dumpall"/>.
   </para>
 
@@ -57,37 +58,37 @@
    Les extractions peuvent être réalisées sous la forme de scripts ou de
    fichiers d'archive. Les scripts sont au format texte et contiennent les
    commandes SQL nécessaires à la reconstruction de la base de données dans
-   l'état où elle était au moment de l'export. La restauration s'effectue
-   en chargeant ces scripts avec <xref linkend="app-psql"/>. Ces scripts
+   l'état où elle se trouvait au moment de l'export. La restauration s'effectue
+   en exécutant ces scripts avec <xref linkend="app-psql"/>. Ces scripts
    permettent de reconstruire la base de données sur d'autres machines et
-   d'autres architectures, et même, au prix de quelques modifications, sur
-   d'autres bases de données SQL.
+   d'autres architectures, et même, moyennant quelques modifications, sur
+   d'autres systèmes de gestion de bases de données SQL.
   </para>
 
   <para>
    La reconstruction de la base de données à partir d'autres formats de
-   fichiers archive est obtenue avec <xref linkend="app-pgrestore"/>.
+   fichiers d'archive s'effectue avec <xref linkend="app-pgrestore"/>.
    <application>pg_restore</application> permet, à partir de ces formats, de
-   sélectionner les éléments à restaurer, voire de les réordonner avant
-   restauration. Les fichiers d'archive sont conçus pour être portables au
-   travers d'architectures différentes.
+   sélectionner les éléments à restaurer, voire de les réorganiser avant la
+   restauration. Les fichiers d'archive sont conçus pour être portables entre
+   différentes architectures.
   </para>
 
   <para>
-   Utilisé avec un des formats de fichier d'archive et combiné avec
+   Utilisé avec l'un des formats de fichier d'archive et combiné avec
    <application>pg_restore</application>, <application>pg_dump</application>
    fournit un mécanisme d'archivage et de transfert flexible.
    <application>pg_dump</application> peut être utilisé pour exporter une
    base de données dans son intégralité&nbsp;;
-   <application>pg_restore</application> peut alors être utilisé pour examiner
-   l'archive et/ou sélectionner les parties de la base de données à restaurer.
-   Les formats de fichier en sortie les plus flexibles sont le format
+   <application>pg_restore</application> peut alors servir à examiner
+   l'archive et/ou à sélectionner les parties de la base de données à restaurer.
+   Les formats de sortie les plus flexibles sont le format
    <quote>custom</quote> (<option>-Fc</option>) et le format
-   <quote>directory</quote> (<option>-Fd</option>). Ils permettent la
-   sélection et le ré-ordonnancement de tous les éléments archivés, le support
-   de la restauration en parallèle. De plus, ils sont compressés par défaut.
+   <quote>directory</quote> (<option>-Fd</option>). Ils permettent de
+   sélectionner et de réorganiser tous les éléments archivés, prennent en charge
+   la restauration en parallèle, et sont compressés par défaut.
    Le format <quote>directory</quote> est aussi le seul format à permettre les
-   sauvegardes parallélisées.
+   exports parallélisés.
   </para>
 
   <para>
@@ -102,7 +103,7 @@
   <title>Options</title>
 
   <para>
-   Les options suivantes de la ligne de commande contrôlent le contenu et le
+   Les options en ligne de commande suivantes contrôlent le contenu et le
    format de la sortie.
 
    <variablelist>
@@ -110,9 +111,9 @@
      <term><replaceable class="parameter">nom_base</replaceable></term>
      <listitem>
       <para>
-       Le nom de la base de données à sauvegarder. En l'absence de précision,
+       Le nom de la base de données à exporter. Si ce paramètre n'est pas précisé,
        la variable d'environnement <envar>PGDATABASE</envar> est utilisée. Si
-       cette variable n'est pas positionnée, le nom de l'utilisateur de la
+       celle-ci n'est pas définie, le nom d'utilisateur spécifié pour la
        connexion est utilisé.
       </para>
      </listitem>
@@ -123,9 +124,9 @@
      <term><option>--data-only</option></term>
      <listitem>
       <para>
-       Seules les données sont sauvegardées, pas le schéma (définition des
-       données) ou les statistiques. Les données des tables, les Large Objects,
-       et les valeurs des séquences sont sauvegardées.
+       Seules les données sont exportées, et non le schéma (définitions des
+       données) ni les statistiques. Les données des tables, les Large Objects,
+       et les valeurs des séquences sont exportés.
       </para>
 
       <para>
@@ -141,7 +142,7 @@
      <term><option>--blobs</option> (obsolète)</term>
      <listitem>
       <para>
-       Inclut les objets larges dans la sauvegarde. C'est le comportement par
+       Inclut les objets larges dans l'export. C'est le comportement par
        défaut, sauf si une des options suivantes est ajoutée&nbsp;:
        <option>--schema</option>, <option>--table</option>,
        <option>--schema-only</option>, <option>--statistics-only</option> ou
@@ -162,14 +163,14 @@
      <term><option>--no-blobs</option> (obsolète)</term>
      <listitem>
       <para>
-       Exclut les objets larges de la sauvegarde.
+       Exclut les objets larges (Large Objects) de l'export.
       </para>
 
       <para>
-       Quand à la fois les options <option>-b</option> et <option>-B</option>
-       sont fournies, le comportement est de produire les objets larges, quand
-       les données sont sauvegardées, voir la documentation de
-       <option>-b</option>.
+       Lorsque les options <option>-b</option> et <option>-B</option> sont
+       toutes deux spécifiées, le comportement est d'inclure les objets larges
+       lors de l'export des données. Voir la documentation de <option>-b</option>
+       pour plus de détails.
       </para>
      </listitem>
     </varlistentry>
@@ -181,9 +182,9 @@
       <para>
        Les commandes de suppression (<command>DROP</command>) des objets de la
        base sont écrites avant les commandes de création.
-       Cette option est utile quand la restauration écrase une base existante.
-       Si un des objets n'existe pas dans la base de destination, des messages
-       d'erreur, à ignorer, seront renvoyées lors de la restauration sauf si
+       Cette option est utile quand la restauration doit écraser une base existante.
+       Si certains objets n'existent pas dans la base de destination, des messages
+       d'erreur, à ignorer, seront renvoyés lors de la restauration sauf si
        l'option <option>--if-exists</option> est aussi précisée.
       </para>
 
@@ -200,21 +201,21 @@
      <term><option>--create</option></term>
      <listitem>
       <para>
-       La sortie débute par une commande de création de la base de données et
-       de connexion à cette base. Peu importe, dans ce cas, la base de données
-       de connexion à la restauration. De plus, si <option>--clean</option>
-       est aussi spécifié, le script supprime puis crée de nouveau la base de
-       données cible avant de s'y connecter.
+       La sortie commence par une commande de création de la base de données,
+       suivie d'une connexion à cette base nouvellement créée. Avec un tel script,
+       peu importe la base à laquelle on est connecté avant l'exécution du script.
+       Si <option>--clean</option> est également spécifiée, le script supprime
+       puis recrée la base de données cible avant de s'y reconnecter.
       </para>
 
       <para>
        Avec <option>--create</option>, la sortie inclut aussi le commentaire
-       de la base de données, s'il a été configuré, et toute variable de
+       associé à la base de données, s'il existe, et toute variable de
        configuration spécifique à cette base de données, configurée via les
        commandes <command>ALTER DATABASE ... SET ...</command> et
-       <command>ALTER ROLE ... IN DATABASE ... SET ...</command> mentionnant
-       cette base. Les droits d'accès à la base elle-même sont aussi
-       sauvegardés, sauf si <option>--no-acl</option> est indiqué.
+       <command>ALTER ROLE ... IN DATABASE ... SET ...</command> la mentionnant.
+       Les droits d'accès à la base elle-même sont aussi exportés,
+       sauf si <option>--no-acl</option> est spécifié.
       </para>
 
       <para>
@@ -225,52 +226,36 @@
      </listitem>
     </varlistentry>
 
-    <varlistentry>
-     <term><option>-f <replaceable class="parameter">fichier</replaceable></option></term>
-     <term><option>--file=<replaceable class="parameter">fichier</replaceable></option></term>
-     <listitem>
-      <para>
-       La sortie est redirigée vers le fichier indiqué. Ce paramètre peut être
-       omis pour les sorties en mode fichier, dans ce cas la sortie standard
-       sera utilisée. Par contre, il doit être fourni pour le format
-       'directory' (répertoire), où il spécifie le répertoire cible plutôt
-       qu'un fichier. Dans ce cas, le répertoire est créé par
-       <command>pg_dump</command> et ne doit pas exister auparavant.
-      </para>
-     </listitem>
-    </varlistentry>
-
      <varlistentry>
       <term><option>-e <replaceable class="parameter">motif</replaceable></option></term>
       <term><option>--extension=<replaceable class="parameter">motif</replaceable></option></term>
       <listitem>
        <para>
-        Ne sauvegarde que les extensions correspondant au
-        <replaceable class="parameter">motif</replaceable> indiqué.
-        Sans cette option, seront sauvées toutes les extensions non système
-        de la base sauvegardée. Plusieurs extensions peuvent être sélectionnées à l'aide
-        de plusieurs paramètres <option>-e</option>.
+        Exporte uniquement les extensions correspondantes au
+        <replaceable class="parameter">motif</replaceable> spécifié.
+        Sans cette option, toutes les extensions non système de la base de
+        données cible seront exportées. Plusieurs extensions peuvent être
+        sélectionnées en répétant le paramètre <option>-e</option>.
         Le <replaceable class="parameter">motif</replaceable> est interprété
-        suivant les mêmes règles que la commande <literal>\d</literal>
-        de <application>psql</application> (voir <xref linkend="app-psql-patterns"/>)&nbsp;;
-        ainsi plusieurs extensions peuvent être sélectionnées à l'aide de jokers
-        dans le motif. Dans ce cas, prenez soin d'encadrer le motif de
-        guillemets simples au besoin, pour empêcher le shell de les interpréter.
+        selon les mêmes règles que les commandes <literal>\d</literal>
+        de <application>psql</application> (voir <xref linkend="app-psql-patterns"/>),
+        ce qui permet ainsi de sélectionner plusieurs extensions à l'aide de
+        jokers. Dans ce cas, prenez soin d'encadrer le motif de guillemets
+        simples si nécessaire, pour empêcher le shell de les interpréter.
        </para>
 
        <para>
-        Toute configuration de table enregistrée dans
-        <function>pg_extension_config_dump</function> est incluse dans la
-        sauvegarde si l'extension est spécifiée dans <option>--extension</option>.
+        Toute table de configuration enregistrée via
+        <function>pg_extension_config_dump</function> est incluse dans l'export
+        si son extension est spécifiée dans <option>--extension</option>.
        </para>
 
        <note>
         <para>
          Quand <option>-e</option> est spécifié, <application>pg_dump</application>
-         ne cherche pas à sauvegarder tout autre objet dont l'extension pourrait
-         dépendre. En conséquence, il n'y a pas de garantie que le résultat
-         d'une sauvegarde en précisant les extensions puisse être restauré
-         dans une base propre.
+         ne tente pas d'exporter les autres objets dont l'extension pourrait
+         dépendre. Il n'est donc pas garanti qu'un export limité à une extension
+         spécifique puisse être restauré avec succès dans une base de données vide.
         </para>
        </note>
       </listitem>
@@ -281,12 +266,27 @@
      <term><option>--encoding=<replaceable class="parameter">codage</replaceable></option></term>
      <listitem>
       <para>
-       La sauvegarde est créée dans l'encodage indiqué. Par défaut, la
-       sauvegarde utilise celui de la base de données. Le même résultat peut
-       être obtenu en positionnant la variable d'environnement
-       <envar>PGCLIENTENCODING</envar> avec le codage désiré pour la
-       sauvegarde. Les encodages supportés sont décrits dans <xref
+       L'export est créé dans l'encodage indiqué. Par défaut, l'export
+       utilise celui de la base de données. Le même résultat peut
+       être obtenu en définissant la variable d'environnement
+       <envar>PGCLIENTENCODING</envar> avec l'encodage souhaité.
+       Les encodages supportés sont décrits dans <xref
        linkend="multibyte-charset-supported"/>.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term><option>-f <replaceable class="parameter">fichier</replaceable></option></term>
+     <term><option>--file=<replaceable class="parameter">fichier</replaceable></option></term>
+     <listitem>
+      <para>
+       La sortie est redirigée vers le fichier spécifié. Ce paramètre peut être
+       omis pour les formats de sortie basés sur des fichiers, auquel cas la
+       sortie standard sera utilisée. Par contre, il doit être précisé pour le
+       format 'directory' (répertoire), où il désigne le répertoire cible plutôt
+       qu'un fichier. Dans ce cas, le répertoire est créé par
+       <command>pg_dump</command> et ne doit pas exister au préalable.
       </para>
      </listitem>
     </varlistentry>
@@ -296,16 +296,15 @@
      <term><option>--format=<replaceable class="parameter">format</replaceable></option></term>
      <listitem>
       <para>
-       Le format de la sortie. <replaceable>format</replaceable> correspond à
-       un des éléments suivants&nbsp;:
+       Sélectionne le format de la sortie.
+       <replaceable>format</replaceable> peut être l'un des éléments suivants&nbsp;:
 
        <variablelist>
         <varlistentry>
          <term><literal>p</literal></term>
          <listitem>
           <para>
-           Fichier de scripts <acronym>SQL</acronym> en texte simple
-           (défaut).
+           Fichier de scripts <acronym>SQL</acronym> en texte simple (défaut).
           </para>
          </listitem>
         </varlistentry>
@@ -314,10 +313,10 @@
          <term><literal>c</literal></term>
          <listitem>
           <para>
-           archive personnalisée utilisable par
+           Archive personnalisée utilisable par
            <application>pg_restore</application>. Avec le format de sortie
            répertoire, c'est le format le plus souple, car il permet la
-           sélection manuelle et le réordonnancement des objets archivés au
+           sélection manuelle et la réorganisation des objets archivés au
            moment de la restauration. Ce format est aussi compressé par
            défaut.
           </para>
@@ -329,20 +328,20 @@
          <term><literal>directory</literal></term>
          <listitem>
           <para>
-           Produire une archive au format répertoire utilisable en entrée de
+           Archive au format répertoire utilisable par
            <application>pg_restore</application>. Cela créera un répertoire
            avec un fichier pour chaque table et Large Object exporté, ainsi qu'un
-           fichier appelé Table of Contents (Table des matières) décrivant les
+           fichier appelé Table of Contents (table des matières) décrivant les
            objets exportés dans un format machine que
            <application>pg_restore</application> peut lire. Une archive au
            format répertoire peut être manipulée avec des outils Unix
-           standard; par exemple, les fichiers d'une archive non-compressée
+           standard&nbsp;; par exemple, les fichiers d'une archive non-compressée
            peuvent être compressés avec les outils
            <application>gzip</application>,
            <application>lz4</application> ou
-           <application>zstd</application>. Ce format est compressé par défaut
-           en utilisant <literal>gzip</literal> et supporte aussi les
-           sauvegardes parallélisées.
+           <application>zstd</application>.
+           Ce format est compressé par défaut en utilisant <literal>gzip</literal>
+           et supporte aussi les exports parallélisés.
           </para>
          </listitem>
         </varlistentry>
@@ -353,8 +352,8 @@
           <para>
            Archive <command>tar</command> utilisable par
            <application>pg_restore</application>. Le format tar est compatible
-           avec le format répertoire; l'extraction d'une archive au format tar
-           produit une archive au format répertoire valide. Toutefois, le
+           avec le format répertoire&nbsp;; l'extraction d'une archive au format
+           tar produit une archive au format répertoire valide. Toutefois, le
            format tar ne supporte pas la compression. Par ailleurs, lors de
            l'utilisation du format tar, l'ordre de restauration des données
            des tables ne peut pas être changé au moment de la restauration.
@@ -373,12 +372,12 @@
      <term><option>--jobs=<replaceable class="parameter">njobs</replaceable></option></term>
      <listitem>
       <para>
-       Exécute une sauvegarde parallélisée en sauvegardant <replaceable
-       class="parameter">njobs</replaceable> tables simultanément. Cette
-       option réduit la durée de la sauvegarde mais elle augmente aussi la
-       charge sur le serveur de base de données. Vous ne pouvez utiliser cette
-       option qu'avec le format de sortie répertoire car c'est le seul format
-       où plusieurs processus peuvent écrire leur données en même temps.
+       Exécute l'export en parallèle en traitant <replaceable
+       class="parameter">njobs</replaceable> tables simultanément. Cette option
+       peut réduire le temps nécessaire à l'export, mais elle augmente également
+       la charge sur le serveur de base de données. Cette option n'est utilisable
+       qu'avec le format de sortie répertoire, car c'est le seul format permettant
+       à plusieurs processus d'écrire leurs données en parallèle.
       </para>
 
       <para>
@@ -390,42 +389,42 @@
       </para>
 
       <para>
-       Réclamer des verrous exclusifs sur les objets de la base lors de
-       l'exécution d'une sauvegarde parallélisée peut causer l'échec de la
-       sauvegarde. La raison en est que le processus principal de
+       Réclamer des verrous exclusifs sur les objets de la base pendant un
+       export en parallèle peut provoquer l'échec de l'export.
+       Cela s'explique par le fait que le processus principal de
        <application>pg_dump</application> réclame des verrous partagés
        (<link linkend="locking-tables">ACCESS SHARE</link>) sur les
-       objets que les processus fils vont sauvegarder plus tard pour s'assurer
-       que personne ne les supprime pendant la sauvegarde. Si un autre client
-       demande alors un verrou exclusif sur une table, ce verrou ne sera pas
-       accepté mais mis en queue, en attente du relâchement du verrou partagé
-       par le processus principal. En conséquence, tout autre accès à la table ne
-       sera pas non plus accepté. Il sera lui-aussi mis en queue, après la
-       demande de verrou exclusif. Cela inclut le processus fils essayant de
-       sauvegarder la table. Sans autre précaution, cela résulterait en un
-       classique « deadlock ». Pour détecter ce conflit, le processus fils
-       <application>pg_dump</application> réclame un nouveau verrou partagé en
-       utilisant l'option <literal>NOWAIT</literal>. Si le processus fils
-       n'obtient pas ce verrou, quelqu'un d'autre doit avoir demandé un verrou
-       exclusif entre temps, et il n'existe donc aucun moyen de continuer la
-       sauvegarde. <application>pg_dump</application> n'a d'autre choix que
-       d'annuler la sauvegarde.
+       objets que les processus fils vont traiter plus tard, afin de s'assurer
+       que personne ne les supprime pendant l'export. Si un autre client demande
+       ensuite un verrou exclusif sur une table, ce verrou ne pourra pas être accordé
+       immédiatement et sera mis en attente jusqu'à ce que le verrou partagé du
+       processus principal soit libéré. Par conséquent, tout autre accès à la
+       table ne sera pas non plus accepté et sera mis en attente, derrière la
+       demande de verrou exclusif. Cela inclut le processus fils essayant
+       d'exporter la table. Sans autre précaution, cela résulterait donc en un
+       classique « deadlock ». Pour détecter ce conflit, le processus fils de
+       <application>pg_dump</application> demande à son tour un verrou partagé,
+       en utilisant l'option <literal>NOWAIT</literal>. Si ce verrou ne peut pas
+       être obtenu, cela signifie qu'un autre client a probablement demandé un
+       verrou exclusif entre-temps, et il n'est alors plus possible de poursuivre
+       l'export. Dans ce cas, <application>pg_dump</application> n'a pas d'autre
+       choix que d'interrompre l'export.
       </para>
 
       <para>
-       Pour réaliser une sauvegarde parallélisée, le serveur de la base de
-       données a besoin de supporter les images (« snapshots ») synchronisées.
+       Pour effectuer un export en parallèle, le serveur de base de données doit
+       supporter les instantanés (« snapshots ») synchronisées.
        Cette fonctionnalité a été introduite avec
        <productname>PostgreSQL</productname> version 9.2 pour les serveurs
-       primaires et version 10 pour les serveurs secondaires. Avec cette
-       fonctionnalité, les clients de la base de données peuvent s'assurer de
-       voir le même ensemble de données, même s'ils utilisent des connexions
-       différentes. <command>pg_dump -j</command> utilise plusieurs connexions
-       à la base de données&nbsp;; il se connecte une première fois en tant
-       que processus principal et une fois encore par processus fils. Sans la
-       fonctionnalité d'images synchronisées, les différent processus ne
-       pourraient pas garantir de voir les mêmes données sur chaque connexion,
-       ce qui aurait pour résultat une sauvegarde incohérente.
+       primaires et version 10 pour les serveurs secondaires. Grâce à cette
+       fonctionnalité, les clients peuvent s'assurer qu'ils accèdent au même
+       jeu de données, même s'ils utilisent des connexions différentes.
+       <command>pg_dump -j</command> utilise plusieurs connexions
+       à la base de données&nbsp;; une pour le processus principal, et une autre
+       pour chaque processus fils.
+       Sans la fonctionnalité d'instantanés synchronisées, rien ne garantit que
+       les différents processus voient les mêmes données via leurs connexions
+       respectives, ce qui pourrait conduire à un export incohérent.
       </para>
      </listitem>
     </varlistentry>
@@ -435,36 +434,34 @@
      <term><option>--schema=<replaceable class="parameter">motif</replaceable></option></term>
      <listitem>
       <para>
-       Sauvegarde uniquement les schémas correspondant à <replaceable
-       class="parameter">schema</replaceable>&nbsp;; la sélection se fait à la
-       fois sur le schéma et sur les objets qu'il contient. Quand cette option
+       Exporte uniquement les schémas correspondants au <replaceable
+       class="parameter">motif</replaceable> spécifié&nbsp;; cela inclut à la fois
+       le schéma lui-même et tous les objets qu'il contient. Quand cette option
        n'est pas indiquée, tous les schémas non système de la base cible sont
-       sauvegardés. Plusieurs schémas peuvent être indiqués en utilisant
-       plusieurs fois l'option <option>-n</option>. De plus, le paramètre
-       <replaceable class="parameter">motif</replaceable> est interprété
-       comme un modèle selon les règles utilisées par les commandes
-       <literal>\d</literal> de <application>psql</application> (voir <xref
-       linkend="app-psql-patterns"/>). Du coup, plusieurs schémas peuvent être
-       sélectionnés en utilisant des caractères joker dans le modèle. Lors de
-       l'utilisation de ces caractères, il faut faire attention à placer le
-       modèle entre guillemets, si nécessaire, pour empêcher le shell de
-       remplacer les jokers&nbsp;; voir <xref linkend="pg-dump-examples"/>.
+       exportés. Plusieurs schémas peuvent être indiqués en répétant
+       l'option <option>-n</option>.
+       Le <replaceable class="parameter">motif</replaceable> est interprété
+       selon les mêmes règles que les commandes <literal>\d</literal>
+       de <application>psql</application> (voir <xref linkend="app-psql-patterns"/>),
+       ce qui permet ainsi de sélectionner plusieurs schémas à l'aide de
+       jokers. Dans ce cas, prenez soin d'encadrer le motif de guillemets
+       simples si nécessaire, pour empêcher le shell de les interpréter.
+       Voir <xref linkend="pg-dump-examples"/> ci-dessous.
       </para>
 
       <note>
        <para>
-        Quand <option>-n</option> est indiqué,
-        <application>pg_dump</application> ne sauvegarde aucun autre objet de
-        la base que ceux dont les schémas sélectionnés dépendent. Du coup, il
-        n'est pas garanti que la sauvegarde d'un schéma puisse être restaurée
-        avec succès dans une base vide.
+        Quand <option>-n</option> est spécifié, <application>pg_dump</application>
+        ne tente pas d'exporter les autres objets dont le schéma pourrait
+        dépendre. Il n'est donc pas garanti qu'un export limité à un schéma
+        spécifique puisse être restauré avec succès dans une base de données vide.
        </para>
       </note>
 
       <note>
        <para>
         Les objets qui ne font pas partie du schéma comme les Large Objects ne
-        sont pas sauvegardés quand <option>-n</option> est précisé. Ils
+        sont pas exportés quand <option>-n</option> est spécifié. Ils
         peuvent être rajoutés avec l'option <option>--large-objects</option>.
        </para>
       </note>
@@ -476,20 +473,19 @@
      <term><option>--exclude-schema=<replaceable class="parameter">motif</replaceable></option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les schémas correspondant au modèle <replaceable
-       class="parameter">motif</replaceable>. Le modèle est interprété selon
+       N'exporte aucun schéma correspondant au <replaceable
+       class="parameter">motif</replaceable> spécifié. Le motif est interprété selon
        les même règles que <option>-n</option>. <option>-N</option> peut aussi
-       être indiqué plus d'une fois pour exclure des schémas correspondant à
-       des modèles différents.
+       être répété pour exclure des schémas correspondants à différents motifs.
       </para>
 
       <para>
-       Quand les options <option>-n</option> et <option>-N</option> sont
-       indiquées, seuls sont sauvegardés les schémas qui correspondent à au
-       moins une option <option>-n</option> et à aucune option
-       <option>-N</option>. Si <option>-N</option> apparaît sans
-       <option>-n</option>, alors les schémas correspondant à
-       <option>-N</option> sont exclus de ce qui est une sauvegarde normale.
+       Lorsque les options <option>-n</option> et <option>-N</option> sont toutes
+       deux spécifiées, seuls les schémas correspondants à au moins une option
+       <option>-n</option> mais à aucune option <option>-N</option> sont exportés.
+       Si <option>-N</option> est utilisé sans <option>-n</option>,
+       alors les schémas correspondants à <option>-N</option> sont simplement
+       exclus de l'export normal.
       </para>
      </listitem>
     </varlistentry>
@@ -499,13 +495,14 @@
      <term><option>--no-owner</option></term>
      <listitem>
       <para>
-       Les commandes d'initialisation des possessions des objets au regard de
-       la base de données originale ne sont pas produites. Par défaut,
-       <application>pg_dump</application> engendre des instructions
+       N'émet pas les commandes destinées à définir les propriétaires des objets
+       conformément à ceux de la base de données d'origine.
+       Par défaut, <application>pg_dump</application> génère des instructions
        <command>ALTER OWNER</command> ou <command>SET SESSION
-        AUTHORIZATION</command> pour fixer ces possessions. Ces instructions
-       échouent lorsque le script n'est pas lancé par un superutilisateur (ou
-       par l'utilisateur qui possède tous les objets de ce script). L'option
+        AUTHORIZATION</command> pour rétablir la propriété des objets créés.
+       Ces instructions échoueront lors de l'exécution du script, sauf si
+       celui-ci est lancé par un superutilisateur ou par l'utilisateur
+       propriétaire de tous les objets. L'option
        <option>-O</option> est utilisée pour créer un script qui puisse être
        restauré par n'importe quel utilisateur. En revanche, c'est cet
        utilisateur qui devient propriétaire de tous les objets.
@@ -524,7 +521,7 @@
      <term><option>--no-reconnect</option></term>
      <listitem>
       <para>
-       Cette option, obsolète, est toujours acceptée pour des raisons de
+       Cette option est obsolète mais toujours acceptée pour des raisons de
        compatibilité ascendante.
       </para>
      </listitem>
@@ -535,14 +532,15 @@
      <term><option>--schema-only</option></term>
      <listitem>
       <para>
-       Seule la définition des objets (le schéma) est sauvegardée, pas les
-       données.
+       Exporte uniquement les définitions des objets (le schéma), sans les
+       données ni les statistiques.
       </para>
 
       <para>
-       Cette option est l'inverse de <option>--data-only</option>. Elle est
-       similaire, mais pas identique (pour des raisons historiques), à
-       <option>--section=pre-data --section=post-data</option>.
+       Cette option ne peut pas être utilisée avec <option>--data-only</option>
+       ni avec <option>--statistics-only</option>. Elle est similaire à
+       <option>--section=pre-data --section=post-data</option>, mais pour des
+       raisons historiques, elle n'est pas strictement identique.
       </para>
 
       <para>
@@ -551,8 +549,7 @@
       </para>
 
       <para>
-       Pour exclure les données de la table pour seulement un sous-ensemble
-       des tables de la base de données, voir
+       Pour exclure les données de certaines tables seulement, voir
        <option>--exclude-table-data</option>.
       </para>
      </listitem>
@@ -563,11 +560,11 @@
      <term><option>--superuser=<replaceable class="parameter">nom_utilisateur</replaceable></option></term>
      <listitem>
       <para>
-       Le nom du superutilisateur à utiliser lors de la désactivation des
-       triggers. Cela n'a d'intérêt que si l'option
+       Spécifie le nom de l'utilisateur superutilisateur à utiliser lors de la
+       désactivation des triggers. Cela n'a d'intérêt que si l'option
        <option>--disable-triggers</option> est précisée. (En règle générale,
        il est préférable de ne pas utiliser cette option et de lancer le
-       script produit en tant que superutilisateur.)
+       script généré en tant que superutilisateur.)
       </para>
      </listitem>
     </varlistentry>
@@ -577,44 +574,41 @@
      <term><option>--table=<replaceable class="parameter">motif</replaceable></option></term>
      <listitem>
       <para>
-       Sauvegarde seulement les tables dont le nom correspond à <replaceable
+       Exporte uniquement les tables dont le nom correspond au <replaceable
        class="parameter">motif</replaceable>. Plusieurs tables sont sélectionnables
-       en utilisant plusieurs fois l'option <option>-t</option>. De plus, le
-       paramètre <replaceable class="parameter">motif</replaceable> est
-       interprété comme un modèle suivant les règles utilisées par les
-       commandes <literal>\d</literal> de <application>psql</application>
-       (voir <xref linkend="app-psql-patterns"/>). Du coup, plusieurs tables
-       peuvent être sélectionnées en utilisant des caractères joker dans le
-       modèle. Lors de l'utilisation de ces caractères, il faut faire
-       attention à placer le modèle entre guillemets, si nécessaire, pour
-       empêcher le shell de remplacer les jokers&nbsp;; voir <xref
-       linkend="pg-dump-examples"/>.
+       en utilisant plusieurs fois l'option <option>-t</option>.
+       Le <replaceable class="parameter">motif</replaceable> est interprété
+       selon les mêmes règles que les commandes <literal>\d</literal>
+       de <application>psql</application> (voir <xref linkend="app-psql-patterns"/>),
+       ce qui permet ainsi de sélectionner plusieurs tables à l'aide de
+       jokers. Dans ce cas, prenez soin d'encadrer le motif de guillemets
+       simples si nécessaire, pour empêcher le shell de les interpréter.
+       Voir <xref linkend="pg-dump-examples"/> ci-dessous.
       </para>
 
       <para>
-       Conçue pour les tables, cette option peut être utilisée pour
-       sauvegarder la définition des vues, vues matérialisées, tables externes
-       et séquences correspondantes. Elle ne sauvegardera pas le contenu des
-       vues et des vues matérialisées. Le contenu des tables externes ne sera
-       sauvegardé que si le serveur distant correspondant est précisé avec
+       En plus des tables, cette option permet également d'exporter
+       la définition des vues, vues matérialisées, tables externes et
+       séquences correspondantes au motif. Elle n'exporte pas le contenu des
+       vues ou des vues matérialisées, et le contenu des tables externes n'est
+       exporté que si le serveur distant correspondant est spécifié avec
        l'option <option>--include-foreign-data</option>.
       </para>
 
       <para>
        Les options <option>-n</option> et <option>-N</option> n'ont aucun
        effet quand l'option <option>-t</option> est utilisée car les tables
-       sélectionnées par <option>-t</option> sont sauvegardées quelle que soit
+       sélectionnées par <option>-t</option> sont exportées quelle que soit
        la valeur des options relatives aux schémas. Les objets qui ne sont pas
-       des tables ne sont pas sauvegardés.
+       des tables ne sont pas exportés.
       </para>
 
       <note>
        <para>
-        Quand <option>-t</option> est indiqué,
-        <application>pg_dump</application> ne sauvegarde aucun autre objet de
-        la base dont la (ou les) table(s) sélectionnée(s) pourrai(en)t
-        dépendre. Du coup, il n'est pas garanti que la sauvegarde spécifique
-        d'une table puisse être restaurée avec succès dans une base vide.
+        Quand <option>-t</option> est spécifié, <application>pg_dump</application>
+        ne tente pas d'exporter les autres objets dont la table pourrait
+        dépendre. Il n'est donc pas garanti qu'un export limité à une table
+        spécifique puisse être restauré avec succès dans une base de données vide.
        </para>
       </note>
      </listitem>
@@ -625,20 +619,20 @@
      <term><option>--exclude-table=<replaceable class="parameter">motif</replaceable></option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les tables correspondant au modèle <replaceable
-       class="parameter">motif</replaceable>. Le modèle est interprété selon
-       les même règles que <option>-t</option>. <option>-T</option> peut aussi
-       être indiqué plusieurs pour exclure des tables correspondant à des
-       modèles différents.
+       N'exporte aucune table correspondante au <replaceable
+       class="parameter">motif</replaceable> spécifié. Le motif est interprété
+       selon les mêmes règles que pour l'option <option>-t</option>.
+       L'option <option>-T</option> peut être répétée pour exclure plusieurs
+       tables correspondantes à différents motifs.
       </para>
 
       <para>
-       Quand les options <option>-t</option> et <option>-T</option> sont
-       indiquées, seules sont sauvegardées les tables qui correspondent à au
-       moins une option <option>-t</option> et à aucune option
-       <option>-T</option>. Si <option>-T</option> apparaît sans
-       <option>-t</option>, alors les tables correspondant à
-       <option>-T</option> sont exclues de ce qui est une sauvegarde normale.
+       Lorsque les options <option>-t</option> et <option>-T</option> sont toutes
+       deux spécifiées, seuls les tables correspondantes à au moins une option
+       <option>-t</option> mais à aucune option <option>-T</option> sont exportées.
+       Si <option>-T</option> est utilisé sans <option>-t</option>,
+       alors les tables correspondantes à <option>-N</option> sont simplement
+       exclues de l'export normal.
       </para>
      </listitem>
     </varlistentry>
@@ -648,9 +642,9 @@
      <term><option>--verbose</option></term>
      <listitem>
       <para>
-       Mode verbeux. <application>pg_dump</application> affiche des
+       Mode verbeux. <application>pg_dump</application> inclus des
        commentaires détaillés sur les objets et les heures de début et de fin
-       dans le fichier de sauvegarde. Des messages de progression sont
+       dans le fichier d'export. Des messages de progression sont
        également affichés sur la sortie d'erreur standard.
        Répéter l'option entraîne l'apparition de messages de débogage
        supplémentaires sur la sortie d'erreur standard.
@@ -674,13 +668,13 @@
      <term><option>--no-acl</option></term>
      <listitem>
       <para>
-       Les droits d'accès (commandes grant/revoke) ne sont pas sauvegardés.
+       Les droits d'accès (commandes grant/revoke) ne sont pas exportés.
       </para>
      </listitem>
     </varlistentry>
 
     <varlistentry>
-     <term><option>-Z <replaceable class="parameter">level</replaceable></option></term>
+     <term><option>-Z <replaceable class="parameter">nivea</replaceable></option></term>
      <term><option>-Z <replaceable class="parameter">method</replaceable></option>[:<replaceable>detail</replaceable>]</term>
      <term><option>--compress=<replaceable class="parameter">level</replaceable></option></term>
      <term><option>--compress=<replaceable class="parameter">method</replaceable></option>[:<replaceable>detail</replaceable>]</term>
@@ -694,7 +688,7 @@
        entier, cela correspond au niveau de compression. Autrement, il s'agit
        d'une liste d'éléments séparés par des virgules pouvant prendre la forme
        <literal>clé</literal> ou <literal>clé=valeur</literal>.
-       Actuellement, les mots-clés supportés sont <literal>level</literal> et
+       Actuellement, les mots clés supportés sont <literal>level</literal> et
        <literal>long</literal>.
       </para>
 
@@ -702,26 +696,26 @@
        Si aucun niveau de compression n'est spécifié, le niveau de compression
        par défaut sera utilisé. Si seul un niveau est spécifié sans mentionner
        d'algorithme, la compression <literal>gzip</literal> sera utilisée si le
-       niveau est supérieur à <literal>0</literal>, et aucune compression
+       niveau est supérieur à <literal>0</literal>, et aucune compression ne
        sera utilisée si le niveau est <literal>0</literal>.
       </para>
 
       <para>
        Pour les formats <quote>custom</quote> et <quote>directory</quote>, ce
-       paramètre spécifie la compression des segments individuels des données de
-       la table et par défaut la compression se fait à l'aide de
+       paramètre spécifie la compression des segments de données de table
+       individuellement, et par défaut la compression se fait à l'aide de
        <literal>gzip</literal> à un niveau modéré. Pour le format texte simple,
        la définition d'un niveau de compression non nul entraîne la
        compression de l'ensemble du fichier de sortie, comme s'il était passé
        par <application>gzip</application>,
        <application>lz4</application>, ou <application>zstd</application>&nbsp;;
        mais par défaut, il n'y a pas de compression.
-       Avec la compression zstd, le mode <literal>long</literal> peut améliorer le taux de
-       compression, au prix d'une utilisation accrue de la mémoire.
+       Avec la compression zstd, le mode <literal>long</literal> peut améliorer
+       le taux de compression, au prix d'une utilisation accrue de la mémoire.
       </para>
 
       <para>
-       Le format d'archive tar ne supporte pas du tout la compression.
+       Le format d'archive tar ne supporte pas la compression.
       </para>
      </listitem>
     </varlistentry>
@@ -730,8 +724,8 @@
      <term><option>--binary-upgrade</option></term>
      <listitem>
       <para>
-       Cette option est destinée à être utilisée pour une mise à jour en
-       ligne. Son utilisation dans d'autres buts n'est ni recommandée ni
+       Cette option est destinée à être utilisée par les utilitaires de mise à
+       jour en ligne. Son utilisation dans d'autres buts n'est ni recommandée ni
        supportée. Le comportement de cette option peut changer dans les
        futures versions sans avertissement.
       </para>
@@ -743,12 +737,12 @@
      <term><option>--attribute-inserts</option></term>
      <listitem>
       <para>
-       Extraire les données en tant que commandes <command>INSERT</command>
+       Extrait les données en tant que commandes <command>INSERT</command>
        avec des noms de colonnes explicites (<literal>INSERT INTO
         <replaceable>table</replaceable> (<replaceable>colonne</replaceable>,
         ...) VALUES ...</literal>). Ceci rendra la restauration très
-       lente&nbsp;; c'est surtout utile pour créer des extractions qui
-       puissent être chargées dans des bases de données autres que
+       lente&nbsp;; c'est surtout utile pour créer des exports qui
+       puissent être chargés dans des bases de données autres que
        <productname>PostgreSQL</productname>. Toute erreur lors du
        rechargement causera la perte uniquement des lignes faisant partie du
        <command>INSERT</command> problématique, et pas du contenu complet de
@@ -776,23 +770,23 @@
        données mais pas la structure.
        Ceci demande à <application>pg_dump</application> d'inclure des
        commandes pour désactiver temporairement les triggers sur les tables
-       cibles pendant que les données sont rechargées. Utilisez ceci si, sur
-       les tables, vous avez des contraintes d'intégrité ou des triggers que
+       cibles pendant que les données sont rechargées. Utilisez cette option si,
+       sur vos tables, vous avez des contraintes d'intégrité ou des triggers que
        vous ne voulez pas invoquer pendant le rechargement.
       </para>
 
       <para>
-       À l'heure actuelle, les commandes émises pour
+       À l'heure actuelle, les commandes émises par
        <option>--disable-triggers</option> doivent être exécutées en tant que
        superutilisateur. Par conséquent, vous devez aussi spécifier un nom de
        superutilisateur avec <option>-S</option>, ou préférablement faire
-       attention à lancer le script résultat en tant que superutilisateur.
+       attention à lancer le script généré en tant que superutilisateur.
       </para>
 
       <para>
-       Cette option n'a de sens que pour le format texte simple. Pour les
-       formats d'archive, vous pouvez spécifier cette option quand vous
-       appelez <command>pg_restore</command>.
+       Cette option n'a d'intérêt que pour le format texte. Pour les formats
+       archive, l'option est précisée à l'appel de
+       <command>pg_restore</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -801,23 +795,23 @@
      <term><option>--enable-row-security</option></term>
      <listitem>
       <para>
-       Cette option est seulement adéquate lors de la sauvegarde du contenu
+       Cette option est seulement utile lors de l'export du contenu
        d'une table disposant du mode de sécurité niveau ligne. Par défaut,
        <application>pg_dump</application> configurera <xref
        linkend="guc-row-security"/> à off pour s'assurer que toutes les
-       données de la table soient sauvegardées. Si l'utilisateur n'a pas les
+       données de la table soient exportées. Si l'utilisateur n'a pas les
        droits suffisant pour contourner la sécurité niveau ligne, alors une
        erreur est renvoyée. Ce paramètre force
        <application>pg_dump</application> à configurer <xref
-       linkend="guc-row-security"/> à on, permettant à l'utilisateur de ne
-       sauvegarder que le contenu auquel il a le droit d'accéder.
+       linkend="guc-row-security"/> à on, permettant à l'utilisateur d'exporter
+       uniquement les parties de la table auxquelles il a accès.
       </para>
 
       <para>
-       Notez que si vous utilisez cette option actuellement, vous serez
-       certainement intéressé à faire une sauvegarde au format
-       <command>INSERT</command> car les politiques de sécurité ne sont pas
-       respectées par l'instruction <command>COPY FROM</command>.
+       Notez que si vous utilisez actuellement cette option, vous souhaiterez
+       probablement que l'export soit effectué au format
+       <command>INSERT</command> car l'instruction <command>COPY FROM</command>
+       utilisée lors de la restauration ne prend pas en charge la sécurité niveau ligne.
       </para>
      </listitem>
     </varlistentry>
@@ -826,23 +820,21 @@
       <term><option>--exclude-extension=<replaceable class="parameter">motif</replaceable></option></term>
       <listitem>
        <para>
-        Ne sauvegarde pas les extensions correspondant au <replaceable
-        class="parameter">motif</replaceable>. Le motif est interprété suivant
-        les mêmes règles que pour <option>-e</option>.
+        N'exporte pas les extensions correspondantes au <replaceable
+        class="parameter">motif</replaceable> spécifié. Le motif est interprété
+        selon les mêmes règles que pour l'option <option>-e</option>.
         <option>--exclude-extension</option> peut être utilisé plus d'une fois
-        pour exclure des extensions correspondant à différents motifs.
+        pour exclure des extensions dont le nom correspond à des motifs différents.
        </para>
 
        <para>
-        Quand <option>-e</option> et <option>--exclude-extension</option>
-        sont utilisés en même temps, le comportement est de sauvegarder
-        uniquement les extensions qui correspondent à au moins une option
-        <option>-e</option> et à aucune option
-        <option>--exclude-extension</option>. Si
-        <option>--exclude-extension</option> apparaît sans
-        <option>-e</option>, alors les extensions correspondant à
-        <option>--exclude-extension</option> sont exclues de ce qui serait
-        habituellement une sauvegarde normale.
+        Lorsque les options <option>-e</option> et <option>--exclude-extension</option>
+        sont toutes deux spécifiées, seules les extensions correspondantes à
+        au moins une option <option>-e</option> mais à aucune option
+        <option>--exclude-extension</option> sont exportées. Si
+        <option>--exclude-extension</option> est utilisé sans
+        <option>-e</option>, les extensions correspondantes sont simplement
+        exclues de l'export normal.
        </para>
       </listitem>
      </varlistentry>
@@ -853,8 +845,8 @@
       <para>
        Cette option fonctionne de la même manière que l'option
        <option>-T</option>/<option>--exclude-table</option>, à l'exception
-       qu'elle exclue également les partitions et les tables enfant des tables
-       dont le nom correspond à <replaceable class="parameter">motif</replaceable>.
+       qu'elle exclut également les partitions et les tables enfants des tables
+       dont le nom correspond au <replaceable class="parameter">motif</replaceable>.
       </para>
      </listitem>
     </varlistentry>
@@ -863,11 +855,11 @@
      <term><option>--exclude-table-data=<replaceable class="parameter">motif</replaceable></option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les données pour toute table correspondant au motif
-       indiqué par <replaceable class="parameter">motif</replaceable>. Le
+       N'exporte pas les données des tables correspondantes au
+       <replaceable class="parameter">motif</replaceable> spécifié. Le
        motif est interprété selon les même règles que pour l'option
        <option>-t</option>. <option>--exclude-table-data</option> peut être
-       utilisé plusieurs fois pour exclure des tables dont le nom correspond à
+       répété pour exclure les données de tables dont le nom correspond à
        des motifs différents. Cette option est utile quand vous avez besoin de
        la définition d'une table particulière mais pas de ses données.
       </para>
@@ -883,9 +875,9 @@
      <listitem>
       <para>
       Cette option fonctionne de la même manière que l'option
-      <option>--exclude-table-data</option>, à l'exception qu'elle exclue
-      également les données des partitions et des tables enfant des tables
-      dont le nom correspond à <replaceable class="parameter">motif</replaceable>.
+      <option>--exclude-table-data</option>, à la différence qu'elle exclut
+      également les données des partitions et des tables enfants des tables
+      dont le nom correspond au <replaceable class="parameter">motif</replaceable>.
       </para>
      </listitem>
     </varlistentry>
@@ -895,10 +887,9 @@
      <listitem>
       <para>
        Utilise la valeur spécifiée pour <option>extra_float_digits</option>
-       lors de la
-       sauvegarde de valeurs en virgule flottante, au lieu de la précision
-       maximale disponible. Les sauvegardes de routine ne devraient pas
-       utiliser cette option.
+       lors de l'export de valeurs en virgule flottante, au lieu de la précision
+       maximale disponible. Cette option ne doit pas être utilisée pour des
+       exports de routine effectués à des fins de sauvegarde.
       </para>
      </listitem>
     </varlistentry>
@@ -907,9 +898,9 @@
      <term><option>--filter=<replaceable class="parameter">filename</replaceable></option></term>
      <listitem>
       <para>
-       Indique un nom de fichier à partir duquel lire les motifs des objets
-       exclus ou inclus d'une restauration. Les motifs sont interprétés
-       suivant les mêmes règles que les options correspondantes&nbsp;:
+       Spécifie un fichier à partir duquel lire les motifs des objets
+       à inclure ou à exclure de l'export. Les motifs sont interprétés
+       selon les mêmes règles que pour les options correspondantes&nbsp;:
        <option>-t</option>/<option>--table</option>,
        <option>--table-and-children</option>,
        <option>-T</option>/<option>--exclude-table</option> et
@@ -919,80 +910,78 @@
        schémas, <option>--include-foreign-data</option> pour les données des
        serveurs distants, <option>--exclude-table-data</option> et
        <option>--exclude-table-data-and-children</option> pour les données
-       des tables, et <option>-e</option>/<option>--extension</option> et
-       <option>--exclude-extension</option> pour les extensions. Pour lire à
-       partir de <literal>STDIN</literal>, utilisez <filename>-</filename>
+       des tables, et <option>-e</option>/<option>--extension</option> ainsi que
+       <option>--exclude-extension</option> pour les extensions. Pour lire
+       depuis <literal>STDIN</literal>, utilisez <filename>-</filename>
        comme nom de fichier. L'option <option>--filter</option> peut être
-       utilisé en même temps que les options listées ci-dessus pour inclure
-       ou exclure des objets, et peut aussi être utilisée plus d'une fois
-       pour prendre en compte plusieurs fichiers de filtre.
-
+       utilisée en complément des options ci-dessus pour inclure
+       ou exclure des objets, et peut également être spécifiée plusieurs fois
+       afin d'utiliser plusieurs fichiers de filtre.
       </para>
       <para>
-       Le fichier liste un motif de base par ligne en respectant le
-       format suivant&nbsp;:
+       Le fichier contient un motif d'objet par ligne, selon le format suivant&nbsp;:
 <synopsis>
 { include | exclude } { extension | foreign_data | table | table_and_children | table_data | table_data_and_children | schema } <replaceable class="parameter">PATTERN</replaceable>
 </synopsis>
       </para>
 
       <para>
-       Le premier mot clé indique si les objets correspondant aux motifs
-        doivent être inclus ou exclus. Le deuxième mot clé précise le
-        type d'objet à filtrer suivant le motif&nbsp;:
+        Le premier mot clé indique si les objets correspondants au motif
+        doivent être inclus ou exclus. Le second mot clé précise le
+        type d'objet à filtrer à l'aide du motif&nbsp;:
        <itemizedlist>
         <listitem>
          <para>
-          <literal>extension</literal>&nbsp;: extensions. Ceci fonctionne
+          <literal>extension</literal>&nbsp;: extensions. Fonctionne
           comme les options <option>-e</option>/<option>--extension</option>
           et <option>--exclude-extension</option>.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>foreign_data</literal>&nbsp;: données sur les serveurs
-          distants. Ceci fonctionne comme l'option
-          <option>--include-foreign-data</option>. Ce mot clé peut seulement
-          être utilisé avec le mot clé <literal>include</literal>.
+          <literal>foreign_data</literal>&nbsp;: données sur des serveurs
+          distants. Fonctionne comme l'option
+          <option>--include-foreign-data</option>. Ce mot clé ne peut
+          être utilisé qu'avec le mot clé <literal>include</literal>.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>table</literal>&nbsp;: tables. Ceci fonctionne comme les
+          <literal>table</literal>&nbsp;: tables. Fonctionne comme les
           options <option>-t</option>/<option>--table</option> et
           <option>-T</option>/<option>--exclude-table</option>.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>table_and_children</literal>&nbsp;: tables incluant des
-          partitions ou des tables enfants par héritage. Ceci fonctionne
+          <literal>table_and_children</literal>&nbsp;: tables, incluant les
+          partitions ou les tables enfants par héritage. Fonctionne
           comme les options <option>--table-and-children</option> et
           <option>--exclude-table-and-children</option>.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>table_data</literal>: données de table pour toute table
-          correspondant à <replaceable>pattern</replaceable>. Ceci
-          fonctionne comme l'option <option>--exclude-table-data</option>. Ce
-          mot clé peut seulement être utilisé avec le mot clé
+          <literal>table_data</literal>: données des tables
+          correspondantes au <replaceable>pattern</replaceable>.
+          Fonctionne comme l'option <option>--exclude-table-data</option>. Ce
+          mot clé ne peut être utilisé qu'avec le mot clé
           <literal>exclude</literal>.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>table_data_and_children</literal>&nbsp;: données de table
-          pour toute table correspondant à <replaceable>pattern</replaceable>
-          ainsi qu'à toute partition ou table enfant de la table sélectionnée.
-          Ceci fonctionne comme l'option
-          <option>--exclude-table-data-and-children</option>. Ce mot clé peut
-          seulement être utilisé avec le mot clé <literal>exclude</literal>.
+          <literal>table_data_and_children</literal>&nbsp;: données des tables
+          correspondantes au <replaceable>pattern</replaceable>,
+          ainsi que les partitions ou les tables enfants par héritage de la
+          table sélectionnée. Fonctionne comme l'option
+          <option>--exclude-table-data-and-children</option>. Ce mot clé ne peut
+          être utilisé qu'avec le mot clé <literal>exclude</literal>.
          </para>
         </listitem>
         <listitem>
          <para>
-          <literal>schema</literal>&nbsp;: schémas. Ceci fonctionne comme
+          <literal>schema</literal>&nbsp;: schémas. Fonctionne comme
           les options <option>-n</option>/<option>--schema</option> et
           <option>-N</option>/<option>--exclude-schema</option>.
          </para>
@@ -1001,16 +990,16 @@
       </para>
 
       <para>
-       Les lignes commençant avec <literal>#</literal> sont considérées
-       comme des commentaires et, de ce fait, sont ignorées. Les
-       commentaires peuvent aussi être placés après une ligne de motif
-       d'objet. Les lignes blanches sont elles-aussi ignorées. Voir
-       <xref linkend="app-psql-patterns"/> pour savoir comment réaliser
+       Les lignes commençant par <literal>#</literal> sont considérées
+       comme des commentaires et sont ignorées.
+       Des commentaires peuvent aussi être placés à la suite d'une ligne
+       contenant un motif d'objet. Les lignes vides sont elles-aussi ignorées.
+       Voir <xref linkend="app-psql-patterns"/> pour savoir comment réaliser
        l'échappement dans les motifs.
       </para>
 
       <para>
-       Les fichiers d'exemple sont listés dans la section <xref
+       Les fichiers d'exemple sont listés ci-dessous dans la section <xref
        linkend="pg-dump-examples"/>.
       </para>
       </listitem>
@@ -1023,7 +1012,7 @@
        Utilise des commandes <literal>DROP ... IF EXISTS</literal> pour
        supprimer des objets dans le mode <option>--clean</option>. Cela
        permet de supprimer les erreurs <quote>does not exist</quote> qui
-       seraient sinon renvoyées. Cette option n'est pas valide sauf si
+       seraient renvoyées sinon. Cette option n'est pas valide sauf si
        <option>--clean</option> est aussi indiquée.
       </para>
      </listitem>
@@ -1033,20 +1022,19 @@
      <term><option>--include-foreign-data=<replaceable class="parameter">foreignserver</replaceable></option></term>
      <listitem>
       <para>
-       Sauvegarde les données de toute table externe ayant comme serveur
-       distant <replaceable class="parameter">foreignserver</replaceable>.
-       Plusieurs serveurs distants peuvent être sélectionnés en utilisant
-       plusieurs fois l'options <option>--include-foreign-data</option>. De
-       plus, le paramètre <replaceable
-       class="parameter">foreignserver</replaceable> est interprété comme un
-       motif suivant les mêmes règles que celles utilisées par les commandes
-       <literal>\d</literal> de <application>psql</application> (voir <xref
-       linkend="app-psql-patterns"/>), donc plusieurs serveurs
-       distants peuvent aussi être sélectionnés en écrivant des caractères
-       joker dans le motif. Lors de l'utilisation des jokers, faites
-       attention à placer le motif entre guillemets pour empêcher le shell de
-       les prendre en compte&nbsp;; voir <xref linkend="pg-dump-examples"/>
-       ci-dessous. Le seule exception est qu'un motif vide est interdit.
+       Exporte les données de toute table externe dont le serveur distant
+       correspond à <replaceable class="parameter">foreignserver</replaceable>.
+       Plusieurs serveurs distants peuvent être sélectionnés en répétant
+       l'option <option>--include-foreign-data</option>. De plus,
+       le paramètre <replaceable class="parameter">foreignserver</replaceable>
+       est interprété comme un motif selon les mêmes règles que celles utilisées
+       par les commandes <literal>\d</literal> de <application>psql</application>
+       (voir <xref linkend="app-psql-patterns"/>), ce qui permet ainsi de
+       sélectionner plusieurs serveurs distants en utilisant des caractères
+       joker dans le motif. Lors de l'utilisation des jokers, prenez soin
+       d'encadrer le motif de guillemets simples si nécessaire, pour empêcher le
+       shell de les interpréter&nbsp;; voir <xref linkend="pg-dump-examples"/>
+       ci-dessous. Le seule exception est qu'un motif vide n'est pas autorisé.
       </para>
 
       <note>
@@ -1054,7 +1042,7 @@
         L'utilisation de jokers dans <option>--include-foreign-data</option>
         pourrait donner accès à des serveurs distants inattendus. De plus,
         pour utiliser cette option en toute sécurité, assurez-vous que le serveur
-        nommé a un propriétaire de confiance.
+        ciblé a un propriétaire de confiance.
        </para>
       </note>
 
@@ -1063,8 +1051,8 @@
         Quand <option>--include-foreign-data</option> est précisé,
         <application>pg_dump</application> ne vérifie pas que la table
         externe est accessible en écriture. De ce fait, il n'y a pas de
-        garantie que la sauvegarde des données de la table distante pourra
-        être restaurée sans erreurs.
+        garantie que l'export des données de la table distante pourra
+        être restauré sans erreurs.
        </para>
       </note>
      </listitem>
@@ -1074,14 +1062,14 @@
      <term><option>--inserts</option></term>
      <listitem>
       <para>
-       Extraire les données en tant que commandes <command>INSERT</command>
+       Extrait les données en tant que commandes <command>INSERT</command>
        (plutôt que <command>COPY</command>). Ceci rendra la restauration très
-       lente&nbsp;; c'est surtout utile pour créer des extractions qui
-       puissent être chargées dans des bases de données autres que
+       lente&nbsp;; c'est surtout utile pour créer des exports qui
+       puissent être chargés dans des bases de données autres que
        <productname>PostgreSQL</productname>. Toute erreur lors du
-       rechargement fera que seules les lignes comprises dans le
-       <command>INSERT</command> problématique seront perdues, plutôt que le
-       contenu entier de la table. Notez que la restauration pourrait échouer
+       rechargement causera uniquement la perte des lignes faisant partie du
+       <command>INSERT</command> problématique, et pas du contenu complet de
+       de la table. Notez que la restauration pourrait échouer
        si vous avez modifié l'ordre des colonnes. L'option
        <option>--column-inserts</option> protège contre les changements
        d'ordre des colonnes au prix de lenteurs supplémentaires.
@@ -1093,17 +1081,16 @@
      <term><option>--load-via-partition-root</option></term>
      <listitem>
       <para>
-       Lors de l'export de données d'une partition, faire que les instructions
-       <command>COPY</command> ou <command>INSERT</command> ciblent la racine
-       du partitionnement qui contient cette partition, plutôt que la
-       partition elle-même. Ceci fait que la partition appropriée soit
-       re-déterminée pour chaque ligne au moment du chargement. Ceci peut être
-       utile quand le rechargement des données se fait sur un serveur où les
-       lignes ne tomberont pas forcément dans les mêmes partitions que celles
-       du serveur original. Ceci pourrait arriver si la colonne de
-       partitionnement est de type text et que les deux systèmes ont une
-       définition différente du collationnement utilisé pour tier la colonne
-       de partitionnement.
+       Lors de l'export de données d'une partition, les instructions
+       <command>COPY</command> ou <command>INSERT</command> cibleront la racine
+       du partitionnement à laquelle elle appartient, plutôt que la
+       partition elle-même. Cela entraîne une réévaluation de la partition
+       appropriée pour chaque ligne au moment du chargement. Ceci peut être
+       utile lors de la restauration sur un serveur où les lignes ne seraient pas
+       forcément réparties dans les mêmes partitions que sur le serveur d'origine.
+       Cela peut se produire, par exemple, si la colonne de partitionnement est
+       de type text et que les deux systèmes ont des définitions différentes du
+       collationnement utilisé pour trier cette colonne.
       </para>
      </listitem>
     </varlistentry>
@@ -1113,12 +1100,12 @@
      <listitem>
       <para>
        Ne pas attendre indéfiniment l'acquisition de verrous partagés sur
-       table au démarrage de l'extraction. Échouer à la place s'il est
-       impossible de verrouiller une table dans le temps d'<replaceable
-       class="parameter">expiration</replaceable> indiqué. L'expiration peut
-       être spécifiée dans tous les formats acceptés par <command>SET
-        statement_timeout</command>, les valeurs autorisées dépendant de la
-       version du serveur sur laquelle vous faites l'extraction, mais une
+       les tables au démarrage de l'export. L'opération échoue s'il est
+       impossible de verrouiller une table dans le délai spécifié par le
+       paramètre <replaceable class="parameter">timeout</replaceable>.
+       Le délai peut être exprimé dans l'un des formats acceptés par la commande
+       <command>SET statement_timeout</command>. Les formats autorisés dépendent
+       de la version du serveur sur laquelle l'export est effectué, mais une
        valeur entière en millisecondes est acceptée par toutes les versions.
       </para>
      </listitem>
@@ -1128,7 +1115,7 @@
      <term><option>--no-comments</option></term>
      <listitem>
       <para>
-       Do not dump <command>COMMENT</command> commands.
+       Ne pas exporter les instructions <command>COMMENT</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -1137,7 +1124,7 @@
      <term><option>--no-data</option></term>
      <listitem>
       <para>
-       Do not dump data.
+       Ne pas exporter les données.
       </para>
      </listitem>
     </varlistentry>
@@ -1146,7 +1133,7 @@
      <term><option>--no-policies</option></term>
      <listitem>
       <para>
-       Do not dump row security policies.
+       Ne pas exporter les politiques de sécurité niveau ligne.
       </para>
      </listitem>
     </varlistentry>
@@ -1155,7 +1142,7 @@
      <term><option>--no-publications</option></term>
      <listitem>
       <para>
-       Ne pas sauvegarder les publications.
+       Ne pas exporter les publications.
       </para>
      </listitem>
     </varlistentry>
@@ -1164,7 +1151,7 @@
      <term><option>--no-schema</option></term>
      <listitem>
       <para>
-       Do not dump schema (data definitions).
+       Ne pas exporter les schémas (les définitions des données).
       </para>
      </listitem>
     </varlistentry>
@@ -1173,7 +1160,7 @@
      <term><option>--no-security-labels</option></term>
      <listitem>
       <para>
-       Ne pas sauvegarder les labels de sécurité.
+       Ne pas exporter les labels de sécurité.
       </para>
      </listitem>
     </varlistentry>
@@ -1182,7 +1169,7 @@
      <term><option>--no-statistics</option></term>
      <listitem>
       <para>
-       Do not dump statistics.
+       Ne pas exporter les statistiques.
       </para>
      </listitem>
     </varlistentry>
@@ -1191,7 +1178,7 @@
      <term><option>--no-subscriptions</option></term>
      <listitem>
       <para>
-       Ne pas sauvegarder les souscriptions.
+       Ne pas exporter les souscriptions.
       </para>
      </listitem>
     </varlistentry>
@@ -1200,13 +1187,13 @@
      <term><option>--no-sync</option></term>
      <listitem>
       <para>
-       Par défaut, <command>pg_dump</command> attendra que tous les fichiers
-       aient été écrits de manière sûre sur disque.  Cette option force
-       <command>pg_dump</command> à rendre la main sans attendre, ce qui est
-       plus rapide, mais signifie qu'un arrêt brutal du serveur survenant
-       après la sauvegarde peut laisser la sauvegarde dans un état corrompu.
-       De manière générale, cette option est utile durant les tests mais ne
-       devrait pas être utilisée dans un environnement de production.
+       Par défaut, <command>pg_dump</command> attend que tous les fichiers
+       soient correctement écrits sur disque. Cette option permet à
+       <command>pg_dump</command> de rendre la main immédiatement, sans attendre,
+       ce qui est plus rapide, mais peut entraîner une corruption de l'export
+       en cas d'arrêt brutal du système d'exploitation.
+       De manière générale, cette option est utile pour les tests, mais ne
+       doit pas être utilisée dans un environnement de production.
       </para>
      </listitem>
     </varlistentry>
@@ -1216,14 +1203,14 @@
      <listitem>
       <para>
        Ne pas générer de commandes pour sélectionner les méthodes d'accès
-       aux tables. Avec cette option, tous les objets seront créés avec la
-       méthode d'accès par défaut au moment de la restauration.
+       aux tables. Avec cette option, tous les objets seront créés en utilisant
+       la méthode d'accès par défaut au moment de la restauration.
       </para>
 
       <para>
-       Cette option est ignorée lors de la création d'un fichier d'archive
-       (non texte). Pour les formats d'archivage, vous pouvez indiquer
-       l'option lors de l'appel à <command>pg_restore</command>.
+       Cette option est ignorée lors de la génération d'un fichier dans un
+       format d'archive (non texte). Pour les formats d'archive, vous pouvez
+       spécifier cette option lors de l'appel à <command>pg_restore</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -1232,15 +1219,15 @@
      <term><option>--no-tablespaces</option></term>
      <listitem>
       <para>
-       Ne pas générer de commandes pour créer des tablespace, ni sélectionner
-       de tablespace pour les objets. Avec cette option, tous les objets
-       seront créés dans le tablespace par défaut durant la restauration.
+       Ne pas générer de commandes pour sélectionner les tablespaces.
+       Avec cette option, tous les objets seront créés dans le tablespace
+       par défaut au moment de la restauration.
       </para>
 
       <para>
-       Cette option n'a de sens que pour le format texte simple. Pour les
-       formats d'archive, vous pouvez spécifier cette option quand vous
-       appelez <command>pg_restore</command>.
+       Cette option n'a d'intérêt que pour le format texte. Pour les formats
+       archive, l'option est précisée à l'appel de
+       <command>pg_restore</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -1249,10 +1236,10 @@
      <term><option>--no-toast-compression</option></term>
      <listitem>
       <para>
-       Ne génère pas de commandes pour définir les méthodes de compression
+       Ne pas générer d'instructions pour définir les méthodes de compression
        <acronym>TOAST</acronym>.
-       Avec cette option, toutes les colonnes seront restaurées avec la méthode de
-       compression par défaut en vigueur au moment de la restauration.
+       Avec cette option, toutes les colonnes seront restaurées avec la méthode
+       de compression par défaut en vigueur au moment de la restauration.
       </para>
      </listitem>
     </varlistentry>
@@ -1262,11 +1249,10 @@
      <listitem>
       <para>
        Ne pas exporter le contenu des tables et séquences non journalisées
-       (unlogged).  Cette option n'a aucun effet sur le fait que la définition
-       (schéma) des tables et séquences soit exportée ou non&nbsp;; seul
-       l'export des données de la table et de la séquence est supprimé. Les
-       données des tables et séquences non journalisées sont toujours exclues
-       lors d'une sauvegarde à partir d'un serveur en standby.
+       (unlogged). Cette option n'a aucun effet sur l'export des définitions
+       des tables et des séquences (le schéma)&nbsp;; elle supprime uniquement
+       l'export des données. Les données des tables et séquences non journalisées
+       sont toujours exclues lors d'un export depuis un serveur en standby.
       </para>
      </listitem>
     </varlistentry>
@@ -1278,7 +1264,7 @@
        Ajouter <literal>ON CONFLICT DO NOTHING</literal> aux commandes
        <command>INSERT</command>. Cette option n'est seulement valide que si
        <option>--inserts</option>, <option>--column-inserts</option> ou
-       <option>--rows-per-insert</option> est aussi utilisée.
+       <option>--rows-per-insert</option> sont aussi spécifiés.
       </para>
      </listitem>
     </varlistentry>
@@ -1287,18 +1273,18 @@
      <term><option>--quote-all-identifiers</option></term>
      <listitem>
       <para>
-       Force la mise entre guillemets de tous les identifiants. Cette option
-       est recommandée lors de la sauvegarde d'un serveur
-       <productname>PostgreSQL</productname> dont la version majeure est
-       différente de celle du <application>pg_dump</application> ou quand le
-       résultat est prévu d'être rechargé dans une autre version majeure. Par
-       défaut, <application>pg_dump</application> met entre guillemets
-       uniquement les identifiants qui sont des mots réservés dans sa propre
-       version majeure. Ceci peut poser parfois des problèmes de compatibilité
-       lors de l'utilisation de serveurs de versions différentes qui auraient
-       des ensembles différents de mots clés. Utiliser
-       <option>--quote-all-identifiers</option> empêche ce type de problèmes
-       au prix d'un script résultant plus difficile à lire.
+       Forcer la mise entre guillemets de tous les identifiants. Cette option
+       est recommandée lorsqu'on exporte une base de données depuis un serveur
+       dont la version majeure de <productname>PostgreSQL</productname> diffère
+       de celle de <application>pg_dump</application>, ou lorsque l'export
+       est destiné à être rechargé dans une version majeure différente.
+       Par défaut, <application>pg_dump</application> ne met entre guillemets
+       que les identifiants correspondants à des mots réservés dans sa propre
+       version majeure. Cela peut parfois entraîner des problèmes de compatibilité
+       avec des serveurs de versions différentes, dont la liste des mots
+       réservés peut légèrement varier. L'utilisation de l'option
+       <option>--quote-all-identifiers</option> permet d'éviter ce type de problème,
+       au prix d'un script d'export moins lisible.
       </para>
      </listitem>
     </varlistentry>
@@ -1307,8 +1293,8 @@
      <term><option>--rows-per-insert=<replaceable class="parameter">nlignes</replaceable></option></term>
      <listitem>
       <para>
-       Sauvegarde les données sous la forme de commandes
-       <command>INSERT</command> (plutôt qu'avec <command>COPY</command>).
+       Exporter les données sous la forme de commandes
+       <command>INSERT</command> (au lieu de <command>COPY</command>).
        Contrôle le nombre maximum de lignes par commande
        <command>INSERT</command>. La valeur indiquée doit être strictement
        positive. Toute erreur lors du rechargement provoquera uniquement la
@@ -1322,21 +1308,20 @@
      <term><option>--section=<replaceable class="parameter">nom_section</replaceable></option></term>
      <listitem>
       <para>
-       Sauvegarde seulement la section nommée. Le nom de la section peut être
+       N'exporter que la section spécifiée. Le nom de la section peut être
        <option>pre-data</option>, <option>data</option> ou
-       <option>post-data</option>. Cette option peut être spécifiée plus d'une
-       fois pour sélectionner plusieurs sections. La valeur par défaut est
-       toutes les sections.
+       <option>post-data</option>. Cette option peut être répétée pour sélectionner
+       plusieurs sections. Par défaut, toutes les sections sont exportées.
       </para>
 
       <para>
-       La section data contient toutes les données des tables, le contenu des
-       Large Objects, les statistiques pour les tables et vues matérialisées,
-       et les valeurs des séquences. Les éléments
-       post-data incluent la définition des index, triggers, règles,
-       statistiques pour les index et
-       contraintes (autres que les contraintes de vérification validées). Les
-       éléments pre-data incluent en tous les autres éléments de définition.
+       La section data contient les données réelles des tables, le contenu des
+       Large Objects, les valeurs des séquences et les statistiques associées
+       aux tables, vues matérialisées et tables externes. Les éléments de la
+       section post-data incluent la définition des index, triggers, règles,
+       statistiques sur les index et les contraintes (autres que les contraintes
+       de vérification validées). Les éléments de la section pre-data
+       regroupent tous les autres éléments de définition de données.
       </para>
      </listitem>
     </varlistentry>
@@ -1345,9 +1330,9 @@
      <term><option>--sequence-data</option></term>
      <listitem>
       <para>
-       Include sequence data in the dump.  This is the default behavior except
-       when <option>--no-data</option>, <option>--schema-only</option>, or
-       <option>--statistics-only</option> is specified.
+       Inclure les données des séquences dans l'export. Ce comportement est activé
+       par défaut, sauf si l'on utilise les options <option>--no-data</option>,
+       <option>--schema-only</option> ou <option>--statistics-only</option>.
       </para>
      </listitem>
     </varlistentry>
@@ -1357,35 +1342,34 @@
      <listitem>
       <para>
        Utiliser une transaction <literal>sérialisable</literal> pour l'export,
-       pour garantir que l'instantané utilisé est cohérent avec les états
-       futurs de la base; mais ceci est effectué par l'attente d'un point dans
-       le flux des transactions auquel aucune anomalie ne puisse être
-       présente, afin qu'il n'y ait aucun risque que l'export échoue ou cause
+       afin de garantir que l'instantané utilisé soit cohérent avec les états
+       futurs de la base. Cela est réalisé en attendant un point dans
+       le flux des transactions où aucune anomalie ne peut être présente,
+       de sorte qu'il n'y ait aucun risque que l'export échoue ou provoque
        l'annulation d'une autre transaction pour <literal>erreur de
-        sérialisation</literal>. Voyez <xref linkend="mvcc"/> pour davantage
+        sérialisation</literal>. Voir <xref linkend="mvcc"/> pour davantage
        d'informations sur l'isolation des transactions et le contrôle d'accès
        concurrent.
       </para>
 
       <para>
-       Cette option est inutile pour une sauvegarde qui ne sera utilisée qu'en cas de
-       récupération après sinistre. Elle pourrait être utile pour une sauvegarde
-       utilisée pour charger une copie de la base pour du reporting ou toute
-       autre activité en lecture seule tandis que la base originale continue à
-       être mise à jour. Sans cela, la sauvegarde serait dans un état incohérent
-       avec l'exécution sérielle des transactions qui auront été finalement
-       validées. Par exemple, si un traitement de type batch est exécuté, un
-       batch pourrait apparaître comme terminé dans la sauvegarde sans que tous les
-       éléments du batch n'apparaissent.
+       Cette option n'est pas utile pour un export uniquement destiné à une
+       récupération après sinistre. Elle peut en revanche être utile si l'export
+       est utilisé pour charger une copie de la base pour du reporting ou toute
+       autre activité en lecture seule, pendant que la base d'origine continue à
+       être mise à jour. Sans cela, l'export serait dans un état incohérent
+       avec l'exécution en parallèle des transactions qui auraient été validées
+       entre temps. Par exemple, si un traitement de type batch est exécuté, un
+       batch pourrait apparaître comme terminé dans l'export sans que tous les
+       éléments qu'il contient y figurent.
       </para>
 
       <para>
-       Cette option ne fera aucune différence si aucune transaction en
+       Cette option n'aura aucun effet si aucune transaction en
        lecture-écriture n'est active au lancement de pg_dump. Si des
-       transactions en lecture-écriture sont actives, le démarrage de la sauvegarde
-       pourrait être retardé pour une durée indéterminée. Une fois qu'il sera
-       démarré, la performance est identique à celle de la sauvegarde sans cette
-       option.
+       transactions en lecture-écriture sont actives, le démarrage de l'export
+       peut être retardé pour une durée indéterminée. Une fois l'export lancé,
+       les performances sont identiques, que l'option soit activée ou non.
       </para>
      </listitem>
     </varlistentry>
@@ -1394,22 +1378,21 @@
      <term><option>--snapshot=<replaceable class="parameter">nom_snapshot</replaceable></option></term>
      <listitem>
       <para>
-       Utilise l'image de base de données synchronisée spécifiée lors de la
-       sauvegarde d'une base de données (voir <xref
+       Utiliser l'instantané synchronisé spécifié lors de l'export de la base
+       de données (voir <xref
        linkend="functions-snapshot-synchronization-table"/> pour plus de
        détails).
       </para>
 
       <para>
-       Cette option est utile lorsqu'il est nécessaire de synchroniser la
-       sauvegarde avec un slot de réplication logique (voir <xref
+       Cette option est utile lorsqu'il est nécessaire de synchroniser l'export
+       avec un slot de réplication logique (voir <xref
        linkend="logicaldecoding"/>) ou avec une session concurrente.
       </para>
 
       <para>
-       Dans le cas d'une sauvegarde parallèle, le nom de l'image défini par
-       cette option est utilisé plutôt que de prendre une nouvelle image de
-       base.
+       Dans le cas d'un export en parallèle, le nom d'instantané défini par
+       cette option est utilisé au lieu de créer un nouvel instantané.
       </para>
      </listitem>
     </varlistentry>
@@ -1418,8 +1401,8 @@
      <term><option>--statistics-only</option></term>
      <listitem>
       <para>
-       Dump only the statistics, not the schema (data definitions) or data.
-       Statistics for tables, materialized views, and indexes are dumped.
+       Extraire uniquement les statistiques, sans le schéma (définitions des données) ni les données.
+       Les statistiques des tables, des vues matérialisées et des index sont exportées.
       </para>
      </listitem>
     </varlistentry>
@@ -1428,25 +1411,24 @@
      <term><option>--strict-names</option></term>
      <listitem>
       <para>
-       Implique que chaque qualificateur d'extension (<option>-e</option>/
-       <option>--extension</option>), de schéma(<option>-n</option>/<option>--schema</option>)
-       et de table (<option>-t</option>/<option>--table</option>)
-       corresponde à au moins un ou une extension/schéma/table dans la base à
-       sauvegarder.
-       Ceci s'applique aussi aux filtres utilisés avec
-       <option>--filter</option>.
-       Notez que, si aucun motif d'extension/schéma/table ne trouve une correspondance,
-       <application>pg_dump</application> générera une erreur, y compris sans
-       <option>--strict-names</option>.
+       Exiger que chaque motif d'extension (<option>-e</option>/
+       <option>--extension</option>), de schéma (<option>-n</option>/<option>--schema</option>)
+       ou de table (<option>-t</option>/<option>--table</option>)
+       corresponde à au moins une extension, un schéma ou une table dans la
+       base de données à exporter. Cela s'applique également aux filtres
+       utilisés avec <option>--filter</option>.
+       Notez que si aucun des motifs d'extension, de schéma ou de table ne
+       trouve de correspondance, <application>pg_dump</application> renverra
+       une erreur même sans <option>--strict-names</option>.
       </para>
 
       <para>
        Cette option n'a pas d'effet sur
        <option>--exclude-extension</option>,
        <option>-N</option> / <option>--exclude-schema</option>,
-       <option>-T</option> / <option>--exclude_table</option> et
-       <option>--exclude-table-date</option>. Tout échec de correspondance
-       pour un motif d'exclusion n'est pas considéré comme une erreur.
+       <option>-T</option> / <option>--exclude_table</option> ou
+       <option>--exclude-table-date</option>. Un motif d'exclusion
+       ne correspondant à aucun objet n'est pas considéré comme une erreur.
       </para>
      </listitem>
     </varlistentry>
@@ -1455,22 +1437,21 @@
      <term><option>--sync-method=<replaceable class="parameter">method</replaceable></option></term>
      <listitem>
       <para>
-       Quand il est initialisé à <literal>fsync</literal>, qui est la valeur
+       Lorsqu'elle est définie à <literal>fsync</literal>, qui est la valeur
        par défaut, <command>pg_dump --format=directory</command> va ouvrir
-       récursivement tous les fichiers du répertoire d'archivage et les
+       récursivement tous les fichiers du répertoire d'archives et les
        synchroniser sur disque.
       </para>
       <para>
        Sur Linux, <literal>syncfs</literal> peut être utilisé à la place
-       pour demander au système d'exploitation de synchroniser le système
-       de fichiers complet qui contient le répertoire d'archivage. Voir
-       <xref linkend="guc-recovery-init-sync-method"/> pour plus d'informations
-       sur les points importants à connaître lors de l'utilisation de
-       <literal>syncfs</literal>.
+       pour demander au système d'exploitation de synchroniser l'ensemble
+       du système de fichiers contenant le répertoire d'archives. Voir
+       <xref linkend="guc-recovery-init-sync-method"/> pour les précautions
+       à connaître lors de l'utilisation de <literal>syncfs</literal>.
       </para>
       <para>
-       Cette option n'a aucun effet quand <option>--no-sync</option> est
-       utilisé et quand <option>--format</option> n'est pas configuré à
+       Cette option n'a aucun effet si <option>--no-sync</option> est
+       utilisé ou si <option>--format</option> n'est pas défini à
        <literal>directory</literal>.
       </para>
      </listitem>
@@ -1481,9 +1462,9 @@
      <listitem>
       <para>
 	   Cette option fonctionne de la même manière que l'option
-	   <option>-t</option>/<option>--table</option>, à l'exception qu'elle inclue
-	   également les partitions et les tables enfant des tables dont le nom
-	   correspond à <replaceable class="parameter">motif</replaceable>.
+       <option>-t</option>/<option>--table</option>, à la différence qu'elle inclut
+       également les partitions et les tables enfants des tables dont le nom
+       correspond au <replaceable class="parameter">motif</replaceable>.
       </para>
      </listitem>
     </varlistentry>
@@ -1494,12 +1475,12 @@
       <para>
        Émettre des commandes SQL standard <command>SET SESSION
         AUTHORIZATION</command> à la place de commandes <command>ALTER
-        OWNER</command> pour déterminer l'appartenance d'objet. Ceci rend
+        OWNER</command> pour définir la propriété des objets. Ceci rend
        l'extraction davantage compatible avec les standards, mais, suivant
-       l'historique des objets de l'extraction, peut ne pas se restaurer
+       l'historique des objets exportés, la restauration pourrait ne pas fonctionner
        correctement. Par ailleurs, une extraction utilisant <command>SET
         SESSION AUTHORIZATION</command> nécessitera certainement des droits
-       superutilisateur pour se restaurer correctement, alors que
+       superutilisateur pour être restaurée correctement, alors que
        <command>ALTER OWNER</command> nécessite des droits moins élevés.
       </para>
      </listitem>
@@ -1509,7 +1490,7 @@
      <term><option>--with-data</option></term>
      <listitem>
       <para>
-       Dump data. This is the default.
+       Exporter les données. C'est le comportement par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -1518,7 +1499,7 @@
      <term><option>--with-schema</option></term>
      <listitem>
       <para>
-       Dump schema (data definitions). This is the default.
+       Exporter le schéma (définitions des données). C'est le comportement par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -1527,7 +1508,7 @@
      <term><option>--with-statistics</option></term>
      <listitem>
       <para>
-       Dump statistics. This is the default.
+       Exporter les statistiques. C'est le comportement par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -1537,8 +1518,8 @@
      <term><option>--help</option></term>
      <listitem>
       <para>
-       Affiche l'aide sur les arguments en ligne de commande de
-       <application>pg_dump</application>, puis quitte
+       Afficher l'aide sur les arguments en ligne de commande de
+       <application>pg_dump</application>, puis quitter.
       </para>
      </listitem>
     </varlistentry>
@@ -1546,7 +1527,7 @@
   </para>
 
   <para>
-   Les options de ligne de commande suivantes gèrent les paramètres de
+   Les options de ligne de commande suivantes contrôlent les paramètres de
    connexion&nbsp;:
 
    <variablelist>
@@ -1555,12 +1536,12 @@
      <term><option>--dbname=<replaceable class="parameter">nom_base</replaceable></option></term>
      <listitem>
       <para>
-       Indique le nom de la base de données de connexion. Ceci revient à
+       Indique le nom de la base de données à laquelle se connecter. Ceci revient à
        spécifier <replaceable class="parameter">nom_base</replaceable> comme
-       premier argument sans option sur la ligne de commande. Ce nom de base
+       premier argument non optionnel sur la ligne de commande. Ce nom
        peut être remplacé par une <link linkend="libpq-connstring">chaîne de
         connexion</link>. Dans ce cas, les paramètres de la chaîne de connexion
-       surchargeront toutes les options en ligne de commande conflictuelles.
+       surchargeront toute option de ligne de commande conflictuelle.
       </para>
      </listitem>
     </varlistentry>
@@ -1570,12 +1551,12 @@
      <term><option>--host <replaceable class="parameter">hôte</replaceable></option></term>
      <listitem>
       <para>
-       Le nom d'hôte de la machine sur laquelle le serveur de bases de données
-       est exécuté. Si la valeur commence par une barre oblique (/), elle est
-       utilisée comme répertoire pour le socket de domaine Unix. La valeur par
-       défaut est fournie par la variable d'environnement
-       <envar>PGHOST</envar>, si elle est initialisée. Dans le cas contraire,
-       une connexion sur la socket de domaine Unix est tentée.
+       Indique le nom d'hôte de la machine sur laquelle le serveur de bases de
+       données est en cours d'exécution. Si la valeur commence par une barre
+       oblique (/), elle est interprétée comme le répertoire du socket de
+       domaine Unix. Par défaut, la valeur est tirée de la variable
+       d'environnement <envar>PGHOST</envar>, si elle est définie&nbsp;;
+       sinon, une connexion via socket de domaine Unix est tentée.
       </para>
      </listitem>
     </varlistentry>
@@ -1585,10 +1566,10 @@
      <term><option>--port <replaceable class="parameter">port</replaceable></option></term>
      <listitem>
       <para>
-       Le port TCP ou le fichier local de socket de domaine Unix sur lequel le
-       serveur écoute les connexions. La valeur par défaut est fournie par la
-       variable d'environnement <envar>PGPORT</envar>, si elle est
-       initialisée. Dans le cas contraire, il s'agit de la valeur fournie à la
+       Indique le port TCP ou le suffixe du fichier socket de domaine Unix local
+       sur lequel le serveur écoute les connexions. La valeur par défaut est
+       celle de la variable d'environnement <envar>PGPORT</envar>, si elle est
+       définie. Dans le cas contraire, il s'agit de la valeur fournie à la
        compilation.
       </para>
      </listitem>
@@ -1599,7 +1580,7 @@
      <term><option>--username <replaceable class="parameter">nomutilisateur</replaceable></option></term>
      <listitem>
       <para>
-       Le nom d'utilisateur utilisé pour la connexion.
+       Indique le nom d'utilisateur utilisé pour la connexion.
       </para>
      </listitem>
     </varlistentry>
@@ -1609,12 +1590,12 @@
      <term><option>--no-password</option></term>
      <listitem>
       <para>
-       Ne demande jamais un mot de passe. Si le serveur en réclame un pour
-       l'authentification et qu'un mot de passe n'est pas disponible d'une
-       autre façon (par exemple avec le fichier <filename>.pgpass</filename>),
-       la tentative de connexion échouera. Cette option peut être utile pour
-       les scripts où aucun utilisateur n'est présent pour saisir un mot de
-       passe.
+       Ne jamais demander de mot de passe. Si le serveur requiert une
+       authentification par mot de passe et qu'aucun mot de passe n'est disponible
+       par un autre moyen (par exemple via le fichier <filename>.pgpass</filename>),
+       la tentative de connexion échouera. Cette option peut être utile dans les
+       scripts ou les traitements de type batch, où aucun utilisateur
+       n'est présent pour saisir un mot de passe.
       </para>
      </listitem>
     </varlistentry>
@@ -1629,13 +1610,13 @@
       </para>
 
       <para>
-       Cette option n'est jamais nécessaire car
+       Cette option n'est jamais indispensable car
        <application>pg_dump</application> demande automatiquement un mot de
        passe si le serveur exige une authentification par mot de passe.
        Néanmoins, <application>pg_dump</application> perd une tentative de
-       connexion pour tester si le serveur demande un mot de passe. Dans
+       connexion pour tester si le serveur requiert un mot de passe. Dans
        certains cas, il est préférable d'ajouter l'option <option>-W</option>
-       pour éviter la tentative de connexion.
+       pour éviter cette tentative de connexion supplémentaire.
       </para>
      </listitem>
     </varlistentry>
@@ -1644,7 +1625,7 @@
      <term><option>--role=<replaceable class="parameter">nomrole</replaceable></option></term>
      <listitem>
       <para>
-       Spécifie un rôle à utiliser pour créer l'extraction. Avec cette option,
+       Spécifie un rôle à utiliser pour réaliser l'export. Avec cette option,
        <application>pg_dump</application> émet une commande <command>SET
         ROLE</command> <replaceable class="parameter">nomrole</replaceable>
        après s'être connecté à la base. C'est utile quand l'utilisateur
@@ -1652,7 +1633,7 @@
        <application>pg_dump</application> a besoin, mais peut basculer vers un
        rôle qui les a. Certaines installations ont une politique qui est
        contre se connecter directement en tant que superutilisateur, et
-       l'utilisation de cette option permet que les extractions soient faites
+       l'utilisation de cette option permet que les exports soient faits
        sans violer cette politique.
       </para>
      </listitem>
@@ -1738,78 +1719,77 @@
   </para>
 
   <para>
-   Quand une sauvegarde sans structure est sélectionnée et que l'option
+   Lorsqu'une extraction sans schéma est demandée et que l'option
    <option>--disable-triggers</option> est utilisée,
-   <application>pg_dump</application> engendre des commandes de désactivation
-   des triggers sur les tables utilisateur avant l'insertion des données,
-   puis après coup, des commandes de réactivation après l'insertion. Si la
-   restauration est interrompue, il se peut que les catalogues systèmes
-   conservent cette position.
+   <application>pg_dump</application> émet des commandes pour désactiver les
+   triggers sur les tables utilisateur avant l'insertion des données,
+   puis des commandes pour les réactiver après l'insertion. Si la restauration
+   est interrompue en cours d'exécution, les catalogues système peuvent se
+   retrouver dans un état incohérent.
   </para>
 
   <para>
-   By default, <command>pg_dump</command> will include most optimizer
-   statistics in the resulting dump file.  However, some statistics may not be
-   included, such as those created explicitly with <xref
-   linkend="sql-createstatistics"/> or custom statistics added by an
-   extension.  Therefore, it may be useful to run <command>ANALYZE</command>
-   after restoring from a dump file to ensure optimal performance; see <xref
-   linkend="vacuum-for-statistics"/> and <xref linkend="autovacuum"/> for more
-   information.
+   Si l'option <option>--with-statistics</option> est spécifiée,
+   <command>pg_dump</command> inclura la plupart des statistiques de l'optimiseur
+   dans le fichier d'export généré. Cependant, certaines statistiques peuvent
+   ne pas être incluses, comme celles créées explicitement avec
+   <xref linkend="sql-createstatistics"/> ou des statistiques personnalisées
+   ajoutées par une extension. Il peut donc être utile d'exécuter <command>ANALYZE</command>
+   après la restauration d'un export afin de garantir des performances optimales.
+   Voir <xref linkend="vacuum-for-statistics"/> et <xref linkend="autovacuum"/>
+   pour plus d'informations.
   </para>
 
   <para>
    Parce que <application>pg_dump</application> est utilisé pour transférer
-   des données vers des nouvelles versions de
-   <productname>PostgreSQL</productname>, la sortie de
-   <application>pg_dump</application> devra pouvoir se charger dans les
-   versions du serveur <productname>PostgreSQL</productname> plus récentes que
-   la version de <application>pg_dump</application>.
-   <application>pg_dump</application> peut aussi extraire des données de
-   serveurs <productname>PostgreSQL</productname> plus anciens que sa propre
-   version. (À l'heure actuelle, les versions de serveurs supportées vont
-   jusqu'à la 9.2.) Toutefois, <application>pg_dump</application> ne peut pas
-   réaliser d'extraction de serveurs <productname>PostgreSQL</productname>
-   plus récents que sa propre version majeure&nbsp;; il refusera même
-   d'essayer, plutôt que de risquer de fournir une extraction invalide. Par
-   ailleurs, il n'est pas garanti que la sortie de
-   <application>pg_dump</application> puisse être chargée dans un serveur
-   d'une version majeure plus ancienne&nbsp;&mdash; pas même si l'extraction a
-   été faite à partir d'un serveur dans cette version. Charger un fichier
-   d'extraction dans un serveur de version plus ancienne pourra requérir une
-   édition manuelle du fichier pour supprimer les syntaxe incomprises de
-   l'ancien serveur. L'utilisation de l'option
-   <option>--quote-all-identifiers</option> est recommendée lors de
-   l'utilisation avec des versions différentes, car cela permet d'empêcher la
-   venue de problèmes provenant de listes de mots clés dans différentes
-   versions de <productname>PostgreSQL</productname>.
+   des données vers de nouvelles versions de
+   <productname>PostgreSQL</productname>, sa sortie doit pouvoir être chargée
+   dans des serveurs <productname>PostgreSQL</productname> plus récents
+   que la version de <application>pg_dump</application> elle-même.
+   <application>pg_dump</application> peut également extraire des données
+   de serveurs <productname>PostgreSQL</productname> plus anciens que sa propre
+   version. (Actuellement, les versions serveur prises en charge remontent
+   jusqu'à la 9.2.) En revanche, <application>pg_dump</application> ne peut pas
+   extraire de données depuis un serveur <productname>PostgreSQL</productname>
+   dont la version majeure est plus récente que la sienne&nbsp;; il refusera même
+   d'essayer, afin d'éviter de produire un export invalide. De plus, rien
+   ne garantit que la sortie de <application>pg_dump</application> puisse être
+   chargée dans un serveur d'une version majeure plus ancienne &nbsp;&mdash;
+   même si les données ont été extraites depuis une telle version. Restaurer
+   un export dans un serveur de version plus ancienne pourrait nécessiter de
+   modifier manuellement le fichier pour retirer les syntaxes non reconnues par
+   cette version. L'utilisation de l'option
+   <option>--quote-all-identifiers</option> est recommandée lors de
+   l'utilisation de versions différentes, afin d'éviter certains problèmes liés
+   aux différences entre les listes de mots réservés d'une version à l'autre
+   de <productname>PostgreSQL</productname>.
   </para>
 
   <para>
-   Lors de la sauvegarde des souscription de réplication logique,
+   Lors de l'export des souscriptions de réplication logique,
    <application>pg_dump</application> générera des commandes <command>CREATE
-   SUBSCRIPTION</command> qui utilisent l'option <literal>connect =
-   false</literal>, afin que la restauration des souscriptions ne fasse pas de
-   connexions distantes pour créer un slot de réplication ou pour la copie
-   initiale de table.  De cette façon, la sauvegarde peut être restaurée sans
-   avoir besoin d'un accès réseau aux serveurs distants.  Il est alors à la
-   charge de l'utilisateur de réactiver les souscriptions de manière adaptée.
-   Si les hôtes impliquées ont changés, l'information de connexion pourrait
-   nécessiter d'être changée.  Il pourrait également être approprié de tronquer
-   les tables cibles avant de lancer une nouvelle copie complète des tables.  Si
-   les utilisateurs ont pour but de copier les données originales lors du
-   rafraichissement, ils doivent créer le slot avec <link
-   linkend="sql-createsubscription-params-with-two-phase"><literal>two_phase</literal></link>.
-   Après la synchronisation initiale, l'option
-   <literal>two_phase</literal> sera automatiquement activée si la souscription
-   a été créée à l'origine avec l'option <literal>two_phase = true</literal>.
+    SUBSCRIPTION</command> utilisant l'option <literal>connect = false</literal>,
+   afin que la restauration de la souscription n'établisse pas de connexion
+   distante pour créer un slot de réplication ou pour effectuer la copie
+   initiale des tables. De cette façon, l'export peut être restauré sans
+   nécessiter d'accès réseau aux serveurs distants. Il revient alors à
+   l'utilisateur de réactiver les souscriptions de manière appropriée.
+   Si les hôtes concernés ont changé, les informations de connexion devront
+   être mises à jour. Il peut également être pertinent de tronquer les tables
+   cibles avant de lancer une nouvelle copie complète. Si les utilisateurs
+   souhaitent copier les données initiales lors du rafraîchissement, ils
+   doivent créer le slot avec <literal>two_phase = false</literal>. Après la
+   synchronisation initiale, l'option <link
+   linkend="sql-createsubscription-params-with-two-phase"><literal>two_phase</literal></link>
+   sera automatiquement activée si la souscription a été initialement créée avec
+   l'option <literal>two_phase = true</literal>.
   </para>
 
   <para>
-   Il est généralement recommendé d'utiliser l'option <option>-X</option>
-   (<option>--no-psqlrc</option>) lors de la restauration d'une base à partir
-   d'un script texte de <application>pg_dump</application> pour s'assurer
-   d'un traitement propre et empêcher tout conflit potentiel avec des
+   Il est généralement recommandé d'utiliser l'option <option>-X</option>
+   (<option>--no-psqlrc</option>) lors de la restauration d'une base de données
+   à partir d'un script texte généré par <application>pg_dump</application> pour
+   s'assurer d'un traitement propre et empêcher tout conflit potentiel avec des
    configurations personnalisées de <application>psql</application>.
   </para>
  </refsect1>
@@ -1818,18 +1798,9 @@
   <title>Exemples</title>
 
   <para>
-   Sauvegarder une base appelée <literal>ma_base</literal> dans un script
+   Exporter une base appelée <literal>ma_base</literal> dans un script
    SQL&nbsp;:
    <screen><prompt>$</prompt> <userinput>pg_dump ma_base &gt; base.sql</userinput>
-   </screen>
-  </para>
-
-  <para>
-   Pour sauvegarder une base de données dans une archive au format
-   répertoire&nbsp;:
-
-   <screen>
-<prompt>$</prompt> <userinput>pg_dump -Fd ma_base -f rep_sauve</userinput>
    </screen>
   </para>
 
@@ -1842,15 +1813,24 @@
   </para>
 
   <para>
-   Sauvegarder une base dans un fichier au format personnalisé&nbsp;:
+   Exporter une base dans un fichier archive au format personnalisé&nbsp;:
 
    <screen><prompt>$</prompt> <userinput>pg_dump -Fc ma_base &gt; base.dump</userinput>
    </screen>
   </para>
 
   <para>
-   Pour sauvegarder une base de données en utilisant le format répertoire et
-   en activant la parallélisation sur cinq jobs&nbsp;:
+   Exporter une base de données dans une archive au format
+   répertoire&nbsp;:
+
+   <screen>
+<prompt>$</prompt> <userinput>pg_dump -Fd ma_base -f rep_sauve</userinput>
+   </screen>
+  </para>
+
+  <para>
+   Exporter une base de données en utilisant le format répertoire et
+   en activant la parallélisation sur cinq processus&nbsp;:
 
    <screen>
 <prompt>$</prompt> <userinput>pg_dump -Fd ma_base -j 5 -f rep_sauvegarde</userinput>
@@ -1866,8 +1846,7 @@
   </para>
 
   <para>
-   Pour recharger un fichier archive dans la même base de données, annuler le
-   contenu actuel de cette base&nbsp;:
+   Recharger un fichier d'archive dans la même base de données que celle depuis laquelle il a été exporté, en supprimant son contenu actuel&nbsp;:
 
    <screen>
 <prompt>$</prompt> <userinput>pg_restore -d postgres --clean --create db.dump</userinput>
@@ -1875,23 +1854,23 @@
   </para>
 
   <para>
-   Sauvegarder la table nommée <literal>mytab</literal>&nbsp;:
+   Exporter la table nommée <literal>mytab</literal>&nbsp;:
 
    <screen><prompt>$</prompt> <userinput>pg_dump -t ma_table ma_base &gt; base.sql</userinput>
    </screen>
   </para>
 
   <para>
-   Sauvegarder toutes les tables du schéma <literal>detroit</literal> et dont
+   Exporter toutes les tables du schéma <literal>detroit</literal> et dont
    le nom commence par <literal>emp</literal> sauf la table nommée
-   <literal>traces_employes</literal>&nbsp;:
+   <literal>employee_log</literal>&nbsp;:
 
-   <screen><prompt>$</prompt> <userinput>pg_dump -t 'detroit.emp*' -T detroit.traces_employes ma_base &gt; base.sql</userinput>
+   <screen><prompt>$</prompt> <userinput>pg_dump -t 'detroit.emp*' -T detroit.employee_log ma_base &gt; base.sql</userinput>
    </screen>
   </para>
 
   <para>
-   Sauvegarder tous les schémas dont le nom commence par
+   Exporter tous les schémas dont le nom commence par
    <literal>est</literal> ou <literal>ouest</literal> et se termine par
    <literal>gsm</literal>, en excluant les schémas dont le nom contient le mot
    <literal>test</literal>&nbsp;:
@@ -1902,14 +1881,14 @@
   </para>
 
   <para>
-   Idem mais en utilisant des expressions rationnelles dans les options&nbsp;:
+   Idem mais en utilisant des expressions régulières pour regrouper les options&nbsp;:
 
    <screen><prompt>$</prompt> <userinput>pg_dump -n '(est|ouest)*gsm' -N '*test*' ma_base &gt; base.sql</userinput>
    </screen>
   </para>
 
   <para>
-   Sauvegarder tous les objets de la base sauf les tables dont le nom commence
+   Exporter tous les objets de la base sauf les tables dont le nom commence
    par <literal>ts_</literal>&nbsp;:
 
    <screen><prompt>$</prompt> <userinput>pg_dump -T 'ts_*' ma_base &gt; base.sql</userinput>
@@ -1917,30 +1896,30 @@
   </para>
 
   <para>
-   Pour indiquer un nom qui comporte des majuscules dans les options
-   <option>-t</option> et assimilées, il faut ajouter des guillemets
-   doubles&nbsp;; sinon le nom est converti en minuscules (voir <xref
-   linkend="app-psql-patterns"/>). Les guillemets doubles sont interprétés par
-   le shell et doivent donc être placés entre guillemets. Du coup, pour
-   sauvegarder une seule table dont le nom comporte des majuscules, on utilise
-   une commande du style&nbsp;:
+   Pour spécifier un nom comportant des majuscules dans les options
+   <option>-t</option> et similaires, il faut entourer le nom de guillemets
+   doubles&nbsp;; sinon, il sera converti en minuscules (voir
+   <xref linkend="app-psql-patterns"/>). Or, comme les guillemets doubles ont
+   une signification particulière pour le shell, ils doivent à leur tour être
+   échappés. Ainsi, pour extraire une seule table dont le nom comporte des
+   majuscules, il faut utiliser une commande du style&nbsp;:
 
    <screen>
 <prompt>$</prompt> <userinput>pg_dump -t "\"NomAMajuscule\"" ma_base &gt; ma_base.sql</userinput>
 </screen></para>
 
   <para>
-   Pour sauvegarder toutes les tables dont le nom commencent par
-   <literal>mytable</literal>, à l'exception de la table
-   <literal>mytable2</literal>, créer un fichier
-   <filename>filter.txt</filename> ainsi&nbsp;:
+   Pour exporter toutes les tables dont le nom commence par
+   <literal>matable</literal>, à l'exception de la table
+   <literal>matable2</literal>, créer un fichier
+   <filename>filtre.txt</filename> comme suit&nbsp;:
 <programlisting>
-include table mytable*
-exclude table mytable2
+include table matable*
+exclude table matable2
 </programlisting>
 
 <screen>
-<prompt>$</prompt> <userinput>pg_dump --filter=filter.txt mydb &gt; db.sql</userinput>
+<prompt>$</prompt> <userinput>pg_dump --filter=filtre.txt ma_base &gt; ma_base.sql</userinput>
    </screen>
   </para>
  </refsect1>


### PR DESCRIPTION
Traduction des parties ajoutées lors du merge v18 beta 1 et relecture globale du fichier pour se mettre en cohérence avec les dernières modifications apportées au fichier source original.

```
$ git log -1 --oneline doc/src/sgml/ref/pg_dump.sgml
dec6643487b Improve pg_dump/pg_dumpall help synopses and terminology
```