### PR TITLE
Traduction des fichiers pglogicalinspect.xml et pgoverexplain.xml

### DIFF
--- a/postgresql/pglogicalinspect.xml
+++ b/postgresql/pglogicalinspect.xml
@@ -2,28 +2,29 @@
 <!-- doc/src/sgml/pglogicalinspect.sgml -->
 
 <sect1 id="pglogicalinspect" xreflabel="pg_logicalinspect">
- <title>pg_logicalinspect &mdash; logical decoding components inspection</title>
+ <title>pg_logicalinspect &mdash; inspection des composants de décodage logique</title>
 
  <indexterm zone="pglogicalinspect">
   <primary>pg_logicalinspect</primary>
  </indexterm>
 
  <para>
-  The <filename>pg_logicalinspect</filename> module provides SQL functions
-  that allow you to inspect the contents of logical decoding components. It
-  allows the inspection of serialized logical snapshots of a running
-  <productname>PostgreSQL</productname> database cluster, which is useful
-  for debugging or educational purposes.
+  Le module <filename>pg_logicalinspect</filename> fournit des fonctions SQL
+  permettant d'inspecter le contenu des composants de décodage logique. Il
+  permet l'inspection des instantanés logiques sérialisés d'un cluster
+  <productname>PostgreSQL</productname> en cours d'exécution, ce qui est utile
+  à des fins de débogage ou d'apprentissage.
  </para>
 
  <para>
-  By default, use of these functions is restricted to superusers and members of
-  the <literal>pg_read_server_files</literal> role. Access may be granted by
-  superusers to others using <command>GRANT</command>.
+  par défaut, l'utilisation de ces fonctions est restrainte aux superutilisateurs
+  et aux membres du rôle <literal>pg_read_server_files</literal>. L'accès peut être
+  accordé à d'autres utilisateurs par les superutilisateurs à l'aide de la commande
+  <command>GRANT</command>.
  </para>
 
  <sect2 id="pglogicalinspect-funcs">
-  <title>Functions</title>
+  <title>Fonctions</title>
 
   <variablelist>
    <varlistentry id="pglogicalinspect-funcs-pg-get-logical-snapshot-meta">
@@ -33,11 +34,11 @@
 
     <listitem>
      <para>
-      Gets logical snapshot metadata about a snapshot file that is located in
-      the server's <filename>pg_logical/snapshots</filename> directory.
-      The <replaceable>filename</replaceable> argument represents the snapshot
-      file name.
-      For example:
+      Récupère les métadonnées de l'instantané logique pour un fichier situé dans
+      le repertoire <filename>pg_logical/snapshots</filename> du serveur.
+      L'argument <replaceable>filename</replaceable> représente le nom du fichier
+      d'instantané.
+      Par exemple :
 <screen>
 postgres=# SELECT * FROM pg_ls_logicalsnapdir();
 -[ RECORD 1 ]+-----------------------
@@ -61,8 +62,8 @@ version  | 6
 </screen>
      </para>
      <para>
-      If <replaceable>filename</replaceable> does not match a snapshot file, the
-      function raises an error.
+      Si <replaceable>filename</replaceable> ne correspond pas à un fichier
+      d'instantané, la fonction renvoie une erreur.
      </para>
     </listitem>
    </varlistentry>
@@ -74,11 +75,11 @@ version  | 6
 
     <listitem>
      <para>
-      Gets logical snapshot information about a snapshot file that is located in
-      the server's <filename>pg_logical/snapshots</filename> directory.
-      The <replaceable>filename</replaceable> argument represents the snapshot
-      file name.
-      For example:
+      Récupère les informations de l'instantané logique pour un fichier situé dans
+      le répertoire <filename>pg_logical/snapshots</filename> du serveur.
+      L'argument <replaceable>filename</replaceable> représente le nom du fichier
+      d'instantané.
+      Par exemple :
 <screen>
 postgres=# SELECT * FROM pg_ls_logicalsnapdir();
 -[ RECORD 1 ]+-----------------------
@@ -124,8 +125,8 @@ catchange_xip            | {751,752}
 </screen>
      </para>
      <para>
-      If <replaceable>filename</replaceable> does not match a snapshot file, the
-      function raises an error.
+      Si <replaceable>filename</replaceable> ne correspond pas à un fichier
+      d'instantané, la fonction renvoie une erreur.
      </para>
     </listitem>
    </varlistentry>
@@ -134,7 +135,7 @@ catchange_xip            | {751,752}
  </sect2>
 
  <sect2 id="pglogicalinspect-author">
