### PR TITLE
Relecture et traduction v18 de pg_dumpall

### DIFF
--- a/postgresql/ref/pg_dump.xml
+++ b/postgresql/ref/pg_dump.xml
@@ -1102,7 +1102,7 @@
        Ne pas attendre indéfiniment l'acquisition de verrous partagés sur
        les tables au démarrage de l'export. L'opération échoue s'il est
        impossible de verrouiller une table dans le délai spécifié par le
-       paramètre <replaceable class="parameter">timeout</replaceable>.
+       paramètre <replaceable class="parameter">expiration</replaceable>.
        Le délai peut être exprimé dans l'un des formats acceptés par la commande
        <command>SET statement_timeout</command>. Les formats autorisés dépendent
        de la version du serveur sur laquelle l'export est effectué, mais une

--- a/postgresql/ref/pg_dumpall.xml
+++ b/postgresql/ref/pg_dumpall.xml
@@ -13,8 +13,8 @@
  <refnamediv>
   <refname>pg_dumpall</refname>
   <refpurpose>exporter une instance de bases de données
-   <productname>PostgreSQL</productname> dans un script SQL ou dans un fichier
-   d'un autre format
+    <productname>PostgreSQL</productname> sous forme de script SQL ou dans
+    d'autres formats
   </refpurpose>
  </refnamediv>
 
@@ -30,45 +30,46 @@
   <title>Description</title>
 
   <para>
