### PR TITLE
Traduction du fichier oauth-validators

### DIFF
--- a/postgresql/oauth-validators.xml
+++ b/postgresql/oauth-validators.xml
@@ -2,163 +2,163 @@
 <!-- doc/src/sgml/oauth-validators.sgml -->
 
 <chapter id="oauth-validators">
- <title>OAuth Validator Modules</title>
+ <title>Modules de validation OAuth</title>
  <indexterm zone="oauth-validators">
-  <primary>OAuth Validators</primary>
+  <primary>Validateurs OAuth</primary>
  </indexterm>
  <para>
-  <productname>PostgreSQL</productname> provides infrastructure for creating
-  custom modules to perform server-side validation of OAuth bearer tokens.
-  Because OAuth implementations vary so wildly, and bearer token validation is
-  heavily dependent on the issuing party, the server cannot check the token
-  itself; validator modules provide the integration layer between the server
-  and the OAuth provider in use.
+  <productname>PostgreSQL</productname> fournit une infrastructure permettant de créer
+  des modules personnalisés pour effectuer la validation côté serveur des jetons
+  OAuth de type Bearer. Les implémentations d'OAuth étant extrêmement variées, et la
+  validation des jetons fortement dépendante de l'émetteur, le serveur ne peut pas
+  vérifier lui-même le jeton ; les modules de validation assurent l'intégration entre
+  le serveur et le fournisseur OAuth utilisé.
  </para>
  <para>
-  OAuth validator modules must at least consist of an initialization function
-  (see <xref linkend="oauth-validator-init"/>) and the required callback for
-  performing validation (see <xref linkend="oauth-validator-callback-validate"/>).
+  Les modules de validation OAuth doivent au minimum contenir une fonction
+  d'initialisation (voir <xref linkend="oauth-validator-init"/>) ainsi que le rappel
+  requis pour effectuer la validation (voir <xref linkend="oauth-validator-callback-validate"/>).
  </para>
  <warning>
   <para>
-   Since a misbehaving validator might let unauthorized users into the database,
-   correct implementation is crucial for server safety. See
-   <xref linkend="oauth-validator-design"/> for design considerations.
+   Un validateur mal implémenté pourrait autoriser l'accès à des utilisateurs non
+   autorisés, compromettant ainsi la sécurité du serveur. La mise en œuvre correcte
+   est donc cruciale. Voir <xref linkend="oauth-validator-design"/> pour les
+   considérations de conception.
   </para>
  </warning>
 
  <sect1 id="oauth-validator-design">
-  <title>Safely Designing a Validator Module</title>
+  <title>Concevoir un module de validation de manière sécurisée</title>
   <warning>
    <para>
-    Read and understand the entirety of this section before implementing a
-    validator module. A malfunctioning validator is potentially worse than no
-    authentication at all, both because of the false sense of security it
-    provides, and because it may contribute to attacks against other pieces of
-    an OAuth ecosystem.
+    Lire et comprendre entièrement cette section avant d'implémenter un module
+    de validation est crucial. Un validateur défaillant est potentiellement pire
+    qu'une absence totale d'authentification, car il donne une fausse impression de sécurité
+    et peut être utilisé dans le cadre d'attaques ciblant d'autres composants de l'écosystème
+    OAuth.
    </para>
   </warning>
 
   <sect2 id="oauth-validator-design-responsibilities">
-   <title>Validator Responsibilities</title>
+   <title>Responsabilités du validateur</title>
    <para>
-    Although different modules may take very different approaches to token
-    validation, implementations generally need to perform three separate
-    actions:
+    Bien que les modules puissent adopter des approches très différentes pour valider
+    les jetons, une implémentation doit généralement effectuer trois actions distinctes :
    </para>
    <variablelist>
     <varlistentry>
-     <term>Validate the Token</term>
+     <term>Valider le jeton</term>
      <listitem>
       <para>
-       The validator must first ensure that the presented token is in fact a
-       valid Bearer token for use in client authentication. The correct way to
-       do this depends on the provider, but it generally involves either
-       cryptographic operations to prove that the token was created by a trusted
-       party (offline validation), or the presentation of the token to that
-       trusted party so that it can perform validation for you (online
-       validation).
+       Le validateur doit d'abord s'assurer que le jeton présenté est bien un jeton
+       Bearer valide pour l'authentification du client. La manière exacte dépend du
+       fournisseur, mais elle implique généralement soit des opérations cryptographiques
+       pour prouver que le jeton a été émis par une entité de confiance (validation
+       hors ligne), soit la présentation du jeton à cette entité afin qu'elle effectue la
+       validation à sa place (validation en ligne).
       </para>
       <para>