-  <title>Author</title>
+  <title>Auteur</title>
 
   <para>
    Bertrand Drouvot <email>bertranddrouvot.pg@gmail.com</email>

--- a/postgresql/pgoverexplain.xml
+++ b/postgresql/pgoverexplain.xml
@@ -2,89 +2,84 @@
 <!-- doc/src/sgml/pgoverexplain.sgml -->
 
 <sect1 id="pgoverexplain" xreflabel="pg_overexplain">
- <title>pg_overexplain &mdash; allow EXPLAIN to dump even more details</title>
+ <title>pg_overexplain &mdash; permet à EXPLAIN d'afficher encore plus de détails</title>
 
  <indexterm zone="pgoverexplain">
   <primary>pg_overexplain</primary>
  </indexterm>
 
  <para>
-  The <filename>pg_overexplain</filename> extends <command>EXPLAIN</command>
-  with new options that provide additional output. It is mostly intended to
-  assist with debugging of and development of the planner, rather than for
-  general use. Since this module displays internal details of planner data
-  structures, it may be necessary to refer to the source code to make sense
-  of the output. Furthermore, the output is likely to change whenever (and as
-  often as) those data structures change.
+    Le module <filename>pg_overexplain</filename> étend la commande <command>EXPLAIN</command>
+  avec de nouvelles options fournissant des sorties supplémentaires. Il est principalement destiné
+  à aider au débogage et au développement du planificateur, plutôt qu'à une utilisation générale.
+  Étant donné que ce module affiche des détails internes des structures de données du planificateur,
+  il peut être nécessaire se référer au code source pour en comprendre la sortie. De plus,
+  cette sortie est susceptible d'évoluer aussi souvent que les structures de données qu'elle expose.
  </para>
 
  <sect2 id="pgoverexplain-debug">
   <title>EXPLAIN (DEBUG)</title>
 
   <para>
-   The <literal>DEBUG</literal> option displays miscellaneous information from
-   the plan tree that is not normally shown because it is not expected to be
-   of general interest. For each individual plan node, it will display the
-   following fields.  See <literal>Plan</literal> in
-   <literal>nodes/plannodes.h</literal> for additional documentation of these
-   fields.
+   Lo'ption <literal>DEBUG</literal> affiche des informations diverses issues
+   de l'arbre de planification qui ne sont normalement pas affichées, car elles ne sont
+   pas censées être d'intérêt général. Pour chaque nœud de plan individuel, les champs suivants
+   seront affichés. Voir <literal>Plan</literal> dans <literal>nodes/plannodes.h</literal>
+   pour une documentation plus détaillée de ces champs.
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     <literal>Disabled Nodes</literal>. Normal <command>EXPLAIN</command>
-     determines whether a node is disabled by checking whether the node's
-     count of disabled nodes is larger than the sum of the counts for the
-     underlying nodes. This option shows the raw counter value.
+     <literal>Disabled Nodes</literal>. La commande  <command>EXPLAIN</command>
+     classique détermine si un nœud est désactivé en comparant le nombre de noeuds désactivés
+     à la somme de ceux des nœuds sous-jacents. Cette option affiche la valeur brute du compteur.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>Parallel Safe</literal>. Indicates whether it would be safe for
-     a plan tree node to appear beneath a <literal>Gather</literal> or
-     <literal>Gather Merge</literal> node, regardless of whether it is
-     actually below such a node.
+     <literal>Parallel Safe</literal>. Indique si un nœud de l'arbre de planification
+     peut apparaître en toute sécurité sous un nœud <literal>Gather</literal> ou
+     <literal>Gather Merge</literal>, indépendamment du fait qu'il y figure
+     réellement ou non.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>Plan Node ID</literal>. An internal ID number that should be
-     unique for every node in the plan tree. It is used to coordinate parallel
-     query activity.
+     <literal>Plan Node ID</literal>. Un identifiant interne unique pour chaque nœud
+     de planification. Il est utilisé pour coordonner l'activité des requêtes parallèles.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>extParam</literal> and <literal>allParam</literal>. Information
-     about which numbered parameters affect this plan node or its children. In
-     text mode, these fields are only displayed if they are non-empty sets.
+     <literal>extParam</literal> et <literal>allParam</literal>. Informations sur les paramètres numérotés
+     affectant ce nœud de plan ou ses enfants. En mode texte, ces champs ne sont affichés que s’ils
+     ne sont pas vides.
     </para>
    </listitem>
   </itemizedlist>
 
   <para>
