### PR TITLE
Suppression d'une entrée dupliquée dans la liste des limites version pg18 (main)

### DIFF
--- a/postgresql/limits.xml
+++ b/postgresql/limits.xml
@@ -68,12 +68,6 @@
     </row>
 
     <row>
-     <entry>colonnes par ensemble de résultats</entry>
-     <entry>1664</entry>
-     <entry></entry>
-    </row>
-
-    <row>
      <entry>taille d'un champ</entry>
      <entry>1 Go</entry>
      <entry></entry>


### PR DESCRIPTION
Bonjour,
cette pr porte sur la suppression d'une entrée en double pour 'colonnes par ensemble de résultats' dans la liste des limites dans la version 18 de postgresql.
Cordialement