### PR TITLE
Corrections diverses dans wal.xml pg17

### DIFF
--- a/postgresql/wal.xml
+++ b/postgresql/wal.xml
@@ -684,18 +684,18 @@
    premier. Avec la valeur par défaut de 0,9, on peut s'attendre à ce que
    <productname>PostgreSQL</productname> termine chaque checkpoint un peu
    avant le prochain checkpoint planifié (à environ 90% de la durée du
-   dernier checkpoint). Ceci étant les I/O autant que possible pour que la
+   dernier checkpoint). Ceci étale les I/O autant que possible pour que la
    charge en I/O des checkpoints soit lissée pendant tout l'intervalle des
    checkpoints. L'inconvénient est que prolonger les checkpoints affecte le
    temps de redémarrage après crash parce qu'un plus grand nombre de segments
    WAL devront être conservés pour une possible utilisation après crash. Un
    utilisateur inquiet par la durée requise pour la restauration après crash
    pourrait vouloir réduire <varname>checkpoint_timeout</varname> pour que
-   les checkpoints surviennent plus fréquemment, tout en diluant les I/O sur
+   les checkpoints surviennent plus fréquemment, tout en étalant les I/O sur
    l'intervalle des checkpoints. Alternativement,
    <varname>checkpoint_completion_target</varname> pourrait être réduit mais
    cela résulterait en des moments avec des I/O plus intenses (lors du
-   checkpoint) et des momentsavec des I/O moins intenses (après la fin du
+   checkpoint) et des moments avec des I/O moins intenses (après la fin du
    checkpoint mais avant le début du suivant). De ce fait, cela n'est pas
    recommandé. Bien que <varname>checkpoint_completion_target</varname>
    puisse être configuré aussi haut que 1,0, il est typiquement recommandé de


### PR DESCRIPTION
Bonjour,
voici une petite série de corrections dans le chapitre décrivant checkpoint_completion_target pour pg17.
* correction typo
* correction d'une erreur de traduction
* cohérence dans la traduction (dilluant à étalant)

Cordialement