-   Once per query, the <literal>DEBUG</literal> option will display the
-   following fields. See <literal>PlannedStmt</literal> in
-   <literal>nodes/plannodes.h</literal> for additional detail.
+   Une fois par requête, l’option <literal>DEBUG</literal> affichera également les champs suivants.
+   Voir <literal>PlannedStmt</literal> dans <literal>nodes/plannodes.h</literal> pour plus de détails.
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     <literal>Command Type</literal>. For example, <literal>select</literal>
-     or <literal>update</literal>.
+     <literal>Command Type</literal>. Par exemple, <literal>select</literal>
+     ou <literal>update</literal>.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>Flags</literal>. A comma-separated list of Boolean structure
-     member names from the <literal>PlannedStmt</literal> that are set to
-     <literal>true</literal>. It covers the following structure members:
+     <literal>Flags</literal>. Une liste séparée par des virgules des membres
+     booléens de la structure <literal>PlannedStmt</literal> ayant la valeur
+     <literal>true</literal>. Cela inclut :
      <literal>hasReturning</literal>, <literal>hasModifyingCTE</literal>,
      <literal>canSetTag</literal>, <literal>transientPlan</literal>,
      <literal>dependsOnRole</literal>, <literal>parallelModeNeeded</literal>.
@@ -93,35 +88,35 @@
 
    <listitem>
     <para>
