### PR TITLE
Colonnes générées *stockées*

### DIFF
--- a/postgresql/catalogs.xml
+++ b/postgresql/catalogs.xml
@@ -1028,7 +1028,7 @@
   <para>
    Le catalogue <structname>pg_attrdef</structname> stocke les expressions
    par défaut des colonnes et les expressions de génération par défaut.
-   Les informations principales sur les clonnes sont enregistrées dans <link
+   Les informations principales sur les colonnes sont enregistrées dans <link
    linkend="catalog-pg-attribute"><structname>pg_attribute</structname></link>.
    Seules les colonnes pour lesquelles une expression ou une génération par
    défaut a été configurée explicitement aura une entrée ici.
@@ -1312,11 +1312,11 @@
        <para>
         Si c'est un octet zéro (<literal>''</literal>), alors ce n'est pas une
         colonne générée.
-        Sinon, <literal>s</literal> = enregistrée, <literal>v</literal> =
-	virtuelle. Une colonne générée enregistrée est stockée physiquement
-	comme une colonne normale. Une colonne générée virtuelle est stockée
-	physiquement comme une valeur NULL, dont la valeur réelle est calculée
-	à l'exécution.
+        Sinon, <literal>s</literal> = stockée, <literal>v</literal> =
+        virtuelle. Une colonne générée stockée est stockée physiquement
+        comme une colonne normale. Une colonne générée virtuelle est stockée
+        physiquement comme une valeur NULL, dont la valeur réelle est calculée
+        à l'exécution.
        </para></entry>
      </row>
 
@@ -6620,10 +6620,10 @@ SCRAM-SHA-256$<replaceable>&lt;nombre d'itération&gt;</replaceable>:<replaceabl
       </para>
       <para>
        Contrôle comment gérer la réplication des colonnes générées lorsqu'il
-       n'y a plus de liste de colonnes de publication&nbsp;:
+       n'y a pas de liste de colonnes de publication&nbsp;:
        <literal>n</literal> = les colonnes générées dans les tables associées
        à la publication ne doivent pas être répliquées,
-       <literal>s</literal> = les colonnes générées enregistrées dans les
+       <literal>s</literal> = les colonnes générées stockées dans les
        tables associées à la publication doivent être répliquées.
       </para></entry>
      </row>

--- a/postgresql/ddl.xml
+++ b/postgresql/ddl.xml
@@ -451,7 +451,7 @@ CREATE TABLE people (
       utilisateur. Autrement dit, elle peut seulement utiliser des fonctions
       et types natifs. Ceci s'applique aussi indirectement, par exemple aux
       fonctions ou types utilisés par des opérateurs ou conversions. (Cette
-      restriction n'existe pas pour les colonnes générées enregistrées.)
+      restriction n'existe pas pour les colonnes générées stockées.)
      </para>
     </listitem>
     <listitem>
@@ -477,12 +477,12 @@ CREATE TABLE people (
       <listitem>
        <para>
         Si une colonne parent est une colonne générée, la colonne enfant doit
-        aussi être une colonne générée de même type (enregistrée ou virtuelle).
+        aussi être une colonne générée de même type (stockée ou virtuelle).
         Néanmoins, la colonne enfant peut
         avoir une expression de génération différente.
        </para>
        <para>
-        Pour les colonnes générées enregistrées,
+        Pour les colonnes générées stockées,
         lors de l'insertion ou de la mise à jour d'une ligne,
         l'expression de génération réellement appliquée est celle associée à la table
         contenant physiquement la ligne. (Ceci est contraire au comportement
@@ -594,7 +594,7 @@ CREATE TABLE people (
       ou en les incluant dans la liste de colonnes de la commande
       <command>CREATE PUBLICATION</command>.
       Pour le moment, ce n'est supporté que pour les colonnes
-      générées enregistrées.
+      générées stockées.
       Voir <xref linkend="logical-replication-gencols"/> pour les détails.
      </para>
     </listitem>

--- a/postgresql/ref/alter_table.xml
+++ b/postgresql/ref/alter_table.xml
@@ -275,7 +275,7 @@ KEY</literal>/<literal>REFERENCES</literal> vaut&nbsp;:</phrase>
      <listitem>
       <para>
        Cette clause remplace l'expression d'une colonne générée. Les données
-       existantes d'une colonne générée enregistrée sont réécrites et toutes
+       existantes d'une colonne générée stockée sont réécrites et toutes
        les modifications futures appliqueront la nouvelle expression.
       </para>
      </listitem>

--- a/postgresql/ref/create_publication.xml
+++ b/postgresql/ref/create_publication.xml
@@ -90,9 +90,9 @@ CREATE PUBLICATION <replaceable class="parameter">nom</replaceable>
      <para>
       Quand une liste de colonnes est indiquée, seules les colonnes nommées sont
       répliquées. La liste de colonnes peut aussi contenir des colonnes générées
-      enregistrées. Si la liste de colonnes est omise, la publication répliquera
+      stockées. Si la liste de colonnes est omise, la publication répliquera
       par défaut toutes les colonnes non générées (incluant celles ajoutées dans
-      le futur). Les colonnes générées enregistrées peuvent aussi être répliquées
+      le futur). Les colonnes générées stockées peuvent aussi être répliquées
       si <literal>publish_generated_columns</literal> est configuré à
       <literal>stored</literal>. Indiquer une liste de colonnes n'a pas d'effet
       sur les commandes <literal>TRUNCATE</literal>. Voir <xref
@@ -214,7 +214,7 @@ CREATE PUBLICATION <replaceable class="parameter">nom</replaceable>
          </para>
 
          <para>
-          Si configuré à <literal>stored</literal>, les colonnes générées enregistrées
+          Si configuré à <literal>stored</literal>, les colonnes générées stockées
           présentes dans les tables associées avec la publication seront répliquées.
          </para>
 

--- a/postgresql/ref/create_table.xml
+++ b/postgresql/ref/create_table.xml
@@ -981,7 +981,7 @@ contrainte <literal>EXCLUDE</literal> peut valoir&nbsp;:</phrase>
       utilisateur. Autrement dit, elle peut seulement utiliser des fonctions
       et types natifs. Cela s'applique aussi indirectement, par exemple pour
       les fonctions ou types faisant partie des opérateurs ou conversions.
-      (Cette restriction n'existe pas pour les colonnes générées enregistrées.)
+      (Cette restriction n'existe pas pour les colonnes générées stockées.)
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Remplacement de toutes les mentions "colonnes générées  enregistrées" par "colonnes générées stockées"

Suite à   https://github.com/gleu/pgdocs_fr/pull/312#issuecomment-3097318506

+ une typo et un faux-sens au passage