-   <application>pg_dumpall</application> est un outil d'extraction
-   (<quote>sauvegarde</quote>) de toutes les bases de données
-   <productname>PostgreSQL</productname> de l'instance vers un script SQL ou
-   une archive.
-   Celui-ci contient les commandes <acronym>SQL</acronym> utilisables pour
-   restaurer les bases de données avec <xref linkend="app-psql"/>. Cela est
-   obtenu en appelant <xref linkend="app-pgdump"/> pour chaque base de données
-   de l'instance. <application>pg_dumpall</application> sauvegarde aussi les
-   objets globaux, communs à toutes les bases de données, autrement dit les
-   rôles, les tablespaces et les droits pour les paramètres de configuration.
-   (<application>pg_dump</application> ne sauvegarde pas ces objets.)
+   <application>pg_dumpall</application> est un outil permettant d'exporter
+   l'ensemble des bases de données d'une instance
+   <productname>PostgreSQL</productname> sous forme de script SQL ou dans un
+   format d'archive.
+   Le résultat contient des commandes <acronym>SQL</acronym> pouvant être utilisées
+   comme entrée de <xref linkend="app-psql"/> pour restaurer les bases de données.
+   Pour cela, <application>pg_dumpall</application> appelle
+   <xref linkend="app-pgdump"/> pour chaque base de données de l'instance.
+   <application>pg_dumpall</application> exporte également les objets globaux
+   communs à toutes les bases, à savoir les rôles, les tablespaces,
+   et les droits d'accès sur les paramètres de configuration.
+   (<application>pg_dump</application> n'exporte pas ces objets.)
   </para>
 
   <para>
    Puisque <application>pg_dumpall</application> lit les tables de toutes les
-   bases de données, il est préférable d'avoir les droits de superutilisateur
-   de la base de données pour obtenir une sauvegarde complète. De plus, il
-   faut détenir des droits superutilisateur pour exécuter le script produit,
-   afin de pouvoir créer les rôles et les bases de données.
+   bases de données, il est généralement nécessaire de disposer des droits
+   de superutilisateur de la base pour produire un export complet. Par ailleurs,
+   il faut également être superutilisateur pour pouvoir exécuter le script
+   généré, notamment afin de créer des rôles et des bases de données.
   </para>
 
   <para>
-   Les scripts SQL sont écrits sur la sortie standard. Utilisez l'option
-   <option>-f</option>/<option>--file</option> ou les opérateurs shell pour la rediriger vers un fichier.
+   Le script SQL est écrit sur la sortie standard. Utilisez l'option
+   <option>-f</option>/<option>--file</option> ou les opérateurs shell pour le rediriger vers un fichier.
   </para>
 
   <para>
-   Les archives dans d'autres formats seront placées dans un répertoire dont le
+   Les archives dans d'autres formats sont placées dans un répertoire dont le
    nom est défini à l'aide de l'option <option>-f</option>/<option>--file</option>,
    qui est obligatoire dans ce cas.
   </para>
 
   <para>
    <application>pg_dumpall</application> se connecte plusieurs fois au serveur
-   <productname>PostgreSQL</productname> (une fois par base de données). Si
-   l'authentification par mot de passe est utilisé, un mot de passe est
-   demandé à chaque tentative de connexion. Il est intéressant de disposer
-   d'un fichier <filename>~/.pgpass</filename> dans de tels cas. Voir <xref
-   linkend="libpq-pgpass"/> pour plus d'informations.
+   <productname>PostgreSQL</productname> (une fois par base de données).
+   Si l'authentification par mot de passe est utilisée, un mot de passe sera
+   demandé à chaque connexion. Il est alors pratique de disposer d'un fichier
+   <filename>~/.pgpass</filename>.
+   Voir <xref linkend="libpq-pgpass"/> pour plus d'informations.
   </para>
 
  </refsect1>
@@ -77,7 +78,7 @@
   <title>Options</title>
 
   <para>
-   Les options suivantes, en ligne de commande, contrôlent le contenu et le
+   Les options en ligne de commande suivantes contrôlent le contenu et le
    format de la sortie.
 
    <variablelist>
@@ -86,8 +87,8 @@
      <term><option>--data-only</option></term>
      <listitem>
       <para>
-       Seules les données sont sauvegardées, pas le schéma (définition des
-       données) et les statistiques.
+       Seules les données sont exportées, et non le schéma (définitions des
+       données) ni les statistiques.
       </para>
      </listitem>
     </varlistentry>
@@ -98,12 +99,12 @@
      <listitem>
       <para>
        Émet des commandes SQL <command>DROP</command> pour supprimer toutes les
-       bases, rôles et tablespaces sauvegardés avant de les recréer.
-       Cette option est utile quand la restauration doit écraser une instance
-       existante. Si un des objets n'existe pas dans l'instance de destination,
-       les messages d'erreur, à ignorer, seront renvoyés lors de la
-       restauration sauf si l'option <option>--if-exists</option> est aussi
-       indiquée.
+       bases de données, rôles et tablespaces exportés, avant de les recréer.
+       Cette option est utile lorsque la restauration doit écraser une instance
+       existante. Si certains objets n'existent pas dans l'instance de destination,
+       des messages d'erreur (sans conséquence) seront affichés lors de la
+       restauration, sauf si l'option <option>--if-exists</option> est également
+       spécifiée.
       </para>
      </listitem>
     </varlistentry>
@@ -113,10 +114,10 @@
      <term><option>--encoding=<replaceable class="parameter">encoding</replaceable></option></term>
      <listitem>
       <para>
-       Crée la sauvegarde dans l'encodage spécifié. Par défaut, l'encodage de
-       la base est utilisé. (Une autre façon d'obtenir le même résultat est de
-       configurer la variable d'environnement <envar>PGCLIENTENCODING</envar>
-       avec l'encodage désiré pour la sauvegarde.)
+       Crée l'export dans l'encodage indiqué. Par défaut, l'export utilise
+       celui de la base de données. Le même résultat peut être obtenu en
+       définissant la variable d'environnement <envar>PGCLIENTENCODING</envar>
+       avec l'encodage souhaité.
       </para>
      </listitem>
     </varlistentry>
@@ -126,10 +127,10 @@
      <term><option>--file=<replaceable class="parameter">nomfichier</replaceable></option></term>
      <listitem>
       <para>
-       Envoie le résultat dans le fichier indiqué. Si cette option n'est pas
-       spécifiée, la sortie standard est utilisée.
-       Remarque&nbsp;: cette option ne peut être omise que lorsque l'option <option>--format</option>
-       est définie à <literal>plain</literal>.
+       Envoie la sortie dans le fichier indiqué. Si cette option est omise,
+       la sortie standard est utilisée.
+       Remarque&nbsp;: cette option ne peut être omise que lorsque
+       <option>--format</option> est défini à <literal>plain</literal>.
       </para>
      </listitem>
     </varlistentry>
@@ -139,13 +140,13 @@
      <term><option>--format=<replaceable class="parameter">format</replaceable></option></term>
      <listitem>
       <para>
-       Spécifie le format des fichiers de sauvegarde. En format <quote>plain</quote>,
-       toutes les données sont envoyées dans un seul flux texte. C'est le comportement par défaut.
+       Spécifie le format des fichiers de l'export. En format <quote>plain</quote>,
+       toutes les données sont envoyées dans un flux texte unique. C'est le comportement par défaut.
 
        Dans tous les autres modes, <application>pg_dumpall</application> crée d'abord deux fichiers :
        <filename>global.dat</filename> et <filename>map.dat</filename>, dans le répertoire
        spécifié par l'option <option>--file</option>.
-       Le premier contient les données globales, comme les rôles et les tablespaces. Le second
+       Le premier contient les données globales, telles que les rôles et les tablespaces. Le second
        contient une correspondance entre les OID des bases de données et leurs noms. Ces fichiers
        sont utilisés par <application>pg_restore</application>. Les données de chaque base de données
        sont placées dans un sous-répertoire <filename>databases</filename>, nommé à l'aide de
@@ -157,9 +158,9 @@
          <term><literal>directory</literal></term>
          <listitem>
           <para>
-           Produit une archive au format <quote>répertoire</quote> pour chaque
-           base de données, utilisable par <application>pg_restore</application>.
-           Le répertoire aura pour nom l'<type>OID</type> de la base de données.
+           Produit des archives au format <quote>répertoire</quote> pour chaque
+           base de données, utilisables en entrée de <application>pg_restore</application>.
+           Chaque répertoire est nommé d'après l'<type>OID</type> de la base concernée.
           </para>
          </listitem>
         </varlistentry>
@@ -180,9 +181,9 @@
          <listitem>
           <para>
            Produit une archive au format personnalisé pour chaque base de données,
-           utilisable par <application>pg_restore</application>. L'archive sera nommée
-           <filename>dboid.dmp</filename> où <type>dboid</type> est l'<type>oid</type>
-           de la base de données.
+           utilisable en entrée de <application>pg_restore</application>. L'archive est
+           nommée <filename>dboid.dmp</filename>, où <type>dboid</type> correspond à
+           l'<type>OID</type> de la base.
           </para>
          </listitem>
         </varlistentry>
@@ -193,16 +194,16 @@
          <listitem>
           <para>
            Produit une archive au format <literal>tar</literal> pour chaque base de données,
-           utilisable par <application>pg_restore</application>. L'archive sera nommée
-           <filename>dboid.tar</filename> où <type>dboid</type> est l'<type>oid</type>
-           de la base de données.
+           utilisable en entrée de <application>pg_restore</application>. L'archive est
+           nommée <filename>dboid.tar</filename>, où <type>dboid</type> correspond à
+           l'<type>OID</type> de la base.
           </para>
          </listitem>
         </varlistentry>
        </variablelist>
 
         Remarque&nbsp;: voir <xref linkend="app-pgdump"/> pour plus de détails
-        sur le fonctionnement des différents formats d'archives non textuels.
+        sur le fonctionnement des différents formats d'archives autres que le format texte.
        </para>
       </listitem>
      </varlistentry>
@@ -212,8 +213,8 @@
      <term><option>--globals-only</option></term>
      <listitem>
       <para>
-       Seuls les objets globaux sont sauvegardés (rôles et tablespaces), pas
-       les bases de données.
+       Exporte seulement les objets globaux (rôles et tablespaces), pas les
+       bases de données.
       </para>
      </listitem>
     </varlistentry>
@@ -223,16 +224,15 @@
      <term><option>--no-owner</option></term>
      <listitem>
       <para>
-       Les commandes permettant de positionner les propriétaires des objets à
-       ceux de la base de données originale. Par défaut,
-       <application>pg_dumpall</application> lance les instructions
+       N'émet pas de commandes pour rétablir les propriétaires d'origine des objets.
+       Par défaut, <application>pg_dumpall</application> génère des instructions
        <command>ALTER OWNER</command> ou <command>SET SESSION
-        AUTHORIZATION</command> pour configurer le propriétaire des éléments
-       créés. Ces instructions échouent lorsque le script est lancé par un
-       utilisateur ne disposant pas des droits de superutilisateur (ou ne
-       possédant pas les droits du propriétaire de tous les objets compris
-       dans ce script). Pour que ce qui devient alors propriétaire de tous les
-       objets créés, l'option <option>-O</option> doit être utilisée.
+        AUTHORIZATION</command> pour attribuer aux éléments créés les mêmes
+       propriétaires que dans la base d'origine. Ces instructions échoueront si
+       le script est exécuté par un utilisateur autre qu'un superutilisateur,
+       ou que le propriétaire de tous les objets. Pour générer un script pouvant
+       être restauré par n'importe quel utilisateur, qui deviendra alors
+       propriétaire de tous les objets, utilisez l'option <option>-O</option>.
       </para>
      </listitem>
     </varlistentry>
@@ -242,7 +242,7 @@
      <term><option>--roles-only</option></term>
      <listitem>
       <para>
-       Sauvegarde seulement les rôles, pas les bases ni les tablespaces.
+       Exporte seulement les rôles, pas les bases ni les tablespaces.
       </para>
      </listitem>
     </varlistentry>
@@ -252,8 +252,7 @@
      <term><option>--schema-only</option></term>
      <listitem>
       <para>
-       Seules les définitions des objets (schéma), sans les données, sont
-       sauvegardées.
+       Exporte seulement les définitions des objets (le schéma), pas les données.
       </para>
      </listitem>
     </varlistentry>
@@ -265,9 +264,9 @@
       <para>
        Précise le nom du superutilisateur à utiliser pour la désactivation des
        triggers. Cela n'a d'intérêt que lorsque
-       <option>--disable-triggers</option> est utilisé. (Il est en général
-       préférable de ne pas utiliser cette option et de lancer le script
-       résultant en tant que superutilisateur.)
+       <option>--disable-triggers</option> est utilisé. (Il est généralement
+       préférable de ne pas utiliser cette option, et d'exécuter le script
+       résultant directement en tant que superutilisateur.)
       </para>
      </listitem>
     </varlistentry>
@@ -277,7 +276,7 @@
      <term><option>--tablespaces-only</option></term>
      <listitem>
       <para>
-       Sauvegarde seulement les tablespaces, ni les bases ni les rôles.
+       Exporte seulement les tablespaces, pas les bases de données ni les rôles.
       </para>
      </listitem>
     </varlistentry>
@@ -287,12 +286,12 @@
      <term><option>--verbose</option></term>
      <listitem>
       <para>
-       Indique l'utilisation du mode verbeux. Ainsi
-       <application>pg_dumpall</application> affiche les heures de
-       démarrage/arrêt dans le fichier de sauvegarde et les messages de
-       progression sur la sortie standard. Répéter l'option entraîne
-       l'apparition de messages de débogage supplémentaires sur la sortie
-       d'erreur standard. Cette option est aussi passée à
+       Active le mode verbeux. Dans ce mode,
+       <application>pg_dumpall</application> inscrit les heures de
+       début et de fin dans le fichier d'export, et affiche les messages de
+       progression sur la sortie d'erreur standard. Si l'option est répétée,
+       des messages de débogage supplémentaires seront affichés sur la sortie
+       d'erreur standard. Cette option est également transmise à
        <application>pg_dump</application>.
       </para>
      </listitem>
@@ -315,7 +314,7 @@
      <term><option>--no-acl</option></term>
      <listitem>
       <para>
-       Les droits d'accès (commandes GRANT/REVOKE) ne sont pas sauvegardés.
+       N'exporte pas les droits d'accès (commandes grant/revoke).
       </para>
      </listitem>
     </varlistentry>
@@ -324,10 +323,10 @@
      <term><option>--binary-upgrade</option></term>
      <listitem>
       <para>
-       Cette option est destinée à être utilisée pour une mise à jour en
-       ligne. Son utilisation dans d'autres buts n'est ni recommandée ni
-       supportée. Le comportement de cette option peut changer dans les
-       versions futures sans avertissement.
+       Cette option est destinée à être utilisée par les utilitaires de mise à
+       jour en ligne. Son utilisation à d'autres fins n'est ni recommandée ni
+       supportée. Le comportement de cette option peut changer sans préavis
+       dans de futures versions.
       </para>
      </listitem>
     </varlistentry>
@@ -337,12 +336,12 @@
      <term><option>--attribute-inserts</option></term>
      <listitem>
       <para>
-       Extraire les données en tant que commandes <command>INSERT</command>
+       Extrait les données sous forme de commandes <command>INSERT</command>
        avec des noms de colonnes explicites (<literal>INSERT INTO
         <replaceable>table</replaceable> (<replaceable>colonne</replaceable>,
         ...) VALUES ...</literal>). Ceci rendra la restauration très
-       lente&nbsp;; c'est surtout utile pour créer des extractions qui
-       puissent être chargées dans des bases de données autres que
+       lente&nbsp;; c'est surtout utile pour créer des exports qui
+       puissent être chargés dans des bases de données autres que
        <productname>PostgreSQL</productname>.
       </para>
      </listitem>
@@ -352,9 +351,9 @@
      <term><option>--disable-dollar-quoting</option></term>
      <listitem>
       <para>
-       L'utilisation du dollar comme guillemet dans le corps des fonctions est
-       désactivée. Celles-ci sont mises entre guillemets en accord avec la
-       syntaxe du standard SQL.
+       Cette option désactive l'utilisation du caractère dollar comme
+       délimiteur de corps de fonctions, et force leur délimitation en tant
+       que chaîne SQL standard.
       </para>
      </listitem>
     </varlistentry>
@@ -363,22 +362,21 @@
      <term><option>--disable-triggers</option></term>
      <listitem>
       <para>
-       Cette option n'est utile que lors de la création d'une sauvegarde des
-       seules données et sans structure. <application>pg_dumpall</application>
-       inclut les
-       commandes de désactivation temporaire des triggers sur les tables
-       cibles pendant le rechargement des données. Cette option est utile
-       lorsqu'il existe des vérifications d'intégrité référentielle ou des
-       triggers sur les tables qu'on ne souhaite pas voir appelés lors du
-       rechargement des données.
+       Cette option ne s'applique que dans le cas d'un export incluant les
+       données mais pas la structure.
+       Ceci demande à <application>pg_dumpall</application> d'inclure des
+       commandes pour désactiver temporairement les triggers sur les tables
+       cibles pendant que les données sont rechargées. Utilisez cette option si,
+       sur vos tables, vous avez des contraintes d'intégrité ou des triggers que
+       vous ne voulez pas invoquer pendant le rechargement.
       </para>
 
       <para>
-       Actuellement, les commandes émises par
-       <option>--disable-triggers</option> nécessitent d'être lancées par un
-       superutilisateur. Il est donc impératif de préciser le nom du
-       superutilisateur avec <option>-S</option> ou, préférentiellement, de
-       lancer le script résultant en tant que superutilisateur.
+       À l'heure actuelle, les commandes émises par
+       <option>--disable-triggers</option> doivent être exécutées en tant que
+       superutilisateur. Par conséquent, vous devez aussi spécifier un nom de
+       superutilisateur avec <option>-S</option>, ou préférablement faire
+       attention à lancer le script généré en tant que superutilisateur.
       </para>
      </listitem>
     </varlistentry>
@@ -387,18 +385,17 @@
      <term><option>--exclude-database=<replaceable class="parameter">motif</replaceable></option></term>
      <listitem>
       <para>
-       Ne pas sauvegarder les bases dont le nom correspond à <replaceable
-       class="parameter">motif</replaceable>. Plusieurs motifs peuvent être
-       proposés en écrivant plusieurs fois l'option
-       <option>--exclude-database</option>. Le paramètre <replaceable
-       class="parameter">motif</replaceable> est interprété comme un motif
-       suivant les mêmes règles que les méta-commandes <literal>\d</literal>
-       de <application>psql</application> (voir <xref
-       linkend="app-psql-patterns"/>), donc
-       plusieurs bases de données peuvent aussi être exclues en écrivant les
-       caractères joker dans le motif. En utilisant les caractères joker,
-       faite attention à bien mettre entre guillemets le motif si nécessaire
-       pour empêcher qu'il ne soit interprété par le shell.
+       N'exporte pas les bases de données dont le nom correspond au <replaceable
+        class="parameter">motif</replaceable>. Plusieurs motifs peuvent être
+       spécifiés en répétant l'option <option>--exclude-database</option>.
+       Le paramètre <replaceable class="parameter">motif</replaceable> est
+       interprété selon les mêmes règles que que celles utilisées par les
+       méta-commandes <literal>\d</literal> de <application>psql</application>
+       (voir <xref linkend="app-psql-patterns"/>).
+       Il est donc possible d'exclure plusieurs bases de données en utilisant
+       les caractères joker dans le motif. Si vous utilisez des jokers,
+       faites attention à mettre le motif entre guillemets pour éviter qu'il
+       ne soit interprété par le shell.
       </para>
      </listitem>
     </varlistentry>
@@ -407,10 +404,10 @@
      <term><option>--extra-float-digits=<replaceable class="parameter">nchiffres</replaceable></option></term>
      <listitem>
       <para>
-       Utiliser la valeur indiquée pour le paramètre extra_float_digits lors
-       de la sauvegarde de données en virgule flottante au lieu de prendre la
-       précision maximale disponible. Les sauvegardes standards ne devraient
-       pas utiliser cette option.
+       Utilise la valeur spécifiée pour <option>extra_float_digits</option>
+       lors de l'export de valeurs en virgule flottante, au lieu de la précision
+       maximale disponible. Cette option ne doit pas être utilisée pour des
+       exports de routine effectués à des fins de sauvegarde.
       </para>
      </listitem>
     </varlistentry>
@@ -419,30 +416,30 @@
      <term><option>--filter=<replaceable class="parameter">nom_fichier</replaceable></option></term>
      <listitem>
       <para>
-       Indique un nom de fichier à partir duquel lire des motifs pour les
-       bases exclues de la sauvegarde. Les motifs sont interprétés
-       suivant les mêmes règles que pour <option>--exclude-database</option>.
-       Pour lire à partir de l'entrée standard <literal>STDIN</literal>,
+       Indique un fichier contenant les motifs des bases de données à exclure
+       de l'export. Ces motifs sont interprétés selon les mêmes règles que pour
+       <option>--exclude-database</option>.
+       Pour lire à partir de l'entrée standard (<literal>STDIN</literal>),
        utilisez <filename>-</filename> comme nom de fichier. L'option
-       <option>--filter</option> peut être utilisée en même temps que
-       <option>--exclude-database</option> pour exclure des bases, et peut
-       aussi être utilisée plusieurs fois pour différents fichiers de filtres.
+       <option>--filter</option> peut être utilisée en combinaison avec
+       <option>--exclude-database</option>, et peut être spécifiée
+       plusieurs fois pour indiquer plusieurs fichiers de filtres.
       </para>
 
       <para>
-       Le fichier liste un motif de base par ligne, en suivant le format
-       ci-dessous&nbsp;:
+       Le fichier contient un motif de base de données par ligne, selon le
+       format suivant&nbsp;:
 <synopsis>
 exclude database <replaceable class="parameter">MOTIF</replaceable>
 </synopsis>
       </para>
 
       <para>
-       Les lignes commençant avec <literal>#</literal> sont considérées comme
-       des commentaires et sont donc ignorées. Les commentaires peuvent être
-       placés après une ligne de motif d'objet. Les lignes vides sont aussi
-       ignorées. Voir <xref linkend="app-psql-patterns"/> pour savoir
-       comment gérer les guillemets dans les motifs.
+       Les lignes commençant par <literal>#</literal> sont interprétées comme
+       des commentaires et sont ignorées. Il est également possible d'ajouter
+       des commentaires à la fin d'une ligne contenant un motif. Les lignes vides
+       sont elles aussi ignorées. Voir <xref linkend="app-psql-patterns"/> pour
+       plus d'informations sur le traitement des guillemets dans les motifs.
       </para>
 
      </listitem>
@@ -453,10 +450,10 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <listitem>
       <para>
        Utilise des commandes <literal>DROP ... IF EXISTS</literal> pour
-       supprimer des objets dans le mode <option>--clean</option>. Cela
-       permet de supprimer les erreurs <quote>does not exist</quote> qui
-       seraient sinon renvoyées. Cette option n'est pas valide sauf si
-       <option>--clean</option> est aussi indiquée.
+       supprimer les objets dans le mode <option>--clean</option>. Cela
+       permet d'éviter les erreurs <quote>does not exist</quote> qui
+       seraient sinon renvoyées. Cette option n'est valable que si
+       <option>--clean</option> est aussi spécifiée.
       </para>
      </listitem>
     </varlistentry>
@@ -465,12 +462,12 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--inserts</option></term>
      <listitem>
       <para>
-       Extraire les données en tant que commandes <command>INSERT</command>
-       (plutôt que <command>COPY</command>). Ceci rendra la restauration très
-       lente&nbsp;; c'est surtout utile pour créer des extractions qui
-       puissent être chargées dans des bases de données autres que
+       Extrait les données en tant que commandes <command>INSERT</command>
+       (plutôt que <command>COPY</command>). Cela rendra la restauration très
+       lente&nbsp;; c'est surtout utile pour créer des exports pouvant être
+       chargés dans des bases de données autres que
        <productname>PostgreSQL</productname>. Notez que la restauration peut
-       échouer complètement si vous avez changé l'ordre des colonnes. L'option
+       échouer complètement si l'ordre des colonnes a été modifié. L'option
        <option>--column-inserts</option> est plus sûre, mais encore plus
        lente.
       </para>
@@ -481,17 +478,16 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--load-via-partition-root</option></term>
      <listitem>
       <para>
-       Lors de l'export de données d'une partition, faire que les instructions
-       <command>COPY</command> ou <command>INSERT</command> ciblent la racine
-       du partitionnement qui contient cette partition, plutôt que la
-       partition elle-même. Ceci fait que la partition appropriée soit
-       re-déterminée pour chaque ligne au moment du chargement. Ceci peut être
-       utile quand le rechargement des données se fait sur un serveur où les
-       lignes ne tomberont pas forcément dans les mêmes partitions que celles
-       du serveur original. Ceci pourrait arriver si la colonne de
-       partitionnement est de type text et que les deux systèmes ont une
-       définition différente du collationnement utilisé pour tier la colonne
-       de partitionnement.
+       Lors de l'export de données d'une partition, les instructions
+       <command>COPY</command> ou <command>INSERT</command> cibleront la racine
+       du partitionnement à laquelle elle appartient, plutôt que la
+       partition elle-même. Cela entraîne une réévaluation de la partition
+       appropriée pour chaque ligne au moment du chargement. Ceci peut être
+       utile lors de la restauration sur un serveur où les lignes ne seraient pas
+       forcément réparties dans les mêmes partitions que sur le serveur d'origine.
+       Cela peut se produire, par exemple, si la colonne de partitionnement est
+       de type text et que les deux systèmes ont des définitions différentes du
+       collationnement utilisé pour trier cette colonne.
       </para>
      </listitem>
     </varlistentry>
@@ -501,48 +497,11 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <listitem>
       <para>
        Ne pas attendre indéfiniment l'acquisition de verrous partagés sur
-       table au démarrage de l'extraction. Échouer à la place s'il est
-       impossible de verrouiller une table dans le temps d'<replaceable
-       class="parameter">expiration</replaceable> spécifié. L'expiration peut
-       être indiquée dans tous les formats acceptés par <command>SET
-        statement_timeout</command>.
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><option>--no-sync</option></term>
-     <listitem>
-      <para>
-       Par défaut, <command>pg_dumpall</command> attendra que tous les
-       fichiers aient été écrits de manière sûre sur disque.  Cette option
-       force <command>pg_dumpall</command> à rendre la main sans attendre, ce
-       qui est plus rapide, mais signifie qu'un arrêt brutal du serveur
-       survenant après la sauvegarde peut laisser la sauvegarde dans un état
-       corrompu. De manière générale, cette option est utile durant les tests
-       mais ne devrait pas être utilisée dans un environnement de production.
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><option>--no-table-access-method</option></term>
-     <listitem>
-      <para>
-       Ne pas générer de commandes pour sélectionner les méthodes d'accès aux
-       tables. Avec cette option, tous les objets seront créés avec la méthode
-       d'accès de table par défaut lors de la restauration.
-      </para>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry>
-     <term><option>--no-tablespaces</option></term>
-     <listitem>
-      <para>
-       Ne pas générer de commandes pour créer des tablespace, ni sélectionner
-       de tablespace pour les objets. Avec cette option, tous les objets
-       seront créés dans le tablespace par défaut durant la restauration.
+       les tables au démarrage de l'export. L'opération échoue s'il est
+       impossible de verrouiller une table dans le délai spécifié par le
+       paramètre <replaceable class="parameter">expiration</replaceable>.
+       Le délai peut être exprimé dans l'un des formats acceptés par la commande
+       <command>SET statement_timeout</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -589,11 +548,11 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
       <para>
        Ne pas exporter les mots de passe des rôles. Lors de la restauration,
        les rôles auront un mot de passe vide et l'authentification par mot de
-       passe échouera toujours jusqu'à ce que le mot de passe soit initialisé.
+       passe échouera systématiquement tant qu'un mot de passe n'aura pas été défini.
        Puisque les valeurs des mots de passe ne sont pas nécessaires quand
        cette option est spécifiée, l'information sur le rôle est lue depuis le
        catalogue système <structname>pg_roles</structname> au lieu de
-       <structname>pg_authid</structname>. De ce fait, cette option aide aussi
+       <structname>pg_authid</structname>. Cette option est donc également utile
        si l'accès à <structname>pg_authid</structname> est restreint par
        certaines politiques de sécurité.
       </para>
@@ -637,10 +596,47 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
     </varlistentry>
 
     <varlistentry>
+     <term><option>--no-sync</option></term>
+     <listitem>
+      <para>
+       Par défaut, <command>pg_dumpall</command> attend que tous les fichiers
+       soient correctement écrits sur disque. Cette option permet à
+       <command>pg_dumpall</command> de rendre la main immédiatement, sans attendre,
+       ce qui est plus rapide, mais peut entraîner une corruption de l'export
+       en cas d'arrêt brutal du système d'exploitation.
+       De manière générale, cette option est utile pour les tests, mais ne
+       doit pas être utilisée dans un environnement de production.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term><option>--no-table-access-method</option></term>
+     <listitem>
+      <para>
+       Ne pas générer de commandes pour sélectionner les méthodes d'accès aux
+       tables. Avec cette option, tous les objets seront créés avec la méthode
+       d'accès aux tables par défaut lors de la restauration.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
+     <term><option>--no-tablespaces</option></term>
+     <listitem>
+      <para>
+       Ne pas générer de commandes pour créer des tablespaces, ni sélectionner
+       de tablespace pour les objets. Avec cette option, tous les objets
+       seront créés dans le tablespace par défaut durant la restauration.
+      </para>
+     </listitem>
+    </varlistentry>
+
+    <varlistentry>
      <term><option>--no-toast-compression</option></term>
      <listitem>
       <para>
-       Ne pas exporter les commandes pour configurer les méthodes de compression
+       N'émet pas de commandes pour définir les méthodes de compression
        des colonnes <acronym>TOAST</acronym>. Avec cette option, toutes les
        colonnes seront restaurées avec les paramètres de compression par défaut.
       </para>
@@ -653,8 +649,8 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
       <para>
        Ne pas exporter le contenu des tables non journalisées
        (<quote>unlogged</quote>). Cette option n'a aucun effet sur l'export des
-       définitions de ces tables&nbsp;; elle empêche uniquement l'export de
-       leurs données.
+       définitions de ces tables&nbsp;; elle empêche uniquement l'export
+       de leurs données.
       </para>
      </listitem>
     </varlistentry>
@@ -664,9 +660,9 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <listitem>
       <para>
        Ajoute <literal>ON CONFLICT DO NOTHING</literal> aux commandes
-       <command>INSERT</command>. Cette option n'est valide que si
+       <command>INSERT</command>. Cette option n'est valable que si
        <option>--inserts</option> ou <option>--column-inserts</option> est
-       aussi indiquée.
+       également spécifiée.
       </para>
      </listitem>
     </varlistentry>
@@ -675,18 +671,18 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--quote-all-identifiers</option></term>
      <listitem>
       <para>
-       Force la mise entre guillemets de tous les identifiants. Cette option
-       est recommandée lors de la sauvegarde d'un serveur
-       <productname>PostgreSQL</productname> dont la version majeure est
-       différente de celle du <application>pg_dumpall</application> ou quand
-       le résultat est prévu d'être rechargé dans une autre version majeure.
-       Par défaut, <application>pg_dumpall</application> met entre guillemets
-       uniquement les identifiants qui sont des mots réservés dans sa propre
-       version majeure. Ceci peut poser parfois des problèmes de compatibilité
-       lors de l'utilisation de serveurs de versions différentes qui auraient
-       des ensembles différents de mots clés. Utiliser
-       <option>--quote-all-identifiers</option> empêche ce type de problèmes
-       au prix d'un script résultant plus difficile à lire.
+       Forcer la mise entre guillemets de tous les identifiants. Cette option
+       est recommandée lorsqu'on exporte une base de données depuis un serveur
+       dont la version majeure de <productname>PostgreSQL</productname> diffère
+       de celle de <application>pg_dumpall</application>, ou lorsque l'export
+       est destiné à être rechargé dans une version majeure différente.
+       Par défaut, <application>pg_dumpall</application> ne met entre guillemets
+       que les identifiants correspondants à des mots réservés dans sa propre
+       version majeure. Cela peut parfois entraîner des problèmes de compatibilité
+       avec des serveurs de versions différentes, dont la liste des mots
+       réservés peut légèrement varier. L'utilisation de l'option
+       <option>--quote-all-identifiers</option> permet d'éviter ce type de problème,
+       au prix d'un script d'export moins lisible.
       </para>
      </listitem>
     </varlistentry>
@@ -695,14 +691,13 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--rows-per-insert=<replaceable class="parameter">nlignes</replaceable></option></term>
      <listitem>
       <para>
-       Sauvegarde les données sous forme de commandes
-       <command>INSERT</command> (plutôt que <command>COPY</command>).
+       Exporter les données sous la forme de commandes
+       <command>INSERT</command> (au lieu de <command>COPY</command>).
        Contrôle le nombre maximum de lignes par commande
-       <command>INSERT</command>. La valeur spécifiée doit être un nombre
-       supérieur à zéro. Toute erreur lors du rechargement causera seulement
-       la perte des lignes faisant partie de l'opération
-       <command>INSERT</command> problématique, plutôt que la part du contenu
-       complet de la table.
+       <command>INSERT</command>. La valeur indiquée doit être strictement
+       positive. Toute erreur lors du rechargement provoquera uniquement la
+       perte des lignes faisant partie du <command>INSERT</command>
+       problématique, et non pas le contenu complet de la table.
       </para>
      </listitem>
     </varlistentry>
@@ -733,12 +728,12 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--use-set-session-authorization</option></term>
      <listitem>
       <para>
-       Les commandes <command>SET SESSION AUTHORIZATION</command> du standard
-       SQL sont affichées à la place des commandes <command>ALTER
-        OWNER</command> pour préciser le propriétaire de l'objet. Cela améliore
-       la compatibilité de la sauvegarde vis-à-vis des standard. Toutefois, du
-       fait de l'ordre d'apparition des objets dans la sauvegarde, la
-       restauration peut ne pas être correcte.
+       Émettre des commandes SQL standard <command>SET SESSION
+        AUTHORIZATION</command> à la place de commandes <command>ALTER
+        OWNER</command> pour définir la propriété des objets. Ceci rend
+       l'extraction davantage compatible avec les standards, mais, suivant
+       l'historique des objets exportés, la restauration pourrait ne pas fonctionner
+       correctement.
       </para>
      </listitem>
     </varlistentry>
@@ -793,20 +788,19 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--dbname=<replaceable class="parameter">connstr</replaceable></option></term>
      <listitem>
       <para>
-       Indique les paramètres utilisés pour se connecter au serveur sous la
-       forme d'une <link linkend="libpq-connstring">chaîne de
-        connexion</link>&nbsp;; elles surchargeront les options en ligne de
-       commande conflictuelles.
+       Indique les paramètres de connexion au serveur, sous la forme d'une
+       <link linkend="libpq-connstring">chaîne de connexion</link>&nbsp;; ils
+       prévaudront sur toute option en ligne de commande conflictuelle.
       </para>
 
       <para>
        Cette option est appelée <literal>--dbname</literal> par cohérence avec
-       les autres applications clientes. Comme
-       <application>pg_dumpall</application> a besoin de se connecter à
-       plusieurs bases de données, le nom de la base indiqué dans la chaîne de
-       connexion sera ignorée. Utilisez l'option <literal>-l</literal> pour
-       spécifier le nom de la base utilisée pour la connexion initiale
-       sauvegardant les objets globaux et découvrant les bases à sauvegarder.
+       les autres applications clientes. Toutefois, comme
+       <application>pg_dumpall</application> doit se connecter à plusieurs bases
+       de données, le nom de la base indiqué dans la chaîne de connexion sera
+       ignoré. Utilisez l'option <literal>-l</literal> pour spécifier le nom de
+       la base à utiliser pour la connexion initiale, qui servira à exporter les
+       objets globaux et à déterminer les bases de données à extraire.
       </para>
      </listitem>
     </varlistentry>
@@ -816,12 +810,12 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--host=<replaceable>hôte</replaceable></option></term>
      <listitem>
       <para>
-       Précise le nom d'hôte de la machine sur laquelle le serveur de bases de
-       données est en cours d'exécution. Si la valeur commence avec un slash,
-       elle est utilisée comme répertoire du socket de domaine Unix. La valeur
-       par défaut est prise à partir de la variable d'environnement
-       <envar>PGHOST</envar>, si elle est initialisée, sinon une connexion
-       socket de domaine Unix est tentée.
+       Indique le nom d'hôte de la machine sur laquelle le serveur de bases de
+       données est en cours d'exécution. Si la valeur commence par une barre
+       oblique (/), elle est interprétée comme le répertoire du socket de
+       domaine Unix. Par défaut, la valeur est tirée de la variable
+       d'environnement <envar>PGHOST</envar>, si elle est définie&nbsp;;
+       sinon, une connexion via socket de domaine Unix est tentée.
       </para>
      </listitem>
     </varlistentry>
@@ -831,10 +825,10 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--database=<replaceable>dbname</replaceable></option></term>
      <listitem>
       <para>
-       Spécifie le nom de la base où se connecter pour la sauvegarde des
-       objets globaux et pour découvrir les bases qui devraient être
-       sauvegardées. Si cette option n'est pas utilisée, la base
-       <literal>postgres</literal> est utilisé et, si elle n'existe pas,
+       Spécifie le nom de la base de données à laquelle se connecter pour
+       exporter les objets globaux et déterminer les bases de données à
+       extraire. Si cette option n'est pas précisée, la base
+       <literal>postgres</literal> sera utilisée et, si elle n'existe pas,
        <literal>template1</literal> sera utilisée.
       </para>
      </listitem>
@@ -845,10 +839,11 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--port=<replaceable>port</replaceable></option></term>
      <listitem>
       <para>
-       Précise le port TCP ou l'extension du fichier socket de domaine Unix
-       local sur lequel le serveur est en écoute des connexions. La valeur par
-       défaut est la variable d'environnement <envar>PGPORT</envar>, si elle
-       est initialisée, ou la valeur utilisée lors de la compilation.
+       Indique le port TCP ou le suffixe du fichier socket de domaine Unix local
+       sur lequel le serveur écoute les connexions. La valeur par défaut est
+       celle de la variable d'environnement <envar>PGPORT</envar>, si elle est
+       définie. Dans le cas contraire, il s'agit de la valeur fournie à la
+       compilation.
       </para>
      </listitem>
     </varlistentry>
@@ -858,7 +853,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--username=<replaceable>nomutilisateur</replaceable></option></term>
      <listitem>
       <para>
-       Utilisateur utilisé pour initier la connexion.
+       Indique le nom d'utilisateur utilisé pour la connexion.
       </para>
      </listitem>
     </varlistentry>
@@ -868,12 +863,12 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-password</option></term>
      <listitem>
       <para>
-       Ne demande jamais un mot de passe. Si le serveur en réclame un pour
-       l'authentification et qu'un mot de passe n'est pas disponible d'une
-       autre façon (par exemple avec le fichier <filename>.pgpass</filename>),
-       la tentative de connexion échouera. Cette option peut être utile pour
-       les scripts où aucun utilisateur n'est présent pour saisir un mot de
-       passe.
+       Ne jamais demander de mot de passe. Si le serveur requiert une
+       authentification par mot de passe et qu'aucun mot de passe n'est disponible
+       par un autre moyen (par exemple via le fichier <filename>.pgpass</filename>),
+       la tentative de connexion échouera. Cette option peut être utile dans les
+       scripts ou les traitements de type batch, où aucun utilisateur
+       n'est présent pour saisir un mot de passe.
       </para>
      </listitem>
     </varlistentry>
@@ -888,20 +883,20 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
       </para>
 
       <para>
-       Cette option n'est jamais obligatoire car
-       <application>pg_dumpall</application> demandera automatiquement un mot
-       de passe si le serveur exige une authentification par mot de passe.
-       Néanmoins, <application>pg_dumpall</application> perdra une tentative
-       de connexion pour trouver que le serveur veut un mot de passe. Dans
+       Cette option n'est jamais indispensable car
+       <application>pg_dumpall</application> demande automatiquement un mot de
+       passe si le serveur exige une authentification par mot de passe.
+       Néanmoins, <application>pg_dumpall</application> perd une tentative de
+       connexion pour tester si le serveur requiert un mot de passe. Dans
        certains cas, il est préférable d'ajouter l'option <option>-W</option>
-       pour éviter la tentative de connexion.
+       pour éviter cette tentative de connexion supplémentaire.
       </para>
 
       <para>
        Notez que le mot de passe sera demandé pour chaque base de données à
-       sauvegarder. Habituellement, il est préférable de configurer un fichier
-       <filename>~/.pgpass</filename> pour que de s'en tenir à une saisie
-       manuelle du mot de passe.
+       exporter. Il est généralement préférable de configurer un fichier
+       <filename>~/.pgpass</filename> plutôt que de saisir manuellement
+       le mot de passe à chaque fois.
       </para>
      </listitem>
     </varlistentry>
@@ -910,7 +905,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--role=<replaceable class="parameter">nomrole</replaceable></option></term>
      <listitem>
       <para>
-       Spécifie un rôle à utiliser pour créer l'extraction. Avec cette option,
+       Spécifie un rôle à utiliser pour réaliser l'export. Avec cette option,
        <application>pg_dumpall</application> émet une commande <command>SET
         ROLE</command> <replaceable class="parameter">nomrole</replaceable>
        après s'être connecté à la base. C'est utile quand l'utilisateur
@@ -918,7 +913,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
        <application>pg_dumpall</application> a besoin, mais peut basculer vers
        un rôle qui les a. Certaines installations ont une politique qui est
        contre se connecter directement en tant que superutilisateur, et
-       l'utilisation de cette option permet que les extractions soient faites
+       l'utilisation de cette option permet que les exports soient faits
        sans violer cette politique.
       </para>
      </listitem>
@@ -940,7 +935,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
 
     <listitem>
      <para>
-      Paramètres de connexion par défaut
+      Paramètres de connexion par défaut.
      </para>
     </listitem>
    </varlistentry>
@@ -949,7 +944,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
     <term><envar>PG_COLOR</envar></term>
     <listitem>
      <para>
-      Indique s'il faut utiliser la couleur pour les messages de diagnostic.
+      Indique s'il faut utiliser la couleur dans les messages de diagnostic.
       Les valeurs possibles sont <literal>always</literal>,
       <literal>auto</literal>, <literal>never</literal>.
      </para>
@@ -972,60 +967,59 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
   <para>
    Comme <application>pg_dumpall</application> appelle
    <application>pg_dump</application> en interne, certains messages de
-   diagnostic se réfèrent en fait à <application>pg_dump</application>.
+   diagnostic feront en fait référence à <application>pg_dump</application>.
   </para>
 
   <para>
-   L'option <option>--clean</option> peut être utile même si votre intention
-   est de restaurer le script de sauvegarde sur une instance vierge.
-   L'utilisation de <option>--clean</option> autorise le script à supprimer
-   puis re-créer les bases de données internes <literal>postgres</literal> et
-   <literal>template1</literal>, en s'assurant que ces bases conserveront les
-   mêmes propriétés (par exemple la locale et l'encodage) que sur l'instance
-   source. Sans l'option, ces bases conserveront les propriétés existantes au
-   niveau base ainsi que le contenu pré-existant.
+   L'option <option>--clean</option> peut être utile même si vous prévoyez de
+   restaurer l'export dans une instance vide. Son utilisation autorise le script
+   à supprimer puis recréer les bases de données système
+   <literal>postgres</literal> et <literal>template1</literal>, garantissant
+   ainsi qu'elles conservent les mêmes propriétés (par exemple la locale et
+   l'encodage) que dans l'instance source. Sans cette option, ces bases
+   conserveront leurs propriétés actuelles au niveau de la base, ainsi que tout
+   contenu préexistant.
   </para>
 
   <para>
-   Si <option>--with-statistics</option> est spécifiée,
+   Si l'option <option>--with-statistics</option> est spécifiée,
    <command>pg_dumpall</command> inclura la plupart des statistiques de l'optimiseur
-   dans le fichier de sauvegarde généré. Cependant, certaines statistiques peuvent
-   ne pas être incluses, comme celles créées explicitement avec
-   <xref linkend="sql-createstatistics"/> ou les statistiques personnalisées
-   ajoutées par une extension. Il peut donc être utile d'exécuter
-   <command>ANALYZE</command> sur chaque base de données après une restauration
-   à partir d'un fichier de sauvegarde, afin de garantir des performances
+   dans le fichier d'export généré. Toutefois, certaines statistiques peuvent ne pas
+   être incluses, notamment celles créées explicitement via
+   <xref linkend="sql-createstatistics"/> ou celles ajoutées par une extension.
+   Il peut donc être utile d'exécuter <command>ANALYZE</command> sur chaque base
+   de données après la restauration d'un export afin de garantir des performances
    optimales. Vous pouvez également exécuter <command>vacuumdb -a -z</command>
    pour analyser toutes les bases de données.
   </para>
 
   <para>
-   On ne doit pas s'attendre à ce que le script de sauvegarde s'exécute sans
-   erreur. En particulier, comme le script exécutera un <command>CREATE
-    ROLE</command> pour chaque rôle existant sur l'instance source, il est
-   certain d'obtenir une erreur <quote>role already exists</quote> pour le
-   superutilisateur initial sauf si l'instance de destination a été initialisé
-   avec un autre nom pour le superutilisateur initial. Cette erreur est sans
-   gravité et doit être ignorée. L'utilisation de l'option
-   <option>--clean</option> a des chances de produire des messages d'erreur
-   supplémentaires sans risque pour les objets inexistants. Vous pouvez
-   minimiser ces erreurs en ajoutant l'option <option>--if-exists</option>.
+   Il ne faut pas s'attendre à ce que le script d'export s'exécute sans aucune
+   erreur. En particulier, comme le script exécutera une commande <command>CREATE
+    ROLE</command> pour chaque rôle présent dans l'instance d'origine, une erreur
+   <quote>role already exists</quote> est inévitable pour le
+   superutilisateur initial, sauf si l'instance de destination a été initialisée
+   avec un nom différent pour ce dernier. Cette erreur est sans conséquence et
+   peut être ignorée. L'utilisation de l'option <option>--clean</option> risque
+   également de générer d'autres messages d'erreur sans gravité concernant des
+   objets inexistants. Vous pouvez minimiser ces erreurs en ajoutant l'option
+   <option>--if-exists</option>.
   </para>
 
   <para>
    <application>pg_dumpall</application> requiert que tous les tablespaces
    nécessaires existent avant la restauration. Dans le cas contraire, la
-   création de la base échouera pour une base qui ne se trouve pas dans
+   création de la base échouera pour les bases situées en dehors de
    l'emplacement par défaut.
   </para>
 
   <para>
    Il est généralement recommandé d'utiliser l'option <option>-X</option>
-   (<option>--no-psqlrc</option>) lors de la restauration d'une base à partir
-   d'un script de <application>pg_dumpall</application> pour s'assurer d'une
-   restauration propre et empêcher tout conflit potentiel avec des configurations
-   personnalisées de <application>psql</application>. De plus, comme un script
-   <application>pg_dumpall</application> pourrait inclure des méta-commandes
+   (<option>--no-psqlrc</option>) lors de la restauration d'une base de données
+   à partir d’un script <application>pg_dumpall</application>, afin de garantir
+   une restauration propre et d’éviter d’éventuels conflits avec une configuration
+   personnalisée de <application>psql</application>. Par ailleurs, comme un script
+   <application>pg_dumpall</application> peut inclure des méta-commandes
    <application>psql</application>, il pourrait être incompatible avec des
    outils clients autres que <application>psql</application>.
   </para>
@@ -1034,25 +1028,25 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
  <refsect1 id="app-pg-dumpall-ex">
   <title>Exemples</title>
   <para>
-   Sauvegarder toutes les bases de données&nbsp;:
+   Pour exporter toutes les bases de données&nbsp;:
 
    <screen><prompt>$</prompt> <userinput>pg_dumpall &gt; db.out</userinput>
    </screen>
   </para>
 
   <para>
-   Pour recharger les bases de données à partir de ce fichier, vous pouvez
+   Pour restaurer les bases de données à partir de ce fichier, vous pouvez
    utiliser&nbsp;:
    <screen><prompt>$</prompt> <userinput>psql -X -f db.out postgres</userinput>
    </screen>
-   La base de données utilisée pour la connexion initiale n'a pas d'importance
-   ici car le fichier de script créé par <application>pg_dumpall</application>
-   contient les commandes nécessaires à la création et à la connexion aux
-   bases de données sauvegardées. Si vous utilisez l'option
-   <option>--clean</option>, vous devez vous connecter à la base
-   <literal>postgres</literal> au début&nbsp;; le script tentera de supprimer
-   les autres bases immédiatement et ceci échouera pour la base où vous êtes
-   connecté.
+   Il n'est pas important de se connecter à une base spécifique ici, car le
+   script généré par <application>pg_dumpall</application> contient les
+   commandes nécessaires pour créer et se connecter aux bases de données
+   exportées. Une exception existe si vous avez utilisé l'option
+   <option>--clean</option> : vous devez alors vous connecter d'abord
+   à la base <literal>postgres</literal>&nbsp;; le script tentera de supprimer
+   les autres bases immédiatement, ce qui échouera pour la base à laquelle
+   vous êtes connecté.
   </para>
  </refsect1>
 
@@ -1060,8 +1054,8 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
   <title>Voir aussi</title>
 
   <para>
-   Vérifier <xref linkend="app-pgdump"/> pour des détails sur les conditions
-   d'erreur possibles.
+   Consultez <xref linkend="app-pgdump"/> pour plus de détails sur les erreurs
+   susceptibles de se produire.
   </para>
  </refsect1>
 

--- a/postgresql/ref/pg_dumpall.xml
+++ b/postgresql/ref/pg_dumpall.xml
@@ -37,7 +37,7 @@
    Celui-ci contient les commandes <acronym>SQL</acronym> utilisables pour
    restaurer les bases de données avec <xref linkend="app-psql"/>. Cela est
    obtenu en appelant <xref linkend="app-pgdump"/> pour chaque base de données
-   de la grappe. <application>pg_dumpall</application> sauvegarde aussi les
+   de l'instance. <application>pg_dumpall</application> sauvegarde aussi les
    objets globaux, communs à toutes les bases de données, autrement dit les
    rôles, les tablespaces et les droits pour les paramètres de configuration.
    (<application>pg_dump</application> ne sauvegarde pas ces objets.)
@@ -57,8 +57,9 @@
   </para>
 
   <para>
-   Archives in other formats will be placed in a directory named using the
-   <option>-f</option>/<option>--file</option>, which is required in this case.
+   Les archives dans d'autres formats seront placées dans un répertoire dont le
+   nom est défini à l'aide de l'option <option>-f</option>/<option>--file</option>,
+   qui est obligatoire dans ce cas.
   </para>
 
   <para>
@@ -126,8 +127,9 @@
      <listitem>
       <para>
        Envoie le résultat dans le fichier indiqué. Si cette option n'est pas
-       utilisée, la sortie standard est utilisée.
-       Note: This option can only be omitted when <option>--format</option> is plain
+       spécifiée, la sortie standard est utilisée.
+       Remarque&nbsp;: cette option ne peut être omise que lorsque l'option <option>--format</option>
+       est définie à <literal>plain</literal>.
       </para>
      </listitem>
     </varlistentry>
@@ -137,16 +139,17 @@
      <term><option>--format=<replaceable class="parameter">format</replaceable></option></term>
      <listitem>
       <para>
-       Specify the format of dump files.  In plain format, all the dump data is
-       sent in a single text stream. This is the default.
+       Spécifie le format des fichiers de sauvegarde. En format <quote>plain</quote>,
+       toutes les données sont envoyées dans un seul flux texte. C'est le comportement par défaut.
 
-       In all other modes, <application>pg_dumpall</application> first creates two files:
-       <filename>global.dat</filename> and <filename>map.dat</filename>, in the directory
-       specified by <option>--file</option>.
-       The first file contains global data, such as roles and tablespaces. The second
-       contains a mapping between database oids and names. These files are used by
-       <application>pg_restore</application>. Data for individual databases is placed in
-       <filename>databases</filename> subdirectory, named using the database's <type>oid</type>.
+       Dans tous les autres modes, <application>pg_dumpall</application> crée d'abord deux fichiers :
+       <filename>global.dat</filename> et <filename>map.dat</filename>, dans le répertoire
+       spécifié par l'option <option>--file</option>.
+       Le premier contient les données globales, comme les rôles et les tablespaces. Le second
+       contient une correspondance entre les OID des bases de données et leurs noms. Ces fichiers
+       sont utilisés par <application>pg_restore</application>. Les données de chaque base de données
+       sont placées dans un sous-répertoire <filename>databases</filename>, nommé à l'aide de
+       l'<type>OID</type> de la base.
 
        <variablelist>
         <varlistentry>
@@ -154,9 +157,9 @@
          <term><literal>directory</literal></term>
          <listitem>
           <para>
-           Output directory-format archives for each database,
-           suitable for input into pg_restore. The directory
-           will have database <type>oid</type> as its name.
+           Produit une archive au format <quote>répertoire</quote> pour chaque
+           base de données, utilisable par <application>pg_restore</application>.
+           Le répertoire aura pour nom l'<type>OID</type> de la base de données.
           </para>
          </listitem>
         </varlistentry>
@@ -166,7 +169,7 @@
          <term><literal>plain</literal></term>
          <listitem>
           <para>
-           Output a plain-text SQL script file (the default).
+           Produit un script SQL en texte brut (comportement par défaut).
           </para>
          </listitem>
         </varlistentry>
@@ -176,10 +179,10 @@
          <term><literal>custom</literal></term>
          <listitem>
           <para>
-           Output a custom-format archive for each database,
-           suitable for input into pg_restore. The archive
-           will be named <filename>dboid.dmp</filename> where <type>dboid</type> is the
-           <type>oid</type> of the database.
+           Produit une archive au format personnalisé pour chaque base de données,
+           utilisable par <application>pg_restore</application>. L'archive sera nommée
+           <filename>dboid.dmp</filename> où <type>dboid</type> est l'<type>oid</type>
+           de la base de données.
           </para>
          </listitem>
         </varlistentry>
@@ -189,17 +192,17 @@
          <term><literal>tar</literal></term>
          <listitem>
           <para>
-           Output a tar-format archive for each database,
-           suitable for input into pg_restore. The archive
-           will be named <filename>dboid.tar</filename> where <type>dboid</type> is the
-           <type>oid</type> of the database.
+           Produit une archive au format <literal>tar</literal> pour chaque base de données,
+           utilisable par <application>pg_restore</application>. L'archive sera nommée
+           <filename>dboid.tar</filename> où <type>dboid</type> est l'<type>oid</type>
+           de la base de données.
           </para>
          </listitem>
         </varlistentry>
        </variablelist>
 
-        Note: see <xref linkend="app-pgdump"/> for details
-        of how the various non plain text archives work.
+        Remarque&nbsp;: voir <xref linkend="app-pgdump"/> pour plus de détails
+        sur le fonctionnement des différents formats d'archives non textuels.
        </para>
       </listitem>
      </varlistentry>
@@ -287,9 +290,9 @@
        Indique l'utilisation du mode verbeux. Ainsi
        <application>pg_dumpall</application> affiche les heures de
        démarrage/arrêt dans le fichier de sauvegarde et les messages de
-       progression sur la sortie standard. Répéter cette option fait
-       apparaitre des messages de débuggage supplémentaires sur la sortie des
-       erreurs. Cette option est aussi passée à
+       progression sur la sortie standard. Répéter l'option entraîne
+       l'apparition de messages de débogage supplémentaires sur la sortie
+       d'erreur standard. Cette option est aussi passée à
        <application>pg_dump</application>.
       </para>
      </listitem>
@@ -548,7 +551,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-comments</option></term>
      <listitem>
       <para>
-       Do not dump <command>COMMENT</command> commands.
+       Ne pas générer les commandes <command>COMMENT</command>.
       </para>
      </listitem>
     </varlistentry>
@@ -557,7 +560,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-data</option></term>
      <listitem>
       <para>
-       Do not dump data.
+       Ne pas exporter les données.
       </para>
      </listitem>
     </varlistentry>
@@ -566,7 +569,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-policies</option></term>
      <listitem>
       <para>
-       Do not dump row security policies.
+       Ne pas exporter les politiques de sécurité au niveau ligne.
       </para>
      </listitem>
     </varlistentry>
@@ -575,7 +578,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-publications</option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les publications.
+       Ne pas exporter les publications.
       </para>
      </listitem>
     </varlistentry>
@@ -584,7 +587,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-role-passwords</option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les mots de passe des rôles. Lors de la restauration,
+       Ne pas exporter les mots de passe des rôles. Lors de la restauration,
        les rôles auront un mot de passe vide et l'authentification par mot de
        passe échouera toujours jusqu'à ce que le mot de passe soit initialisé.
        Puisque les valeurs des mots de passe ne sont pas nécessaires quand
@@ -601,7 +604,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-schema</option></term>
      <listitem>
       <para>
-       Do not dump schema (data definitions).
+       Ne pas exporter le schéma (définitions des données).
       </para>
      </listitem>
     </varlistentry>
@@ -610,7 +613,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-security-labels</option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les labels de sécurité.
+       Ne pas exporter les labels de sécurité.
       </para>
      </listitem>
     </varlistentry>
@@ -619,7 +622,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-statistics</option></term>
      <listitem>
       <para>
-       Do not dump statistics. This is the default.
+       Ne pas exporter les statistiques. C'est le comportement par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -628,7 +631,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-subscriptions</option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas les souscriptions.
+       Ne pas exporter les souscriptions.
       </para>
      </listitem>
     </varlistentry>
@@ -637,9 +640,9 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-toast-compression</option></term>
      <listitem>
       <para>
-       N'affiche pas de commandes pour configurer les méthodes de compression
-       des <acronym>TOAST</acronym>. Avec cette option, toutes les colonnes
-       seront restaurées avec le paramètrage de compression par défaut.
+       Ne pas exporter les commandes pour configurer les méthodes de compression
+       des colonnes <acronym>TOAST</acronym>. Avec cette option, toutes les
+       colonnes seront restaurées avec les paramètres de compression par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -648,10 +651,10 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--no-unlogged-table-data</option></term>
      <listitem>
       <para>
-       Ne sauvegarde pas le contenu des tables non tracées dans les journaux
-       de transactions. Cette option n'a pas d'effet sur la sauvegarde des
-       définitions de table&nbsp;; il supprime seulement la sauvegarde des
-       données des tables.
+       Ne pas exporter le contenu des tables non journalisées
+       (<quote>unlogged</quote>). Cette option n'a aucun effet sur l'export des
+       définitions de ces tables&nbsp;; elle empêche uniquement l'export de
+       leurs données.
       </para>
      </listitem>
     </varlistentry>
@@ -708,9 +711,9 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--statistics-only</option></term>
      <listitem>
       <para>
-       Dump only the statistics, not the schema (data definitions) or data.
-       Statistics for tables, materialized views, foreign tables,
-       and indexes are dumped.
+       Exporter uniquement les statistiques, sans le schéma (définitions des
+       données) ni les données. Les statistiques des tables, vues matérialisées,
+       tables distantes et index sont exportées.
       </para>
      </listitem>
     </varlistentry>
@@ -719,9 +722,9 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--sequence-data</option></term>
      <listitem>
       <para>
-       Include sequence data in the dump.  This is the default behavior except
-       when <option>--no-data</option>, <option>--schema-only</option>, or
-       <option>--statistics-only</option> is specified.
+       Inclure les données des séquences dans l'export. C'est le comportement par
+       défaut, sauf si <option>--no-data</option>, <option>--schema-only</option>
+       ou <option>--statistics-only</option> est spécifié.
       </para>
      </listitem>
     </varlistentry>
@@ -744,7 +747,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--with-data</option></term>
      <listitem>
       <para>
-       Dump data. This is the default.
+       Exporter les données. C'est le comportement par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -753,7 +756,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--with-schema</option></term>
      <listitem>
       <para>
-       Dump schema (data definitions). This is the default.
+       Exporter le schéma (définitions des données). C'est le comportement par défaut.
       </para>
      </listitem>
     </varlistentry>
@@ -762,7 +765,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--with-statistics</option></term>
      <listitem>
       <para>
-       Dump statistics.
+       Exporter les statistiques.
       </para>
      </listitem>
     </varlistentry>
@@ -772,8 +775,8 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
      <term><option>--help</option></term>
      <listitem>
       <para>
-       Affiche l'aide sur les arguments en ligne de commande de
-       <application>pg_dumpall</application>, puis quitte
+       Afficher l'aide sur les arguments en ligne de commande de
+       <application>pg_dumpall</application>, puis quitter.
       </para>
      </listitem>
     </varlistentry>
@@ -781,7 +784,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
   </para>
 
   <para>
-   Les options suivantes en ligne de commande contrôlent les paramètres de
+   Les options en ligne de commande suivantes contrôlent les paramètres de
    connexion à la base de données.
 
    <variablelist>
@@ -984,14 +987,16 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
   </para>
 
   <para>
-   If <option>--with-statistics</option> is specified,
-   <command>pg_dumpall</command> will include most optimizer statistics in the
-   resulting dump file.  However, some statistics may not be included, such as
-   those created explicitly with <xref linkend="sql-createstatistics"/> or
-   custom statistics added by an extension.  Therefore, it may be useful to
-   run <command>ANALYZE</command> on each database after restoring from a dump
-   file to ensure optimal performance.  You can also run <command>vacuumdb -a
-   -z</command> to analyze all databases.
+   Si <option>--with-statistics</option> est spécifiée,
+   <command>pg_dumpall</command> inclura la plupart des statistiques de l'optimiseur
+   dans le fichier de sauvegarde généré. Cependant, certaines statistiques peuvent
+   ne pas être incluses, comme celles créées explicitement avec
+   <xref linkend="sql-createstatistics"/> ou les statistiques personnalisées
+   ajoutées par une extension. Il peut donc être utile d'exécuter
+   <command>ANALYZE</command> sur chaque base de données après une restauration
+   à partir d'un fichier de sauvegarde, afin de garantir des performances
+   optimales. Vous pouvez également exécuter <command>vacuumdb -a -z</command>
+   pour analyser toutes les bases de données.
   </para>
 
   <para>
@@ -1015,7 +1020,7 @@ exclude database <replaceable class="parameter">MOTIF</replaceable>
   </para>
 
   <para>
-   Il est généralement recommendé d'utiliser l'option <option>-X</option>
+   Il est généralement recommandé d'utiliser l'option <option>-X</option>
    (<option>--no-psqlrc</option>) lors de la restauration d'une base à partir
    d'un script de <application>pg_dumpall</application> pour s'assurer d'une
    restauration propre et empêcher tout conflit potentiel avec des configurations


### PR DESCRIPTION
Traduction des parties ajoutées lors des merges v18 beta 1 et beta 2, et relecture globale du fichier pour se mettre en cohérence avec les dernières modifications apportées au fichier source original.

```bash
$ git log -1 --oneline doc/src/sgml/ref/pg_dumpall.sgml
dec6643487b Improve pg_dump/pg_dumpall help synopses and terminology
```