-     <literal>Subplans Needing Rewind</literal>. Integer IDs of subplans that
-     may need to be rewound by the executor.
+     <literal>Subplans Needing Rewind</literal>. Identifiants entiers des sous-plans
+     susceptibles de devoir être relus par l'exécuteur.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>Relation OIDs</literal>. OIDs of relations upon which this plan
-     depends.
+     <literal>Relation OIDs</literal>. OIDs des relations dont dépend ce plan.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>Executor Parameter Types</literal>. Type OID for each executor parameter
-     (e.g. when a nested loop is chosen and a parameter is used to pass a value down
-     to an inner index scan). Does not include parameters supplied to a prepared
-     statement by the user.
+     <literal>Executor Parameter Types</literal>. OID de type pour chaque paramètre d'exécuteur
+     (par exemple, lorsqu'une boucle imbriquée est choisie et qu'un paramètre est utilisé pour
+     transmettre une valeur à une recherche d'index interne). Cela n'inclut pas les paramètres
+     fournis par l'utilisateur à une instruction préparée.
     </para>
    </listitem>
 
    <listitem>
     <para>
-     <literal>Parse Location</literal>. Location within the query string
-     supplied to the planner where this query's text can be found. May be
-     <literal>Unknown</literal> in some contexts. Otherwise, may be
-     <literal>NNN to end</literal> for some integer <literal>NNN</literal> or
-     <literal>NNN for MMM bytes</literal> for some integers
-     <literal>NNN</literal> and <literal>MMM</literal>.
+     <literal>Parse Location</literal>. Indique l'emplacement dans la chaîne de requête
+     transmise au planificateur où le texte de la requête peut être trouvé.
+     Peut valoir <literal>Unknown</literal> dans certains contextes.
+     Sinon, cela peut être
+     <literal>NNN to end</literal> pour certain entier <literal>NNN</literal> ou
+     <literal>NNN for MMM bytes</literal> pour certains entiers
+     <literal>NNN</literal> et <literal>MMM</literal>.
     </para>
    </listitem>
   </itemizedlist>
@@ -131,53 +126,49 @@
   <title>EXPLAIN (RANGE_TABLE)</title>
 
   <para>
-   The <literal>RANGE_TABLE</literal> option displays information from the
-   plan tree specifically concerning the query's range table. Range table
-   entries correspond roughly to items appearing in the query's
-   <literal>FROM</literal> clause, but with numerous exceptions. For example,
-   subqueries that are proved unnecessary may be deleted from the range table
-   entirely, while inheritance expansion adds range table entries for child
-   tables that are not named directly in the query.
+   L’option <literal>RANGE_TABLE</literal> affiche les informations de l’arbre de plan
+   concernant spécifiquement la table de portée (range table) de la requête. Les entrées
+   de la table de portée correspondent grossièrement aux éléments figurant dans la clause
+   <literal>FROM</literal> de la requête, mais il existe de nombreuses exceptions. Par exemple,
+   les sous-requêtes jugées inutiles peuvent être supprimées entièrement de la table de portée,
+   tandis que l’expansion des héritages ajoute des entrées pour les tables filles non nommées
+   directement dans la requête.
   </para>
 
   <para>
-   Range table entries are generally referenced within the query plan by a
-   range table index, or RTI. Plan nodes that reference one or more RTIs will
-   be labelled accordingly, using one of the following fields: <literal>Scan
-   RTI</literal>, <literal>Nominal RTI</literal>, <literal>Exclude Relation
-   RTI</literal>, <literal>Append RTIs</literal>.
+   Les entrées de la table de portée sont généralement référencées dans le plan de requête
+   par un indice de table de portée (RTI). Les nœuds de plan qui référencent un ou
+   plusieurs RTI seront annotés à l'aide de l'un des champs suivants :
+   <literal>Scan RTI</literal>, <literal>Nominal RTI</literal>,
+   <literal>Exclude Relation RTI</literal>, <literal>Append RTIs</literal>.
   </para>
 
   <para>
-   In addition, the query as a whole may maintain lists of range table indexes
-   that are needed for various purposes. These lists will be displayed once
-   per query, labelled as appropriate as <literal>Unprunable RTIs</literal> or
-   <literal>Result RTIs</literal>. In text mode, these fields are only
-   displayed if they are non-empty sets.
+   De plus, la requête dans son ensemble peut maintenir des listes d'indices de table de portée
+   nécessaires à divers traitements. Ces listes seront affichées une fois par requête
+   et étiquetées comme <literal>Unprunable RTIs</literal> ou <literal>Result RTIs</literal>.
+   En mode texte, ces champs ne sont affichés que s'ils ne sont pas vides.
   </para>
 
   <para>
-   Finally, but most importantly, the <literal>RANGE_TABLE</literal> option
-   will display a dump of the query's entire range table. Each range table
-   entry is labelled with the appropriate range table index, the kind of range
-   table entry (e.g.  <literal>relation</literal>,
-   <literal>subquery</literal>, or <literal>join</literal>), followed by the
-   contents of various range table entry fields that are not normally part of
-   <literal>EXPLAIN</literal> output. Some of these fields are only displayed
-   for certain kinds of range table entries. For example,
-   <literal>Eref</literal> is displayed for all types of range table entries,
-   but <literal>CTE Name</literal> is displayed only for range table entries
-   of type <literal>cte</literal>.
+   Enfin, et surtout, l'option <literal>RANGE_TABLE</literal> affichera un
+   vidage complet de la table de portée de la requête. Chaque entrée est annotée
+   avec son indice, son type (par exemple, <literal>relation</literal>,
+    <literal>subquery</literal>, ou <literal>join</literal>), suivi du contenu de
+   divers champs supplémentaires. Certains de ces champs ne sont affichés que
+   pour certains types d'entrés. Par exemple, <literal>Eref</literal> est affiché
+   pour tous les types d'entrées, mais <literal>CTE Name</literal> l'est uniquement
+   pour les entrées de type <literal>cte</literal>.
   </para>
 
   <para>
-   For more information about range table entries, see the definition of
-   <literal>RangeTblEntry</literal> in <literal>nodes/plannodes.h</literal>.
+   Pour plus d'informations sur les entrées de la table de portée, se référer à la définition
+   de <literal>RangeTblEntry</literal> dans <literal>nodes/plannodes.h</literal>.
   </para>
  </sect2>
 
  <sect2 id="pgoverexplain-author">
-  <title>Author</title>
+  <title>Auteur</title>
 
   <para>
    Robert Haas <email>rhaas@postgresql.org</email>


### PR DESCRIPTION
Hello,
Me revoilà avec deux nouveaux fichiers traduits...
Je voudrais juste avoir votre avis sur une partie du fichier `pgoverexplain.xml` : 

La traduction littérale du bloc : 
> <literal>Parse Location</literal>. Location within the query string
     supplied to the planner where this query's text can be found. May be
     <literal>Unknown</literal> in some contexts. Otherwise, may be
     <literal>NNN to end</literal> for some integer <literal>NNN</literal> or
     <literal>NNN for MMM bytes</literal> for some integers
     <literal>NNN</literal> and <literal>MMM</literal>.

Donne : 

> <literal>Parse Location</literal>. Indique l'emplacement dans la chaîne de requête
     transmise au planificateur où le texte de la requête peut être trouvé.
     Peut valoir <literal>Unknown</literal> dans certains contextes.
     Sinon, cela peut être
     <literal>NNN to end</literal> pour certain entier <literal>NNN</literal> ou
     <literal>NNN for MMM bytes</literal> pour certains entiers
     <literal>NNN</literal> et <literal>MMM</literal>.

Je ne connais pas bien cette partie de PostgreSQL (nouveau...) mais ça me semble bizarre non ?

Outre ça, j'espère que le reste ira.