### PR TITLE
suppression du prenom "il" dans l'explication des valeurs de checkpoint_completion_targuet (pg13)

### DIFF
--- a/postgresql/wal.xml
+++ b/postgresql/wal.xml
@@ -641,7 +641,7 @@
    de prolonger les checkpoints est d'impacter le temps de
    récupération, car il faudra conserver plus de journaux de transaction
    si une récupération est nécessaire. Bien que
-   <varname>checkpoint_completion_target</varname> puisse monter à 1.0, il
+   <varname>checkpoint_completion_target</varname> puisse monter à 1.0, 
    le mieux est de la configurer à une valeur plus basse (au
    plus 0,9), car les checkpoints incluent d'autres
    activités en dehors de l'écriture des pages modifiées. Une valeur de 1,0


### PR DESCRIPTION
Bonjour,
pour information, 
l'erreur est présente aussi dans la version 12 de la documentation.  Faut-il faire des pr pour les versions non maintenues de postgresql ?

Cordialement
