### PR TITLE
Suppression d'une entrée dupliquée dans la liste des limites version pg16

### DIFF
--- a/postgresql/limits.xml
+++ b/postgresql/limits.xml
@@ -62,12 +62,6 @@
     </row>
 
     <row>
-     <entry>colonnes par ensemble de résultat</entry>
-     <entry>1664</entry>
-     <entry></entry>
-    </row>
-
-    <row>
      <entry>colonnes par ensemble de résultats</entry>
      <entry>1664</entry>
      <entry></entry>


### PR DESCRIPTION
Bonjour,
cette pr porte sur la suppression d'une entrée en double pour 'colonnes par ensemble de résultats' dans la liste des limites dans la version 16 de postgresql.
Cordialement