-       Online validation, usually implemented via
+       La validation en ligne, généralement mise en œuvre via
        <ulink url="https://datatracker.ietf.org/doc/html/rfc7662">OAuth Token
-       Introspection</ulink>, requires fewer steps of a validator module and
-       allows central revocation of a token in the event that it is stolen
-       or misissued. However, it does require the module to make at least one
-       network call per authentication attempt (all of which must complete
-       within the configured <xref linkend="guc-authentication-timeout"/>).
-       Additionally, your provider may not provide introspection endpoints for
-       use by external resource servers.
+       Introspection</ulink>, demande moins d'étapes de la part du module et
+       permet la révocation centralisée des jetons en cas de vol ou de mauvaise
+       attribution. Cependant, elle nécessite au minimum un appel réseau par
+       tentative d'authentification (tous devant être réalisés dans le délai défini par
+       <xref linkend="guc-authentication-timeout"/>). De plus, certains fournisseurs
+       n'exposent pas de point d'introspection pour les serveurs de ressources externes.
       </para>
       <para>
-       Offline validation is much more involved, typically requiring a validator
-       to maintain a list of trusted signing keys for a provider and then
-       check the token's cryptographic signature along with its contents.
-       Implementations must follow the provider's instructions to the letter,
-       including any verification of issuer ("where is this token from?"),
-       audience ("who is this token for?"), and validity period ("when can this
-       token be used?"). Since there is no communication between the module and
-       the provider, tokens cannot be centrally revoked using this method;
-       offline validator implementations may wish to place restrictions on the
-       maximum length of a token's validity period.
+       La validation hors ligne est beaucoup plus complexe, nécessitant souvent que le
+       validateur maintienne une liste de clés de signature de confiance et vérifie
+       la signature cryptographique du jeton ainsi que son contenu. L'implémentation
+       doit respecter à la lettre les directives du fournisseur, y compris la vérification
+       de l'émetteur (« d'où vient ce jeton ? »), du destinataire (« pour qui est
+       ce jeton ? ») et de la période de validité (« quand ce jeton est-il utilisable ? »).
+       Comme il n'y a pas de communication avec le fournisseur, la révocation centralisée
+       n'est pas possible ; les validateurs hors ligne peuvent vouloir restreindre la durée
+       maximale de validité d'un jeton.
       </para>
       <para>
-       If the token cannot be validated, the module should immediately fail.
-       Further authentication/authorization is pointless if the bearer token
-       wasn't issued by a trusted party.
+       Si le jeton ne peut pas être validé, le module doit immédiatement échouer.
+       Toute tentative d'authentification/autorisation est inutile si le jeton
+       Bearer n'a pas été émis par une entité de confiance.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Authorize the Client</term>
+     <term>Autoriser le client</term>
      <listitem>
       <para>
-       Next the validator must ensure that the end user has given the client
-       permission to access the server on their behalf. This generally involves
-       checking the scopes that have been assigned to the token, to make sure
-       that they cover database access for the current HBA parameters.
+       Ensuite, le validateur doit s'assurer que l'utilisateur final a bien donné
+       au client l'autorisation d'accéder au serveur en son nom. Cela implique
+       généralement de vérifier les portées (scopes) associées au jeton, afin de
+       s'assurer qu'elles couvrent l'accès à la base de données selon les paramètres
+       HBA actuels.
       </para>
       <para>
-       The purpose of this step is to prevent an OAuth client from obtaining a
-       token under false pretenses. If the validator requires all tokens to
-       carry scopes that cover database access, the provider should then loudly
-       prompt the user to grant that access during the flow. This gives them the
-       opportunity to reject the request if the client isn't supposed to be
-       using their credentials to connect to databases.
+       L'objectif de cette étape est d'éviter qu'un client OAuth n'obtienne un
+       jeton sous de faux prétextes. Si le validateur exige que tous les jetons
+       comportent des portées couvrant l'accès à la base de données, le fournisseur
+       doit alors inciter explicitement l'utilisateur à accorder cet accès lors du
+       processus. Cela lui donne l'opportunité de refuser la demande si le client
+       n'est pas censé utiliser ses identifiants pour se connecter à des bases de
+       données.
       </para>
       <para>
-       While it is possible to establish client authorization without explicit
-       scopes by using out-of-band knowledge of the deployed architecture, doing
-       so removes the user from the loop, which prevents them from catching
-       deployment mistakes and allows any such mistakes to be exploited
-       silently. Access to the database must be tightly restricted to only
-       trusted clients
+       Bien qu'il soit possible d'établir l'autorisation du client sans portées
+       explicites, en s'appuyant sur une connaissance externe de l'architecture
+       déployée, cela écarte l'utilisateur du processus, l'empêchant ainsi de
+       détecter d'éventuelles erreurs de déploiement, erreurs qui pourraient alors
+       être exploitées silencieusement. L'accès à la base de données doit être
+       strictement limité aux seuls clients de confiance
        <footnote>
         <para>
-         That is, "trusted" in the sense that the OAuth client and the
-         <productname>PostgreSQL</productname> server are controlled by the same
-         entity. Notably, the Device Authorization client flow supported by
-         libpq does not usually meet this bar, since it's designed for use by
-         public/untrusted clients.
+         C'est-à-dire, « de confiance » dans le sens où le client OAuth et le
+         serveur <productname>PostgreSQL</productname> sont contrôlés par la même
+         entité. Notamment, le flux de client d'autorisation par appareil
+         (Device Authorization) pris en charge par libpq ne répond généralement
+         pas à ce critère, car il est conçu pour des clients publics ou non fiables.
         </para>
        </footnote>
-       if users are not prompted for additional scopes.
+       si aucun prompt ne demande à l'utilisateur des portées supplémentaires.
       </para>
       <para>
-       Even if authorization fails, a module may choose to continue to pull
-       authentication information from the token for use in auditing and
-       debugging.
+       Même si l'autorisation échoue, un module peut choisir de continuer à
+       extraire les informations d'authentification du jeton à des fins d'audit
+       et de débogage.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Authenticate the End User</term>
+     <term>Authentifier l'utilisateur final</term>
      <listitem>
       <para>
-       Finally, the validator should determine a user identifier for the token,
-       either by asking the provider for this information or by extracting it
-       from the token itself, and return that identifier to the server (which
-       will then make a final authorization decision using the HBA
-       configuration). This identifier will be available within the session via
+       Enfin, le validateur doit déterminer un identifiant d'utilisateur associé
+       au jeton, soit en demandant cette information au fournisseur, soit en l'extrayant
+       directement du jeton, puis renvoyer cet identifiant au serveur (qui prendra
+       ensuite une décision finale d'autorisation selon la configuration HBA).
+       Cet identifiant sera disponible durant la session via
        <link linkend="functions-info-session-table"><function>system_user</function></link>
-       and recorded in the server logs if <xref linkend="guc-log-connections"/>
-       is enabled.
+       et enregistré dans les journaux du serveur si <xref linkend="guc-log-connections"/>
+       est activé.
       </para>
       <para>
-       Different providers may record a variety of different authentication
-       information for an end user, typically referred to as
-       <emphasis>claims</emphasis>. Providers usually document which of these
-       claims are trustworthy enough to use for authorization decisions and
-       which are not. (For instance, it would probably not be wise to use an
-       end user's full name as the identifier for authentication, since many
-       providers allow users to change their display names arbitrarily.)
-       Ultimately, the choice of which claim (or combination of claims) to use
-       comes down to the provider implementation and application requirements.
+       Les différents fournisseurs peuvent enregistrer divers types d'informations
+       d'authentification pour un utilisateur final, généralement appelées
+       <emphasis>claims</emphasis> (revendications). En général, les fournisseurs
+       documentent quelles revendications sont suffisamment fiables pour être
+       utilisées dans les décisions d'autorisation, et lesquelles ne le sont pas
+       (par exemple, il ne serait probablement pas judicieux d'utiliser le nom complet
+       d'un utilisateur comme identifiant d'authentification, car beaucoup de fournisseurs
+       permettent aux utilisateurs de modifier leur nom d'affichage de manière arbitraire).
+       En définitive, le choix de la ou des revendications à utiliser dépend de
+       l'implémentation du fournisseur et des besoins de l'application.
       </para>
       <para>
-       Note that anonymous/pseudonymous login is possible as well, by enabling
-       usermap delegation; see
-       <xref linkend="oauth-validator-design-usermap-delegation"/>.
+       Note que la connexion anonyme ou pseudonyme est également possible, en activant
+       la délégation via une table de correspondance des utilisateurs (usermap delegation) ;
+       voir <xref linkend="oauth-validator-design-usermap-delegation"/>
       </para>
      </listitem>
     </varlistentry>
@@ -166,68 +166,73 @@
   </sect2>
 
   <sect2 id="oauth-validator-design-guidelines">
-   <title>General Coding Guidelines</title>
+   <title>Recommandations générales de développement</title>
    <para>
-    Developers should keep the following in mind when implementing token
-    validation:
+    Les développeurs doivent garder à l'esprit les éléments suivants lors de
+    l'implémentation de la validation de jetons :
    </para>
    <variablelist>
     <varlistentry>
-     <term>Token Confidentiality</term>
+     <term>Confidentialité des jetons</term>
      <listitem>
       <para>
-       Modules should not write tokens, or pieces of tokens, into the server
-       log. This is true even if the module considers the token invalid; an
-       attacker who confuses a client into communicating with the wrong provider
-       should not be able to retrieve that (otherwise valid) token from the
-       disk.
+       Les modules ne doivent jamais écrire les jetons, ni même des parties de
+       jetons, dans les journaux du serveur. Cela reste vrai même si le module
+       considère le jeton comme invalide ; un attaquant qui parvient à tromper
+       un client pour qu'il communique avec le mauvais fournisseur ne doit pas
+       pouvoir récupérer ce jeton (valide par ailleurs) depuis le disque.
+
       </para>
       <para>
-       Implementations that send tokens over the network (for example, to
-       perform online token validation with a provider) must authenticate the
-       peer and ensure that strong transport security is in use.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Logging</term>
-     <listitem>
-      <para>
-       Modules may use the same <link linkend="error-message-reporting">logging
-       facilities</link> as standard extensions; however, the rules for emitting
-       log entries to the client are subtly different during the authentication
-       phase of the connection. Generally speaking, modules should log
-       verification problems at the <symbol>COMMERROR</symbol> level and return
-       normally, instead of using <symbol>ERROR</symbol>/<symbol>FATAL</symbol>
-       to unwind the stack, to avoid leaking information to unauthenticated
-       clients.
+       Les implémentations qui envoient des jetons sur le réseau (par exemple,
+       pour effectuer une validation en ligne auprès d'un fournisseur) doivent
+       authentifier le pair distant et s'assurer qu'un transport fortement
+       sécurisé est utilisé.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Interruptibility</term>
+     <term>Journalisation</term>
      <listitem>
       <para>
-       Modules must remain interruptible by signals so that the server can
-       correctly handle authentication timeouts and shutdown signals from
-       <application>pg_ctl</application>. For example, blocking calls on sockets
-       should generally be replaced with code that handles both socket events
-       and interrupts without races (see <function>WaitLatchOrSocket()</function>,
-       <function>WaitEventSetWait()</function>, et al), and long-running loops
-       should periodically call <function>CHECK_FOR_INTERRUPTS()</function>.
-       Failure to follow this guidance may result in unresponsive backend
-       sessions.
+       Les modules peuvent utiliser les mêmes
+       <link linkend="error-message-reporting">mécanismes de journalisation</link>
+       que les extensions standard ; toutefois, les règles pour l'émission de
+       messages vers le client sont légèrement différentes pendant la phase
+       d'authentification de la connexion. En règle générale, les modules doivent
+       consigner les problèmes de vérification au niveau <symbol>COMMERROR</symbol>
+       et retourner normalement, au lieu d'utiliser <symbol>ERROR</symbol>
+       ou <symbol>FATAL</symbol> pour dérouler la pile, afin d'éviter toute fuite
+       d'informations vers les clients non authentifiés.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Testing</term>
+     <term>Interruptibilité</term>
      <listitem>
       <para>
-       The breadth of testing an OAuth system is well beyond the scope of this
-       documentation, but at minimum, negative testing should be considered
-       mandatory. It's trivial to design a module that lets authorized users in;
-       the whole point of the system is to keep unauthorized users out.
+       Les modules doivent rester interruptibles par des signaux, afin que le serveur
+       puisse gérer correctement les délais d'authentification et les signaux d'arrêt
+       émis par <application>pg_ctl</application>. Par exemple, les appels
+       bloquants sur des sockets doivent généralement être remplacés
+       par du code capable de gérer à la fois les évènements sur les sockets et
+       les interruptions sans condition de course (voir <function>WaitLatchOrSocket()</function>,
+       <function>WaitEventSetWait()</function>, etc.), et les boucles longues
+       doivent périodiquement appeler <function>CHECK_FOR_INTERRUPTS()</function>.
+       Ne pas suivre ces recommandations peut entraîner des sessions serveur
+       non réactives.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Tests</term>
+     <listitem>
+      <para>
+       La couverture de tests complète d'un système OAuth dépasse le cadre de cette
+       documentation, mais à minima, les tests négatifs doivent être considérés comme
+       obligatoires. Il est trivial de concevoir un module qui laisse entrer les
+       utilisateurs autorisés ; tout l'enjeu est d'empêcher l'accès aux utilisateurs
+       non autorisés.
       </para>
      </listitem>
     </varlistentry>
@@ -235,13 +240,15 @@
      <term>Documentation</term>
      <listitem>
       <para>
-       Validator implementations should document the contents and format of the
-       authenticated ID that is reported to the server for each end user, since
-       DBAs may need to use this information to construct pg_ident maps. (For
-       instance, is it an email address? an organizational ID number? a UUID?)
-       They should also document whether or not it is safe to use the module in
-       <symbol>delegate_ident_mapping=1</symbol> mode, and what additional
-       configuration is required in order to do so.
+       Les implémentations de validateurs doivent documenter le contenu et le format
+       de l'identifiant authentifié qui est transmis au serveur pour chaque utilisateur,
+       car les administrateurs de base de données (DBA) peuvent avoir besoin de cette
+       information pour créer les correspondances dans <filename>pg_ident.conf</filename>
+       (par exemple, s'agit-il d'une adresse e-mail ? d'un identifiant organisationnel ?
+       d'un UUID ?).
+       Elles doivent aussi indiquer s'il est sûr d'utiliser le module avec l'option
+       <symbol>delegate_ident_mapping=1</symbol>, ainsi que les éventuelles
+       configurations supplémentaires nécessaires.
       </para>
      </listitem>
     </varlistentry>
@@ -249,66 +256,70 @@
   </sect2>
 
   <sect2 id="oauth-validator-design-usermap-delegation">
-   <title>Authorizing Users (Usermap Delegation)</title>
+   <title>Autorisation des utilisateurs (Délégation via usermap)</title>
    <para>
-    The standard deliverable of a validation module is the user identifier,
-    which the server will then compare to any configured
-    <link linkend="auth-username-maps"><filename>pg_ident.conf</filename>
-    mappings</link> and determine whether the end user is authorized to connect.
-    However, OAuth is itself an authorization framework, and tokens may carry
-    information about user privileges. For example, a token may be associated
-    with the organizational groups that a user belongs to, or list the roles
-    that a user may assume, and duplicating that knowledge into local usermaps
-    for every server may not be desirable.
+    Le résultat standard d'un module de validation est un identifiant
+    utilisateur, que le serveur comparera ensuite aux correspondances définies
+    dans <link linkend="auth-username-maps"><filename>pg_ident.conf</filename></link>
+    pour déterminer si l'utilisateur final est autorisé à se connecter.
+    Toutefois, OAuth est en lui-même un cadre d'autorisation, et les jetons
+    peuvent contenir des informations relatives aux privilèges de l'utilisateur.
+    Par exemple, un jeton peut être associé aux groupes organisationnels auxquels
+    appartient un utilisateur, ou à la liste des rôles qu'il peut assumer, et
+    reproduire ces informations dans des fichiers de correspondance locaux sur
+    chaque serveur n'est pas forcément souhaitable.
    </para>
    <para>
-    To bypass username mapping entirely, and have the validator module assume
-    the additional responsibility of authorizing user connections, the HBA may
-    be configured with <xref linkend="auth-oauth-delegate-ident-mapping"/>.
-    The module may then use token scopes or an equivalent method to decide
-    whether the user is allowed to connect under their desired role. The user
-    identifier will still be recorded by the server, but it plays no part in
-    determining whether to continue the connection.
+    Pour contourner entièrement la correspondance des noms d'utilisateur et
+    confier au module de validation la responsabilité supplémentaire
+    d'autoriser les connexions utilisateur, le HBA peut être configuré avec
+    <xref linkend="auth-oauth-delegate-ident-mapping"/>. Le module peut alors
+    utiliser les portées (scopes) du jeton ou une méthode équivalente pour décider
+    si l'utilisateur est autorisé à se connecter avec le rôle souhaité.
+    L'identifiant utilisateur sera toujours enregistré par le serveur, mais il
+    n'interviendra plus dans la décision de poursuite de la connexion.
    </para>
    <para>
-    Using this scheme, authentication itself is optional. As long as the module
-    reports that the connection is authorized, login will continue even if there
-    is no recorded user identifier at all. This makes it possible to implement
-    anonymous or pseudonymous access to the database, where the third-party
-    provider performs all necessary authentication but does not provide any
-    user-identifying information to the server. (Some providers may create an
-    anonymized ID number that can be recorded instead, for later auditing.)
+    Avec ce mécanisme, l'authentification devient optionnelle, tant que le module
+    signale que la connexion est autorisée, l'ouverture de session se poursuit,
+    même si aucun identifiant utilisateur n'est renseigné. Cela permet de mettre
+    en œuvre un accès anonyme ou pseudonyme à la base de données, où le fournisseur
+    tiers effectue toute l'authentification nécessaire, sans fournir aucune
+    information permettant d'identifier l'utilisateur au serveur (certains
+    fournisseurs peuvent générer un identifiant anonymisé à enregistrer à des fins
+    d'audit ultérieur).
    </para>
    <para>
-    Usermap delegation provides the most architectural flexibility, but it turns
-    the validator module into a single point of failure for connection
-    authorization. Use with caution.
+    La délégation via usermap offre une flexibilité architecturale maximale,
+    mais elle fait du module de validation un point de défaillance unique pour
+    l'autorisation des connexions. À utiliser avec prudence.
    </para>
   </sect2>
  </sect1>
 
  <sect1 id="oauth-validator-init">
-  <title>Initialization Functions</title>
+  <title>Fonctions d'initialisation</title>
   <indexterm zone="oauth-validator-init">
    <primary>_PG_oauth_validator_module_init</primary>
   </indexterm>
   <para>
-   OAuth validator modules are dynamically loaded from the shared
-   libraries listed in <xref linkend="guc-oauth-validator-libraries"/>.
-   Modules are loaded on demand when requested from a login in progress.
-   The normal library search path is used to locate the library. To
-   provide the validator callbacks and to indicate that the library is an OAuth
-   validator module a function named
-   <function>_PG_oauth_validator_module_init</function> must be provided. The
-   return value of the function must be a pointer to a struct of type
-   <structname>OAuthValidatorCallbacks</structname>, which contains a magic
-   number and pointers to the module's token validation functions. The returned
-   pointer must be of server lifetime, which is typically achieved by defining
-   it as a <literal>static const</literal> variable in global scope.
+   Les modules de validation OAuth sont chargés dynamiquement à partir des
+   bibliothèques partagées listées dans <xref linkend="guc-oauth-validator-libraries"/>.
+   Les modules sont chargés à la demande lorsqu'une tentative de connexion le requiert.
+   Le chemin de recherche standard des bibliothèques est utilisé pour localiser la
+   bibliothèque. Pour fournir les fonctions de rappel du validateur et indiquer que la
+   bibliothèque est bien un module de validation OAuth, une fonction nommée
+   <function>_PG_oauth_validator_module_init</function> doit être définie.
+   La valeur de retour de cette fonction doit être un pointeur vers une structure
+   de type <structname>OAuthValidatorCallbacks</structname>, qui contient un nombre
+   magique ainsi que des pointeurs vers les fonctions de validation du module.
+   Le pointeur retourné doit avoir une durée de vie égale à celle du serveur,
+   ce qui est généralement obtenu en le définissant comme une variable
+   <literal>static const</literal> dans la portée globale.
 <programlisting>
 typedef struct OAuthValidatorCallbacks
 {
-    uint32        magic;            /* must be set to PG_OAUTH_VALIDATOR_MAGIC */
+    uint32        magic;            /* doit être défini à PG_OAUTH_VALIDATOR_MAGIC */
 
     ValidatorStartupCB startup_cb;
     ValidatorShutdownCB shutdown_cb;
@@ -318,27 +329,27 @@ typedef struct OAuthValidatorCallbacks
 typedef const OAuthValidatorCallbacks *(*OAuthValidatorModuleInit) (void);
 </programlisting>
 
-   Only the <function>validate_cb</function> callback is required, the others
-   are optional.
+   Seul le rappel <structfield>validate_cb</structfield> est obligatoire, les autres
+    sont optionnels.
   </para>
  </sect1>
 
  <sect1 id="oauth-validator-callbacks">
-  <title>OAuth Validator Callbacks</title>
+  <title>Fonctions de rappel du validateur OAuth</title>
   <para>
-   OAuth validator modules implement their functionality by defining a set of
-   callbacks. The server will call them as required to process the
-   authentication request from the user.
+   Les modules de validation OAuth implémentent leur fonctionnalité en définissant
+   un ensemble de fonctions de rappel. Le serveur les appelle selon les besoins
+   pour traiter la demande d'authentification de l'utilisateur.
   </para>
 
   <sect2 id="oauth-validator-callback-startup">
-   <title>Startup Callback</title>
+   <title>Rappel d'initialisation (Startup)</title>
    <para>
-    The <function>startup_cb</function> callback is executed directly after
-    loading the module. This callback can be used to set up local state and
-    perform additional initialization if required. If the validator module
-    has state it can use <structfield>state->private_data</structfield> to
-    store it.
+    Le rappel <function>startup_cb</function> est appelé immédiatement après
+    le chargement du module. Ce rappel peut être utilisé pour initialiser un état
+    local et effectuer d'autres actions d'initialisation si nécessaire.
+    Si le module de validation conserve un état, il peut l'enregistrer dans
+    <structfield>state->private_data</structfield>.
 
 <programlisting>
 typedef void (*ValidatorStartupCB) (ValidatorModuleState *state);
@@ -347,11 +358,11 @@ typedef void (*ValidatorStartupCB) (ValidatorModuleState *state);
   </sect2>
 
   <sect2 id="oauth-validator-callback-validate">
-   <title>Validate Callback</title>
+   <title>Rappel de validation</title>
    <para>
-    The <function>validate_cb</function> callback is executed during the OAuth
-    exchange when a user attempts to authenticate using OAuth.  Any state set in
-    previous calls will be available in <structfield>state->private_data</structfield>.
+    Le rappel <function>validate_cb</function> est exécuté lors de l'échange OAuth
+    lorsqu'un utilisateur tente de s'authentifier à l'aide d'OAuth. Tout état défini
+    dans des appels précédents sera disponible via <structfield>state->private_data</structfield>.
 
 <programlisting>
 typedef bool (*ValidatorValidateCB) (const ValidatorModuleState *state,
@@ -359,12 +370,12 @@ typedef bool (*ValidatorValidateCB) (const ValidatorModuleState *state,
                                      ValidatorModuleResult *result);
 </programlisting>
 
-    <replaceable>token</replaceable> will contain the bearer token to validate.
-    <application>PostgreSQL</application> has ensured that the token is well-formed syntactically, but no
-    other validation has been performed.  <replaceable>role</replaceable> will
-    contain the role the user has requested to log in as.  The callback must
-    set output parameters in the <literal>result</literal> struct, which is
-    defined as below:
+    <replaceable>token</replaceable> contiendra le jeton Bearer à valider.
+    <application>PostgreSQL</application> garantit que le jeton est syntaxiquement valide,
+    mais aucune autre validation n'a encore été effectuée.
+    <replaceable>role</replaceable> contiendra le rôle avec lequel l'utilisateur
+    souhaite se connecter. Le rappel doit renseigner les paramètres de sortie
+    dans la structure <literal>result</literal>, qui est définie comme suit :
 
 <programlisting>
 typedef struct ValidatorModuleResult
@@ -374,39 +385,43 @@ typedef struct ValidatorModuleResult
 } ValidatorModuleResult;
 </programlisting>
 
-    The connection will only proceed if the module sets
-    <structfield>result->authorized</structfield> to <literal>true</literal>.  To
-    authenticate the user, the authenticated user name (as determined using the
-    token) shall be palloc'd and returned in the <structfield>result->authn_id</structfield>
-    field.  Alternatively, <structfield>result->authn_id</structfield> may be set to
-    NULL if the token is valid but the associated user identity cannot be
-    determined.
+    La connexion ne se poursuivra que si le module définit
+    <structfield>result->authorized</structfield> à <literal>true</literal>.
+    Pour authentifier l'utilisateur, le nom d'utilisateur authentifié (déterminé
+    via le jeton) doit être alloué avec <function>palloc</function> et renvoyé
+    dans le champ <structfield>result->authn_id</structfield>.
+    Alternativement, <structfield>result->authn_id</structfield> peut être défini à
+    <literal>NULL</literal> si le jeton est valide, mais que l'identité de l'utilisateur
+    associée ne peut pas être déterminée.
    </para>
    <para>
-    A validator may return <literal>false</literal> to signal an internal error,
-    in which case any result parameters are ignored and the connection fails.
-    Otherwise the validator should return <literal>true</literal> to indicate
-    that it has processed the token and made an authorization decision.
+    Un validateur peut retourner <literal>false</literal> pour signaler une erreur interne,
+    dans ce cas, les autres paramètres du résultat sont ignorés et la connexion échoue.
+    Sinon, le validateur doit retourner <literal>true</literal> pour indiquer
+    que le jeton a été traité et qu'une décision d'autorisation a été prise.
    </para>
    <para>
-    The behavior after <function>validate_cb</function> returns depends on the
-    specific HBA setup.  Normally, the <structfield>result->authn_id</structfield> user
-    name must exactly match the role that the user is logging in as.  (This
-    behavior may be modified with a usermap.)  But when authenticating against
-    an HBA rule with <literal>delegate_ident_mapping</literal> turned on,
-    <productname>PostgreSQL</productname> will not perform any checks on the value of
-    <structfield>result->authn_id</structfield> at all; in this case it is up to the
-    validator to ensure that the token carries enough privileges for the user to
-    log in under the indicated <replaceable>role</replaceable>.
+    Le comportement après le retour de <function>validate_cb</function> dépend de la
+    configuration HBA spécifique. Normalement, le nom d'utilisateur dans
+    <structfield>result->authn_id</structfield> doit correspondre exactement au rôle
+    avec lequel l'utilisateur tente de se connecter (ce comportement peut être modifié
+    à l'aide d'une table de correspondance d'utilisateurs). Mais lorsqu'on utilise
+    une règle HBA avec <literal>delegate_ident_mapping</literal> activé,
+    <productname>PostgreSQL</productname> ne vérifiera pas la valeur de
+    <structfield>result->authn_id</structfield> ; dans ce cas, il revient
+    au validateur de s'assurer que le jeton confère les privilèges nécessaires
+    pour que l'utilisateur puisse se connecter avec le
+    <replaceable>role</replaceable> spécifié.
    </para>
   </sect2>
 
   <sect2 id="oauth-validator-callback-shutdown">
-   <title>Shutdown Callback</title>
+   <title>Rappel d'arrêt (Shutdown)</title>
    <para>
-    The <function>shutdown_cb</function> callback is executed when the backend
-    process associated with the connection exits. If the validator module has
-    any allocated state, this callback should free it to avoid resource leaks.
+    Le rappel <function>shutdown_cb</function> est appelé lorsque le processus
+    backend associé à la connexion se termine. Si le module de validation a
+    alloué de la mémoire ou d'autres ressources, ce rappel doit les libérer afin
+    d'éviter les fuites de mémoire.
 <programlisting>
 typedef void (*ValidatorShutdownCB) (ValidatorModuleState *state);
 </programlisting>


### PR DESCRIPTION
Hello.

J'ajoute encore ma petite pierre à l'édifice. En espérant l'avoir traduit correctement, j'avoue que les blocs techniques sont relativement durs à traduire. 

Je ne savais pas exemple pas si je devais traduire les callbacks en français (ce que j'ai fait en rappel). C'est un terme technique, mais ils sont cités dans une phrase. Je ne sais pas quelle est l'habitude pour ce point là. Si besoin je peux facilement corriger ce que j'ai fait. Il suffit de me le dire.